### PR TITLE
Refactor framework function: configure_script to be a callback

### DIFF
--- a/tools/build_defs/boost_build.bzl
+++ b/tools/build_defs/boost_build.bzl
@@ -9,64 +9,65 @@ load(
 load("//tools/build_defs:detect_root.bzl", "detect_root")
 
 def _boost_build(ctx):
+    attrs = create_attrs(
+        ctx.attr,
+        configure_name = "BuildBoost",
+        configure_script = _create_configure_script,
+        make_commands = ["./b2 install --prefix=."],
+        static_libraries = [
+            "libboost_atomic.a",
+            "libboost_chrono.a",
+            "libboost_container.a",
+            "libboost_context.a",
+            "libboost_contract.a",
+            "libboost_coroutine.a",
+            "libboost_date_time.a",
+            "libboost_exception.a",
+            "libboost_fiber.a",
+            "libboost_filesystem.a",
+            "libboost_graph.a",
+            "libboost_iostreams.a",
+            "libboost_locale.a",
+            "libboost_log.a",
+            "libboost_log_setup.a",
+            "libboost_math_c99.a",
+            "libboost_math_c99f.a",
+            "libboost_math_c99l.a",
+            "libboost_math_tr1.a",
+            "libboost_math_tr1f.a",
+            "libboost_math_tr1l.a",
+            "libboost_numpy27.a",
+            "libboost_prg_exec_monitor.a",
+            "libboost_program_options.a",
+            "libboost_python27.a",
+            "libboost_random.a",
+            "libboost_regex.a",
+            "libboost_serialization.a",
+            "libboost_signals.a",
+            "libboost_stacktrace_addr2line.a",
+            "libboost_stacktrace_backtrace.a",
+            "libboost_stacktrace_basic.a",
+            "libboost_stacktrace_noop.a",
+            "libboost_system.a",
+            "libboost_test_exec_monitor.a",
+            "libboost_thread.a",
+            "libboost_timer.a",
+            "libboost_type_erasure.a",
+            "libboost_unit_test_framework.a",
+            "libboost_wave.a",
+            "libboost_wserialization.a",
+        ],
+    )
+    return cc_external_rule_impl(ctx, attrs)
+
+def _create_configure_script(ctx, attrs, inputs):
     root = detect_root(ctx.attr.lib_source)
 
-    configure_script = "\n".join([
+    return "\n".join([
         "cd $INSTALLDIR",
         "cp -R $EXT_BUILD_ROOT/{}/. .".format(root),
         "./bootstrap.sh",
     ])
-
-    attrs = create_attrs(
-        ctx.attr,
-        configure_name = "BuildBoost",
-        configure_script = configure_script,
-        make_commands = ["./b2 install --prefix=."],
-        static_libraries = [
-          "libboost_atomic.a",
-          "libboost_chrono.a",
-          "libboost_container.a",
-          "libboost_context.a",
-          "libboost_contract.a",
-          "libboost_coroutine.a",
-          "libboost_date_time.a",
-          "libboost_exception.a",
-          "libboost_fiber.a",
-          "libboost_filesystem.a",
-          "libboost_graph.a",
-          "libboost_iostreams.a",
-          "libboost_locale.a",
-          "libboost_log.a",
-          "libboost_log_setup.a",
-          "libboost_math_c99.a",
-          "libboost_math_c99f.a",
-          "libboost_math_c99l.a",
-          "libboost_math_tr1.a",
-          "libboost_math_tr1f.a",
-          "libboost_math_tr1l.a",
-          "libboost_numpy27.a",
-          "libboost_prg_exec_monitor.a",
-          "libboost_program_options.a",
-          "libboost_python27.a",
-          "libboost_random.a",
-          "libboost_regex.a",
-          "libboost_serialization.a",
-          "libboost_signals.a",
-          "libboost_stacktrace_addr2line.a",
-          "libboost_stacktrace_backtrace.a",
-          "libboost_stacktrace_basic.a",
-          "libboost_stacktrace_noop.a",
-          "libboost_system.a",
-          "libboost_test_exec_monitor.a",
-          "libboost_thread.a",
-          "libboost_timer.a",
-          "libboost_type_erasure.a",
-          "libboost_unit_test_framework.a",
-          "libboost_wave.a",
-          "libboost_wserialization.a",
-]
-    )
-    return cc_external_rule_impl(ctx, attrs)
 
 """ Rule for building Boost. Invokes bootstrap.sh and then b2 install.
   Attributes:

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -196,7 +196,7 @@ def cc_external_rule_impl(ctx, attrs):
         "\n".join(_copy_deps_and_tools(inputs)),
         "define_absolute_paths $EXT_BUILD_ROOT/bin $EXT_BUILD_ROOT/bin",
         "pushd $BUILD_TMPDIR",
-        attrs.configure_script,
+        attrs.configure_script(ctx, attrs, inputs),
         "\n".join(attrs.make_commands),
         _value(attrs.postfix_script, ""),
         "replace_absolute_paths $INSTALLDIR $INSTALLDIR",


### PR DESCRIPTION
reason: configure-make should reuse the linking and compilation structures created by framework function