### PR TITLE
Pass the value of --compilation_mode dbg to the rule and to CMake

### DIFF
--- a/for_workspace/compilation_mode.bzl
+++ b/for_workspace/compilation_mode.bzl
@@ -1,0 +1,9 @@
+def _compilation_mode(ctx):
+    return [config_common.FeatureFlagInfo(value = str(ctx.attr.is_debug))]
+
+compilation_mode = rule(
+    attrs = {
+        "is_debug": attr.bool(),
+    },
+    implementation = _compilation_mode,
+)

--- a/test/cmake_text_tests.bzl
+++ b/test/cmake_text_tests.bzl
@@ -232,7 +232,7 @@ def _create_min_cmake_script_no_toolchain_file_test(ctx):
 
     os_info = OSInfo(is_unix = True, is_osx = False, is_win = False)
     script = create_cmake_script("ws", os_info, tools, flags, "test_rule", "external/test_rule", True, user_cache, user_env, ["-GNinja"])
-    expected = "CC=\"/usr/bin/gcc\" CXX=\"/usr/bin/gcc\" CFLAGS=\"-U_FORTIFY_SOURCE -fstack-protector -Wall\" CXXFLAGS=\"-U_FORTIFY_SOURCE -fstack-protector -Wall\" ASMFLAGS=\"-U_FORTIFY_SOURCE -fstack-protector -Wall\" {cmake} -DCMAKE_AR=\"/usr/bin/ar\" -DCMAKE_SHARED_LINKER_FLAGS=\"-shared -fuse-ld=gold\" -DCMAKE_EXE_LINKER_FLAGS=\"-fuse-ld=gold -Wl -no-as-needed\" -DNOFORTRAN=\"on\" -DCMAKE_PREFIX_PATH=\"$EXT_BUILD_DEPS;/abc/def\" -DCMAKE_INSTALL_PREFIX=\"test_rule\" -GNinja $EXT_BUILD_ROOT/external/test_rule"
+    expected = "CC=\"/usr/bin/gcc\" CXX=\"/usr/bin/gcc\" CFLAGS=\"-U_FORTIFY_SOURCE -fstack-protector -Wall\" CXXFLAGS=\"-U_FORTIFY_SOURCE -fstack-protector -Wall\" ASMFLAGS=\"-U_FORTIFY_SOURCE -fstack-protector -Wall\" {cmake} -DCMAKE_AR=\"/usr/bin/ar\" -DCMAKE_SHARED_LINKER_FLAGS=\"-shared -fuse-ld=gold\" -DCMAKE_EXE_LINKER_FLAGS=\"-fuse-ld=gold -Wl -no-as-needed\" -DNOFORTRAN=\"on\" -DCMAKE_PREFIX_PATH=\"$EXT_BUILD_DEPS;/abc/def\" -DCMAKE_INSTALL_PREFIX=\"test_rule\" -DCMAKE_BUILD_TYPE=\"DEBUG\" -GNinja $EXT_BUILD_ROOT/external/test_rule"
     asserts.equals(env, expected.format(cmake = CMAKE_COMMAND), script)
 
     unittest.end(env)
@@ -273,7 +273,7 @@ set(CMAKE_SHARED_LINKER_FLAGS_INIT "-shared -fuse-ld=gold")
 set(CMAKE_EXE_LINKER_FLAGS_INIT "-fuse-ld=gold -Wl -no-as-needed")
 EOF
 
- {cmake} -DNOFORTRAN="on" -DCMAKE_TOOLCHAIN_FILE="crosstool_bazel.cmake" -DCMAKE_PREFIX_PATH="$EXT_BUILD_DEPS" -DCMAKE_INSTALL_PREFIX="test_rule" -GNinja $EXT_BUILD_ROOT/external/test_rule"""
+ {cmake} -DNOFORTRAN="on" -DCMAKE_TOOLCHAIN_FILE="crosstool_bazel.cmake" -DCMAKE_PREFIX_PATH="$EXT_BUILD_DEPS" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_BUILD_TYPE=\"DEBUG\" -GNinja $EXT_BUILD_ROOT/external/test_rule"""
     asserts.equals(env, expected.format(cmake = CMAKE_COMMAND).splitlines(), script.splitlines())
 
     unittest.end(env)
