### PR TITLE
make cmake rule accept install-prefix option

### DIFF
--- a/framework_example/cmake/BUILD
+++ b/framework_example/cmake/BUILD
@@ -11,6 +11,7 @@ cmake_external(
     out_include_dir = "include/libpng16",
     static_libraries = ["libpng16.a"],
     deps = [":libz"],
+    postfix_script = "echo \"POST\""
 )
 
 cc_binary(

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -163,7 +163,7 @@ def cc_external_rule_impl(ctx, attrs):
         "export EXT_BUILD_ROOT=$(pwd)",
         "source " + shell_utils,
         "echo \"Building external library '{}'\"".format(lib_name),
-        "TMPDIR=$(mktemp -d)",
+        "export TMPDIR=$(mktemp -d)",
         "trap \"{ rm -rf $TMPDIR; }\" EXIT",
         "export EXT_BUILD_DEPS=$(mktemp -d --tmpdir=$EXT_BUILD_ROOT)",
         "\n".join(_copy_deps_and_tools(inputs)),

--- a/tools/build_defs/utils.sh
+++ b/tools/build_defs/utils.sh
@@ -52,6 +52,18 @@ function replace_in_files() {
   fi
 }
 
+# copies contents of the directory to target directory (create the target directory if needed)
+# $1 source directory, immediate children of which are copied
+# $2 target directory
+function copy_dir_contents_to_dir() {
+  local children=$(find $1 -maxdepth 1)
+  local target="$2"
+  mkdir -p ${target}
+  for child in $children; do
+    cp -R $child ${target}
+  done
+}
+
 # Symlink contents of the directory to target directory (create the target directory if needed)
 # $1 source directory, immediate children of which are symlinked
 # $2 target directory


### PR DESCRIPTION
this way the users can influence which install prefix will appear in the
generated code
install prefix have to be relative - we are doing the hermetic build
modify our shell script to copy the result of the build into the target directory
(we can not leave it in temp directory, it will be deleted)