### PR TITLE
do not pass android ndk as additional dependency

### DIFF
--- a/examples/cmake_android/BUILD
+++ b/examples/cmake_android/BUILD
@@ -3,9 +3,6 @@ load("@gmaven_rules//:defs.bzl", "gmaven_artifact")
 
 cmake_external(
     name = "libhello",
-    additional_tools = [
-        "@androidndk//:files",
-    ],
     lib_source = "//examples/cmake_hello_world_lib:srcs",
 )
 


### PR DESCRIPTION
because now it gets passed with the cc_toolchain files