### PR TITLE
Exclude synthetic tests from Ubuntu 16 on CI

### DIFF
--- a/.bazelci/config.yaml
+++ b/.bazelci/config.yaml
@@ -5,7 +5,7 @@ platforms:
     - "//examples:tests"
   ubuntu1604:
     test_targets:
-    - "//examples:tests"
+    - "//examples:tests_no_synthetic"
   macos:
     test_targets:
     - "//examples:tests"

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -7,18 +7,26 @@ tests = [
     "//examples/cmake_nghttp2:test_nghttp2",
     "//examples/ninja:test_ninja_version",
     "//test:cmake_script_test_suite",
+]
+
+tests_with_synthetic = tests + [
     "//examples/cmake_synthetic:test_libs",
 ]
 
 test_suite(
     name = "tests",
+    tests = tests_with_synthetic,
+)
+
+test_suite(
+    name = "tests_no_synthetic",
     tests = tests,
 )
 
 test_suite(
     name = "win_tests",
     tags = ["windows"],
-    tests = tests + [
+    tests = tests_with_synthetic + [
         "//examples/cmake_hello_world_lib:test_hello_ninja",
         "//examples/cmake_hello_world_lib:test_hello_nmake",
     ],


### PR DESCRIPTION
Their main target is Windows