@@ -306,11 +306,12 @@ def _create_cmake_script_no_toolchain_file_test(ctx):
         "CMAKE_ASM_FLAGS": "assemble-user",
         "CMAKE_CXX_LINK_EXECUTABLE": "became",
         "CUSTOM_CACHE": "YES",
+        "CMAKE_BUILD_TYPE": "user_type",
     }
 
     os_info = OSInfo(is_unix = True, is_osx = False, is_win = False)
     script = create_cmake_script("ws", os_info, tools, flags, "test_rule", "external/test_rule", True, user_cache, user_env, ["-GNinja"])
-    expected = "CC=\"sink-cc-value\" CXX=\"sink-cxx-value\" CFLAGS=\"-cc-flag -gcc_toolchain cc-toolchain --from-env --additional-flag\" CXXFLAGS=\"--quoted=\\\"abc def\\\" --sysroot=/abc/sysroot --gcc_toolchain cxx-toolchain\" ASMFLAGS=\"assemble assemble-user\" CUSTOM_ENV=\"YES\" {cmake} -DCMAKE_AR=\"cxx_linker_static\" -DCMAKE_CXX_LINK_EXECUTABLE=\"became\" -DCMAKE_SHARED_LINKER_FLAGS=\"shared1 shared2\" -DCMAKE_EXE_LINKER_FLAGS=\"executable\" -DCUSTOM_CACHE=\"YES\" -DCMAKE_PREFIX_PATH=\"$EXT_BUILD_DEPS\" -DCMAKE_INSTALL_PREFIX=\"test_rule\" -GNinja $EXT_BUILD_ROOT/external/test_rule"
+    expected = "CC=\"sink-cc-value\" CXX=\"sink-cxx-value\" CFLAGS=\"-cc-flag -gcc_toolchain cc-toolchain --from-env --additional-flag\" CXXFLAGS=\"--quoted=\\\"abc def\\\" --sysroot=/abc/sysroot --gcc_toolchain cxx-toolchain\" ASMFLAGS=\"assemble assemble-user\" CUSTOM_ENV=\"YES\" {cmake} -DCMAKE_AR=\"cxx_linker_static\" -DCMAKE_CXX_LINK_EXECUTABLE=\"became\" -DCMAKE_SHARED_LINKER_FLAGS=\"shared1 shared2\" -DCMAKE_EXE_LINKER_FLAGS=\"executable\" -DCUSTOM_CACHE=\"YES\" -DCMAKE_BUILD_TYPE=\"user_type\" -DCMAKE_PREFIX_PATH=\"$EXT_BUILD_DEPS\" -DCMAKE_INSTALL_PREFIX=\"test_rule\" -GNinja $EXT_BUILD_ROOT/external/test_rule"
     asserts.equals(env, expected.format(cmake = CMAKE_COMMAND), script)
 
     unittest.end(env)
@@ -363,7 +364,7 @@ set(CMAKE_SHARED_LINKER_FLAGS_INIT "shared1 shared2")
 set(CMAKE_EXE_LINKER_FLAGS_INIT "executable")
 EOF
 
-CUSTOM_ENV="YES" {cmake} -DCUSTOM_CACHE="YES" -DCMAKE_TOOLCHAIN_FILE="crosstool_bazel.cmake" -DCMAKE_PREFIX_PATH="$EXT_BUILD_DEPS" -DCMAKE_INSTALL_PREFIX="test_rule" -GNinja $EXT_BUILD_ROOT/external/test_rule"""
+CUSTOM_ENV="YES" {cmake} -DCUSTOM_CACHE="YES" -DCMAKE_TOOLCHAIN_FILE="crosstool_bazel.cmake" -DCMAKE_PREFIX_PATH="$EXT_BUILD_DEPS" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_BUILD_TYPE=\"DEBUG\" -GNinja $EXT_BUILD_ROOT/external/test_rule"""
     asserts.equals(env, expected.format(cmake = CMAKE_COMMAND).splitlines(), script.splitlines())
 
     unittest.end(env)

