### PR TITLE
Merge CMAKE_PREFIX_PATH, passed by user, with $EXT_BUILD_DEPS

### DIFF
--- a/test/cmake_text_tests.bzl
+++ b/test/cmake_text_tests.bzl
@@ -227,11 +227,12 @@ def _create_min_cmake_script_no_toolchain_file_test(ctx):
     user_env = {}
     user_cache = {
         "NOFORTRAN": "on",
+        "CMAKE_PREFIX_PATH": "/abc/def",
     }
 
     os_info = OSInfo(is_unix = True, is_osx = False, is_win = False)
     script = create_cmake_script("ws", os_info, tools, flags, "test_rule", "external/test_rule", True, user_cache, user_env, ["-GNinja"])
-    expected = "CC=\"/usr/bin/gcc\" CXX=\"/usr/bin/gcc\" CFLAGS=\"-U_FORTIFY_SOURCE -fstack-protector -Wall\" CXXFLAGS=\"-U_FORTIFY_SOURCE -fstack-protector -Wall\" ASMFLAGS=\"-U_FORTIFY_SOURCE -fstack-protector -Wall\" {cmake} -DCMAKE_AR=\"/usr/bin/ar\" -DCMAKE_SHARED_LINKER_FLAGS=\"-shared -fuse-ld=gold\" -DCMAKE_EXE_LINKER_FLAGS=\"-fuse-ld=gold -Wl -no-as-needed\" -DNOFORTRAN=\"on\" -DCMAKE_PREFIX_PATH=\"$EXT_BUILD_DEPS\" -DCMAKE_INSTALL_PREFIX=\"test_rule\" -GNinja $EXT_BUILD_ROOT/external/test_rule"
+    expected = "CC=\"/usr/bin/gcc\" CXX=\"/usr/bin/gcc\" CFLAGS=\"-U_FORTIFY_SOURCE -fstack-protector -Wall\" CXXFLAGS=\"-U_FORTIFY_SOURCE -fstack-protector -Wall\" ASMFLAGS=\"-U_FORTIFY_SOURCE -fstack-protector -Wall\" {cmake} -DCMAKE_AR=\"/usr/bin/ar\" -DCMAKE_SHARED_LINKER_FLAGS=\"-shared -fuse-ld=gold\" -DCMAKE_EXE_LINKER_FLAGS=\"-fuse-ld=gold -Wl -no-as-needed\" -DNOFORTRAN=\"on\" -DCMAKE_PREFIX_PATH=\"$EXT_BUILD_DEPS;/abc/def\" -DCMAKE_INSTALL_PREFIX=\"test_rule\" -GNinja $EXT_BUILD_ROOT/external/test_rule"
     asserts.equals(env, expected.format(cmake = CMAKE_COMMAND), script)
 
     unittest.end(env)


### PR DESCRIPTION
This allows using locally installed libraries to be found by CMake
+ test