### PR TITLE
correct work in osx: take environment from cc_common

### DIFF
--- a/tools/build_defs/cc_toolchain_util.bzl
+++ b/tools/build_defs/cc_toolchain_util.bzl
@@ -263,7 +263,25 @@ def create_linking_info(ctx, user_link_flags, files):
 
     return CcLinkingInfo(**link_params)
 
-def getToolsInfo(ctx):
+def get_env_vars(ctx):
+    cc_toolchain = find_cpp_toolchain(ctx)
+    feature_configuration = cc_common.configure_features(
+        cc_toolchain = cc_toolchain,
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
+    copts = ctx.attr.copts if hasattr(ctx.attr, "copts") else depset()
+    return cc_common.get_environment_variables(
+        feature_configuration = feature_configuration,
+        action_name = C_COMPILE_ACTION_NAME,
+        variables = cc_common.create_compile_variables(
+            feature_configuration = feature_configuration,
+            cc_toolchain = cc_toolchain,
+            user_compile_flags = copts,
+        ),
+    )
+
+def get_tools_info(ctx):
     """ Takes information about tools paths from cc_toolchain, returns CxxToolsInfo
     Args:
         ctx - rule context
@@ -294,7 +312,7 @@ def getToolsInfo(ctx):
         ),
     )
 
-def getFlagsInfo(ctx):
+def get_flags_info(ctx):
     """ Takes information about flags from cc_toolchain, returns CxxFlagsInfo
     Args:
         ctx - rule context

--- a/tools/build_defs/cmake.bzl
+++ b/tools/build_defs/cmake.bzl
@@ -11,15 +11,15 @@ load(
     "//tools/build_defs:detect_root.bzl",
     "detect_root",
 )
-load("//tools/build_defs:cc_toolchain_util.bzl", "absolutize_path_in_str", "getFlagsInfo", "getToolsInfo")
+load("//tools/build_defs:cc_toolchain_util.bzl", "absolutize_path_in_str", "get_flags_info", "get_tools_info")
 load("@foreign_cc_platform_utils//:cmake_globals.bzl", "CMAKE_COMMAND", "CMAKE_DEPS")
 
 def _cmake_external(ctx):
     options = " ".join(ctx.attr.cmake_options)
     root = detect_root(ctx.attr.lib_source)
 
-    tools = getToolsInfo(ctx)
-    flags = getFlagsInfo(ctx)
+    tools = get_tools_info(ctx)
+    flags = get_flags_info(ctx)
     cache_entries = _join_cache_options(ctx, _get_toolchain_entries(ctx, tools, flags), ctx.attr.cache_entries)
 
     install_prefix = _get_install_prefix(ctx)
@@ -165,7 +165,7 @@ def _attrs():
 """
 cmake_external = rule(
     attrs = _attrs(),
-    fragments = ["cpp", "apple"],
+    fragments = ["cpp"],
     output_to_genfiles = True,
     implementation = _cmake_external,
 )

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -7,100 +7,11 @@ load(
     "//tools/build_defs:cc_toolchain_util.bzl",
     "LibrariesToLinkInfo",
     "create_linking_info",
+    "get_env_vars",
     "targets_windows",
 )
 load("//tools/build_defs:detect_root.bzl", "detect_root")
 load("@foreign_cc_platform_utils//:host_os.bzl", "host_os")
-load(
-    "@build_bazel_rules_apple//apple/bundling:platform_support.bzl",
-    "platform_support",
-)
-
-def _create_common_attributes():
-    dict = {
-        # Library name. Defines the name of the install directory and the name of the static library,
-        # if no output files parameters are defined (any of static_libraries, shared_libraries,
-        # interface_libraries, binaries_names)
-        # Optional. If not defined, defaults to the target's name.
-        "lib_name": attr.string(mandatory = False),
-        # Label with source code to build. Typically a filegroup for the source of remote repository.
-        # Mandatory.
-        "lib_source": attr.label(mandatory = True, allow_files = True),
-        # Optional compilation definitions to be passed to the dependencies of this library.
-        # They are NOT passed to the compiler, you should duplicate them in the configuration options.
-        "defines": attr.string_list(mandatory = False, default = []),
-        #
-        # Optional additional inputs to be declared as needed for the shell script action.
-        # Not used by the shell script part in cc_external_rule_impl.
-        "additional_inputs": attr.label_list(mandatory = False, allow_files = True, default = []),
-        # Optional additional tools needed for the building.
-        # Not used by the shell script part in cc_external_rule_impl.
-        "additional_tools": attr.label_list(mandatory = False, allow_files = True, default = []),
-        #
-        # Optional part of the shell script to be added after the make commands
-        "postfix_script": attr.string(mandatory = False),
-        # Optinal make commands, defaults to ["make", "make install"]
-        "make_commands": attr.string_list(mandatory = False, default = ["make", "make install"]),
-        #
-        # Optional dependencies to be copied into the directory structure.
-        # Typically those directly required for the external building of the library/binaries.
-        # (i.e. those that the external buidl system will be looking for and paths to which are
-        # provided by the calling rule)
-        "deps": attr.label_list(mandatory = False, allow_files = True, default = []),
-        # Optional tools to be copied into the directory structure.
-        # Similar to deps, those directly required for the external building of the library/binaries.
-        "tools_deps": attr.label_list(mandatory = False, allow_files = True, default = []),
-        #
-        # Optional name of the output subdirectory with the header files, defaults to 'include'.
-        "out_include_dir": attr.string(mandatory = False, default = "include"),
-        # Optional name of the output subdirectory with the library files, defaults to 'lib'.
-        "out_lib_dir": attr.string(mandatory = False, default = "lib"),
-        # Optional name of the output subdirectory with the binary files, defaults to 'bin'.
-        "out_bin_dir": attr.string(mandatory = False, default = "bin"),
-        #
-        # Optional. if true, link all the object files from the static library,
-        # even if they are not used.
-        "alwayslink": attr.bool(mandatory = False, default = False),
-        # Optional link options to be passed up to the dependencies of this library
-        "linkopts": attr.string_list(mandatory = False, default = []),
-        #
-        # Output files names parameters. If any of them is defined, only these files are passed to
-        # Bazel providers.
-        # if no of them is defined, default lib_name.a/lib_name.lib static library is assumed.
-        #
-        # Optional names of the resulting static libraries.
-        "static_libraries": attr.string_list(mandatory = False),
-        # Optional names of the resulting shared libraries.
-        "shared_libraries": attr.string_list(mandatory = False),
-        # Optional names of the resulting interface libraries.
-        "interface_libraries": attr.string_list(mandatory = False),
-        # Optional names of the resulting binaries.
-        "binaries": attr.string_list(mandatory = False),
-        # Flag variable to indicate that the library produces only headers
-        "headers_only": attr.bool(mandatory = False, default = False),
-        #
-        # link to the shell utilities used by the shell script in cc_external_rule_impl.
-        "_utils": attr.label(
-            default = "@foreign_cc_platform_utils//:shell_utils",
-            allow_single_file = True,
-            cfg = "target",
-        ),
-        # we need to declare this attribute to access cc_toolchain
-        "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
-    }
-    if host_os["is_osx"]:
-        dict.update({
-            "_xcode_config": attr.label(default = Label("@bazel_tools//tools/osx:current_xcode_config")),
-            "_xcrunwrapper": attr.label(
-                executable = True,
-                cfg = "host",
-                default = Label("@bazel_tools//tools/objc:xcrunwrapper"),
-            ),
-            "_platform_type": attr.string(
-                default = str(apple_common.platform_type.macos),
-            ),
-        })
-    return dict
 
 """ Dict with definitions of the context attributes, that customize cc_external_rule_impl function.
  Many of the attributes have default values.
@@ -108,7 +19,77 @@ def _create_common_attributes():
  Typically, the concrete external library rule will use this structure to create the attributes
  description dict. See cmake.bzl as an example.
 """
-CC_EXTERNAL_RULE_ATTRIBUTES = _create_common_attributes()
+CC_EXTERNAL_RULE_ATTRIBUTES = {
+    # Library name. Defines the name of the install directory and the name of the static library,
+    # if no output files parameters are defined (any of static_libraries, shared_libraries,
+    # interface_libraries, binaries_names)
+    # Optional. If not defined, defaults to the target's name.
+    "lib_name": attr.string(mandatory = False),
+    # Label with source code to build. Typically a filegroup for the source of remote repository.
+    # Mandatory.
+    "lib_source": attr.label(mandatory = True, allow_files = True),
+    # Optional compilation definitions to be passed to the dependencies of this library.
+    # They are NOT passed to the compiler, you should duplicate them in the configuration options.
+    "defines": attr.string_list(mandatory = False, default = []),
+    #
+    # Optional additional inputs to be declared as needed for the shell script action.
+    # Not used by the shell script part in cc_external_rule_impl.
+    "additional_inputs": attr.label_list(mandatory = False, allow_files = True, default = []),
+    # Optional additional tools needed for the building.
+    # Not used by the shell script part in cc_external_rule_impl.
+    "additional_tools": attr.label_list(mandatory = False, allow_files = True, default = []),
+    #
+    # Optional part of the shell script to be added after the make commands
+    "postfix_script": attr.string(mandatory = False),
+    # Optinal make commands, defaults to ["make", "make install"]
+    "make_commands": attr.string_list(mandatory = False, default = ["make", "make install"]),
+    #
+    # Optional dependencies to be copied into the directory structure.
+    # Typically those directly required for the external building of the library/binaries.
+    # (i.e. those that the external buidl system will be looking for and paths to which are
+    # provided by the calling rule)
+    "deps": attr.label_list(mandatory = False, allow_files = True, default = []),
+    # Optional tools to be copied into the directory structure.
+    # Similar to deps, those directly required for the external building of the library/binaries.
+    "tools_deps": attr.label_list(mandatory = False, allow_files = True, default = []),
+    #
+    # Optional name of the output subdirectory with the header files, defaults to 'include'.
+    "out_include_dir": attr.string(mandatory = False, default = "include"),
+    # Optional name of the output subdirectory with the library files, defaults to 'lib'.
+    "out_lib_dir": attr.string(mandatory = False, default = "lib"),
+    # Optional name of the output subdirectory with the binary files, defaults to 'bin'.
+    "out_bin_dir": attr.string(mandatory = False, default = "bin"),
+    #
+    # Optional. if true, link all the object files from the static library,
+    # even if they are not used.
+    "alwayslink": attr.bool(mandatory = False, default = False),
+    # Optional link options to be passed up to the dependencies of this library
+    "linkopts": attr.string_list(mandatory = False, default = []),
+    #
+    # Output files names parameters. If any of them is defined, only these files are passed to
+    # Bazel providers.
+    # if no of them is defined, default lib_name.a/lib_name.lib static library is assumed.
+    #
+    # Optional names of the resulting static libraries.
+    "static_libraries": attr.string_list(mandatory = False),
+    # Optional names of the resulting shared libraries.
+    "shared_libraries": attr.string_list(mandatory = False),
+    # Optional names of the resulting interface libraries.
+    "interface_libraries": attr.string_list(mandatory = False),
+    # Optional names of the resulting binaries.
+    "binaries": attr.string_list(mandatory = False),
+    # Flag variable to indicate that the library produces only headers
+    "headers_only": attr.bool(mandatory = False, default = False),
+    #
+    # link to the shell utilities used by the shell script in cc_external_rule_impl.
+    "_utils": attr.label(
+        default = "@foreign_cc_platform_utils//:shell_utils",
+        allow_single_file = True,
+        cfg = "target",
+    ),
+    # we need to declare this attribute to access cc_toolchain
+    "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
+}
 
 def create_attrs(attr_struct, configure_name, configure_script, **kwargs):
     """ Function for adding/modifying context attributes struct (originally from ctx.attr),
@@ -204,10 +185,9 @@ def cc_external_rule_impl(ctx, attrs):
     script_text = "\n".join(script_lines)
     print("script text: " + script_text)
 
-    env = {}
+    env = get_env_vars(ctx)
     execution_requirements = {"block-network": ""}
     if host_os["is_osx"]:
-        env = _xcrun_env(ctx)
         execution_requirements.update({
             "requires-darwin": "",
         })
@@ -495,10 +475,3 @@ def _collect_flags(cc_linking):
     for params in _extract_link_params(cc_linking):
         linkopts = params.linkopts.to_list()
     return collections.uniq(linkopts)
-
-def _xcrun_env(ctx):
-    xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
-
-    action_env = apple_common.target_apple_env(xcode_config, platform_support.platform(ctx))
-    action_env.update(apple_common.apple_host_system_env(xcode_config))
-    return action_env

--- a/workspace_definitions.bzl
+++ b/workspace_definitions.bzl
@@ -96,10 +96,3 @@ _platform_dependent_init = repository_rule(
 def rules_foreign_cc_dependencies():
     repositories()
     _platform_dependent_init(name = "foreign_cc_platform_utils")
-    install_ws_dependency(
-        repo_name = "build_bazel_rules_apple",
-        url = "https://github.com/bazelbuild/rules_apple/archive/0.7.0.tar.gz",
-        strip_prefix = "rules_apple-0.7.0",
-        init_file = "//apple:repositories.bzl",
-        init_function = "apple_rules_dependencies",
-    )


### PR DESCRIPTION
apparently, is it possible to just take the needed environment variables from cc_common, and not do any calls to rules_apple or platform-dependent initialization