--- a/tools/build_defs/cc_toolchain_util.bzl
+++ b/tools/build_defs/cc_toolchain_util.bzl
@@ -276,15 +276,19 @@ def get_env_vars(ctx):
 
     for action_name in [C_COMPILE_ACTION_NAME, CPP_LINK_STATIC_LIBRARY_ACTION_NAME, CPP_LINK_EXECUTABLE_ACTION_NAME]:
         vars.update(cc_common.get_environment_variables(
-                            feature_configuration = feature_configuration,
-                            action_name = action_name,
-                            variables = cc_common.create_compile_variables(
-                                feature_configuration = feature_configuration,
-                                cc_toolchain = cc_toolchain,
-                                user_compile_flags = copts,
-                            ),
-                        ))
+            feature_configuration = feature_configuration,
+            action_name = action_name,
+            variables = cc_common.create_compile_variables(
+                feature_configuration = feature_configuration,
+                cc_toolchain = cc_toolchain,
+                user_compile_flags = copts,
+            ),
+        ))
     return vars
+
+def is_debug_mode(ctx):
+    # see workspace_definitions.bzl
+    return str(True) == ctx.attr._is_debug[config_common.FeatureFlagInfo].value
 
 def get_tools_info(ctx):
     """ Takes information about tools paths from cc_toolchain, returns CxxToolsInfo

--- a/tools/build_defs/cmake.bzl
+++ b/tools/build_defs/cmake.bzl
@@ -15,6 +15,7 @@ load(
     "//tools/build_defs:cc_toolchain_util.bzl",
     "get_flags_info",
     "get_tools_info",
+    "is_debug_mode",
 )
 load(":cmake_script.bzl", "create_cmake_script")
 load("@foreign_cc_platform_utils//:os_info.bzl", "OSInfo")
@@ -39,6 +40,7 @@ def _cmake_external(ctx):
         dict(ctx.attr.cache_entries),
         dict(ctx.attr.env_vars),
         ctx.attr.cmake_options,
+        is_debug_mode(ctx),
     )
     copy_results = "copy_dir_contents_to_dir $BUILD_TMPDIR/{} $INSTALLDIR".format(install_prefix)
 

--- a/tools/build_defs/cmake_script.bzl
+++ b/tools/build_defs/cmake_script.bzl
@@ -13,7 +13,8 @@ def create_cmake_script(
         no_toolchain_file,
         user_cache,
         user_env,
-        options):
+        options,
+        is_debug_mode = True):
     """ Constructs CMake script to be passed to cc_external_rule_impl.
       Args:
         workspace_name - current workspace name
@@ -37,9 +38,12 @@ def create_cmake_script(
     else:
         params = _create_crosstool_file_text(toolchain_dict, user_cache, user_env)
 
+    build_type = params.cache.get("CMAKE_BUILD_TYPE",
+                                  "DEBUG" if is_debug_mode else "RELEASE")
     params.cache.update({
         "CMAKE_PREFIX_PATH": merged_prefix_path,
         "CMAKE_INSTALL_PREFIX": install_prefix,
+        "CMAKE_BUILD_TYPE": build_type,
     })
 
     set_env_vars = " ".join([key + "=\"" + params.env[key] + "\"" for key in params.env])

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -85,6 +85,9 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
         default = "@foreign_cc_platform_utils//:shell_utils",
         allow_single_file = True,
     ),
+    "_is_debug": attr.label(
+        default = "@foreign_cc_platform_utils//:compilation_mode",
+    ),
     # link to the shell utilities used by the shell script in cc_external_rule_impl.
     "_target_os": attr.label(
         default = "@foreign_cc_platform_utils//:target_os",

--- a/workspace_definitions.bzl
+++ b/workspace_definitions.bzl
@@ -15,8 +15,31 @@ def _platform_dependent_init_impl(rctx):
             _create_os_description(rctx, os_name),
             _shell_utils_text(rctx, host_os),
             _build_tools(rctx, host_os),
+            _build_mode(rctx),
         ],
     ))
+
+def _build_mode(rctx):
+    path = rctx.path(Label("//for_workspace:compilation_mode.bzl"))
+    rctx.template("compilation_mode.bzl", path)
+
+    return """
+load("//:compilation_mode.bzl", "compilation_mode")
+
+config_setting(
+  name = "is_debug",
+  values = {"compilation_mode": "dbg"}
+)
+
+compilation_mode(
+  name = "compilation_mode",
+  is_debug = select({
+    ":is_debug": True,
+    "//conditions:default": False,
+}),
+  visibility = ["//visibility:public"],
+)
+"""
 
 def _create_os_description(rctx, os_name):
     path = rctx.path(Label("//for_workspace:os_info.bzl"))


### PR DESCRIPTION
CMAKE_BUILD_TYPE=DEBUG (otherwise RELEASE)
Can be overriden by user passing CMAKE_BUILD_TYPE in cache_entries