### PR TITLE
Adapt tests for Windows: set .a library name, use crosstool file

### DIFF
--- a/examples/cmake_synthetic/BUILD
+++ b/examples/cmake_synthetic/BUILD
@@ -10,24 +10,24 @@ filegroup(
 cmake_external(
     name = "liba",
     cmake_options = ["-GNinja"],
+    generate_crosstool_file = True,
     lib_source = "//examples/cmake_synthetic/liba:a_srcs",
     make_commands = [
         NINJA_COMMAND,
         NINJA_COMMAND + " install",
     ],
-    static_libraries = ["libliba.a"],
     tools_deps = NINJA_DEP,
 )
 
 cmake_external(
     name = "libb",
     cmake_options = ["-GNinja"],
+    generate_crosstool_file = True,
     lib_source = "//examples/cmake_synthetic/libb:b_srcs",
     make_commands = [
         NINJA_COMMAND,
         NINJA_COMMAND + " install",
     ],
-    static_libraries = ["liblibb.a"],
     tools_deps = NINJA_DEP,
     deps = [":liba"],
 )

--- a/examples/cmake_synthetic/liba/src/CMakeLists.txt
+++ b/examples/cmake_synthetic/liba/src/CMakeLists.txt
@@ -5,6 +5,11 @@ set(LIBA_SRC liba.cpp liba.h)
 add_library(liba_static STATIC ${LIBA_SRC})
 
 set_target_properties(liba_static PROPERTIES OUTPUT_NAME "liba")
+IF (WIN32)
+  set_target_properties(liba_static PROPERTIES ARCHIVE_OUTPUT_NAME "liba")
+ELSE()
+  set_target_properties(liba_static PROPERTIES ARCHIVE_OUTPUT_NAME "a")
+ENDIF()
 set_target_properties(liba_static PROPERTIES PUBLIC_HEADER "liba.h")
 
 set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)

--- a/examples/cmake_synthetic/libb/src/CMakeLists.txt
+++ b/examples/cmake_synthetic/libb/src/CMakeLists.txt
@@ -3,15 +3,19 @@ cmake_minimum_required(VERSION 2.8.4)
 set(LIBB_SRC libb.cpp libb.h)
 
 add_library(libb_static STATIC ${LIBB_SRC})
+set_target_properties(libb_static PROPERTIES OUTPUT_NAME "libb")
+IF (WIN32)
+  set_target_properties(libb_static PROPERTIES ARCHIVE_OUTPUT_NAME "libb")
+ELSE()
+  set_target_properties(libb_static PROPERTIES ARCHIVE_OUTPUT_NAME "b")
+ENDIF()
 
 find_package(LIBA REQUIRED NAMES alib liba libliba)
 
 # LIBA_INCLUDE_DIRS is not set, so giving the path relative to liba_config.cmake
 # would be happy to improve that
-target_link_libraries(libb_static PUBLIC ${LIBA_DIR}/../../../lib/libliba.a)
+target_link_libraries(libb_static PUBLIC ${LIBA_DIR}/../../../lib/liba.a)
 target_include_directories(libb_static PUBLIC ${LIBA_DIR}/../../../include)
-
-set_target_properties(libb_static PROPERTIES OUTPUT_NAME "libb")
 
 set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
 


### PR DESCRIPTION
- On Linux, lib is added to the name
- Use CMake crosstool file (needed for Windows)