### PR TITLE
provide several libraries as outputs from external build rules

### DIFF
--- a/framework_example/cmake/BUILD
+++ b/framework_example/cmake/BUILD
@@ -9,7 +9,7 @@ cmake_external(
     name = "libpng",
     lib_source = "@libpng//:all",
     out_include_dir = "include/libpng16",
-    static_library = "libpng16.a",
+    static_libraries = ["libpng16.a"],
     deps = [":libz"],
 )
 


### PR DESCRIPTION
i.e. not single libraries, because in general case several build targets
can be created by a single CMake/configure-make build, and several of them linked to the next dependency