### PR TITLE
External C/C++ libraries rules need to pass transitive info

### DIFF
--- a/examples/cmake/BUILD
+++ b/examples/cmake/BUILD
@@ -95,10 +95,7 @@ cc_binary(
     name = "libgd_with_png_example",
     srcs = ["arc.c"],
     deps = [
-        ":freetype",
         ":libgd",
-        ":libpng",
-        ":libz",
     ],
 )
 

--- a/tools/build_defs/configure.bzl
+++ b/tools/build_defs/configure.bzl
@@ -47,6 +47,7 @@ def _create_configure_script(ctx, attrs, inputs):
         dict(ctx.attr.configure_env_vars),
         is_debug_mode(ctx),
         ctx.attr.configure_command,
+        ctx.attr.deps,
         inputs,
     )
     return "\n".join([define_install_prefix, configure])

--- a/tools/build_defs/configure_script.bzl
+++ b/tools/build_defs/configure_script.bzl
@@ -42,10 +42,10 @@ def _define_deps_flags(deps, inputs):
     # Here go libraries built with Bazel
     gen_dirs_set = {}
     for lib in inputs.libs:
-        _dir = lib.dirname
-        if not gen_dirs_set.get(_dir):
-            gen_dirs_set[_dir] = 1
-            lib_dirs += ["-L$EXT_BUILD_ROOT/" + _dir]
+        dir_ = lib.dirname
+        if not gen_dirs_set.get(dir_):
+            gen_dirs_set[dir_] = 1
+            lib_dirs += ["-L$EXT_BUILD_ROOT/" + dir_]
 
     include_dirs_set = {}
     for dir_list in inputs.include_dirs:

--- a/tools/build_defs/configure_script.bzl
+++ b/tools/build_defs/configure_script.bzl
@@ -1,5 +1,5 @@
 load(":cc_toolchain_util.bzl", "absolutize_path_in_str")
-load(":framework.bzl", "ExternallyBuiltTransitive", "collect_libs")
+load(":framework.bzl", "ForeignCcDeps")
 
 def create_configure_script(
         workspace_name,
@@ -42,17 +42,17 @@ def _define_deps_flags(deps, inputs):
     # Here go libraries built with Bazel
     lib_dirs_set = {}
     for lib in inputs.libs:
-        dir = lib.dirname
-        if not lib_dirs_set.get(dir):
-            lib_dirs_set[dir] = 1
-            lib_dirs += ["-L$EXT_BUILD_ROOT/" + dir]
+        _dir = lib.dirname
+        if not lib_dirs_set.get(_dir):
+            lib_dirs_set[_dir] = 1
+            lib_dirs += ["-L$EXT_BUILD_ROOT/" + _dir]
 
     include_dirs_set = {}
-    for list in inputs.include_dirs:
-        for include_dir in list:
+    for dir_list in inputs.include_dirs:
+        for include_dir in dir_list:
             include_dirs_set[include_dir] = "-I$EXT_BUILD_ROOT/" + include_dir
-    for list in inputs.headers:
-        for header in list:
+    for header_list in inputs.headers:
+        for header in header_list:
             include_dir = header.dirname
             if not include_dirs_set.get(include_dir):
                 include_dirs_set[include_dir] = "-I$EXT_BUILD_ROOT/" + include_dir
@@ -66,9 +66,9 @@ def _define_deps_flags(deps, inputs):
     # the $EXT_BUILD_DEPS/<lib_name>, we ask the provider.
     lib_dirs_set = {}
     for dep in deps:
-        provider = dep[ExternallyBuiltTransitive]
-        if provider:
-            for artifact in provider.artifacts:
+        external_deps = dep[ForeignCcDeps]
+        if external_deps:
+            for artifact in external_deps.artifacts:
                 if not lib_dirs_set.get(artifact.gen_dir):
                     lib_dirs_set[artifact.gen_dir] = 1
 

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -120,18 +120,23 @@ def create_attrs(attr_struct, configure_name, configure_script, **kwargs):
 
 ForeignCcDeps = provider(
     doc = """Provider to pass transitive information about external libraries.""",
-    fields = dict(artifacts = "Depset of ExternallyBuiltArtifact"),
+    fields = {"artifacts": "Depset of ForeignCcArtifact"},
 )
 
 ForeignCcArtifact = provider(
-    doc = """Provider with the information about the external library install directory,
-and relative bin, include and lib directories""",
-    fields = dict(
-        gen_dir = "Install directory",
-        bin_dir_name = "Bin directory, relative to install directory",
-        lib_dir_name = "Lib directory, relative to install directory",
-        include_dir_name = "Include directory, relative to install directory",
-    ),
+    doc = """Groups information about the external library install directory,
+and relative bin, include and lib directories.
+
+Serves to pass transitive information about externally built artifacts up the dependency chain.
+
+Can not be used as a top-level provider.
+Instances of ForeignCcArtifact are incapsulated in a depset ForeignCcDeps#artifacts.""",
+    fields = {
+        "gen_dir": "Install directory",
+        "bin_dir_name": "Bin directory, relative to install directory",
+        "lib_dir_name": "Lib directory, relative to install directory",
+        "include_dir_name": "Include directory, relative to install directory",
+    },
 )
 
 def cc_external_rule_impl(ctx, attrs):
@@ -497,8 +502,8 @@ def _get_headers(compilation_info):
     for header in compilation_info.headers:
         path = header.path
         included = False
-        for _dir in include_dirs:
-            if path.startswith(_dir):
+        for dir_ in include_dirs:
+            if path.startswith(dir_):
                 included = True
                 break
         if not included:

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -118,19 +118,19 @@ def create_attrs(attr_struct, configure_name, configure_script, **kwargs):
         dict[arg] = kwargs[arg]
     return struct(**dict)
 
-ExternallyBuiltTransitive = provider(
+ForeignCcDeps = provider(
     doc = """Provider to pass transitive information about external libraries.""",
     fields = dict(artifacts = "Depset of ExternallyBuiltArtifact"),
 )
 
-ExternallyBuiltArtifact = provider(
+ForeignCcArtifact = provider(
     doc = """Provider with the information about the external library install directory,
 and relative bin, include and lib directories""",
     fields = dict(
         gen_dir = "Install directory",
-        bin_dir_name = "Relative (to install directory) bin directory",
-        lib_dir_name = "Relative (to install directory) lib directory",
-        include_dir_name = "Relative (to install directory) include directory",
+        bin_dir_name = "Bin directory, relative to install directory",
+        lib_dir_name = "Lib directory, relative to install directory",
+        include_dir_name = "Include directory, relative to install directory",
     ),
 )
 
@@ -247,7 +247,7 @@ def cc_external_rule_impl(ctx, attrs):
         env = env,
     )
 
-    externally_built = ExternallyBuiltArtifact(
+    externally_built = ForeignCcArtifact(
         gen_dir = outputs.installdir,
         bin_dir_name = attrs.out_bin_dir,
         lib_dir_name = attrs.out_lib_dir,
@@ -256,11 +256,13 @@ def cc_external_rule_impl(ctx, attrs):
     return [
         DefaultInfo(files = depset(direct = outputs.declared_outputs)),
         OutputGroupInfo(
+            gen_dir = depset([outputs.installdir]),
             bin_dir = depset([outputs.out_bin_dir]),
+            out_binary_files = depset(outputs.out_binary_files),
         ),
-        ExternallyBuiltTransitive(artifacts = depset(
+        ForeignCcDeps(artifacts = depset(
             [externally_built],
-            transitive = [dep[ExternallyBuiltTransitive].artifacts for dep in attrs.deps],
+            transitive = [dep[ForeignCcDeps].artifacts for dep in attrs.deps],
         )),
         cc_common.create_cc_skylark_info(ctx = ctx),
         out_cc_info.compilation_info,
@@ -293,33 +295,33 @@ def _list(item):
     return []
 
 def _copy_deps_and_tools(files):
-    list = []
-    list += _symlink_to_dir("lib", files.libs, False)
-    list += _symlink_to_dir("include", files.headers + files.include_dirs, True)
+    lines = []
+    lines += _symlink_to_dir("lib", files.libs, False)
+    lines += _symlink_to_dir("include", files.headers + files.include_dirs, True)
 
-    list += _symlink_to_dir("bin", files.tools_files, False)
+    lines += _symlink_to_dir("bin", files.tools_files, False)
 
     for ext_dir in files.ext_build_dirs:
-        list += ["symlink_to_dir $EXT_BUILD_ROOT/{} $EXT_BUILD_DEPS".format(_file_path(ext_dir))]
+        lines += ["symlink_to_dir $EXT_BUILD_ROOT/{} $EXT_BUILD_DEPS".format(_file_path(ext_dir))]
 
-    list += ["if [ -d $EXT_BUILD_DEPS/bin ]; then"]
+    lines += ["if [ -d $EXT_BUILD_DEPS/bin ]; then"]
 
-    list += ["  tools=$(find $EXT_BUILD_DEPS/bin -maxdepth 1 -mindepth 1)"]
-    list += ["  for tool in $tools;"]
-    list += ["  do"]
-    list += ["    if  [[ -d \"$tool\" ]] || [[ -L \"$tool\" ]]; then"]
-    list += ["      export PATH=$PATH:$tool"]
-    list += ["    fi"]
-    list += ["  done"]
-    list += ["fi"]
-    list += ["path $EXT_BUILD_DEPS/bin"]
+    lines += ["  tools=$(find $EXT_BUILD_DEPS/bin -maxdepth 1 -mindepth 1)"]
+    lines += ["  for tool in $tools;"]
+    lines += ["  do"]
+    lines += ["    if  [[ -d \"$tool\" ]] || [[ -L \"$tool\" ]]; then"]
+    lines += ["      export PATH=$PATH:$tool"]
+    lines += ["    fi"]
+    lines += ["  done"]
+    lines += ["fi"]
+    lines += ["path $EXT_BUILD_DEPS/bin"]
 
-    return list
+    return lines
 
 def _symlink_to_dir(dir_name, files_list, link_children):
     if len(files_list) == 0:
         return []
-    list = ["mkdir -p $EXT_BUILD_DEPS/" + dir_name]
+    lines = ["mkdir -p $EXT_BUILD_DEPS/" + dir_name]
 
     paths_list = []
     for file in files_list:
@@ -327,9 +329,9 @@ def _symlink_to_dir(dir_name, files_list, link_children):
 
     link_function = "symlink_contents_to_dir" if link_children else "symlink_to_dir"
     for path in paths_list:
-        list += ["{} $EXT_BUILD_ROOT/{} $EXT_BUILD_DEPS/{}".format(link_function, path, dir_name)]
+        lines += ["{} $EXT_BUILD_ROOT/{} $EXT_BUILD_DEPS/{}".format(link_function, path, dir_name)]
 
-    return list
+    return lines
 
 def _file_path(file):
     return file if type(file) == "string" else file.path
@@ -438,13 +440,13 @@ def _define_inputs(attrs):
     ext_build_dirs_set = {}
 
     for dep in attrs.deps:
-        provider = dep[ExternallyBuiltTransitive]
+        external_deps = dep[ForeignCcDeps]
 
         linking_infos_all += [dep[CcLinkingInfo]]
         compilation_infos_all += [dep[CcCompilationInfo]]
 
-        if provider:
-            for artifact in provider.artifacts:
+        if external_deps:
+            for artifact in external_deps.artifacts:
                 if not ext_build_dirs_set.get(artifact.gen_dir):
                     ext_build_dirs_set[artifact.gen_dir] = 1
                     ext_build_dirs += [artifact.gen_dir]
@@ -452,7 +454,7 @@ def _define_inputs(attrs):
             headers_info = _get_headers(dep[CcCompilationInfo])
             bazel_headers += headers_info.headers
             bazel_system_includes += headers_info.include_dirs
-            bazel_libs += collect_libs(dep[CcLinkingInfo])
+            bazel_libs += _collect_libs(dep[CcLinkingInfo])
 
     tools_roots = []
     tools_files = []
@@ -495,8 +497,8 @@ def _get_headers(compilation_info):
     for header in compilation_info.headers:
         path = header.path
         included = False
-        for dir in include_dirs:
-            if path.startswith(dir):
+        for _dir in include_dirs:
+            if path.startswith(_dir):
                 included = True
                 break
         if not included:
@@ -535,7 +537,7 @@ def _extract_link_params(cc_linking):
         cc_linking.dynamic_mode_params_for_executable,
     ]
 
-def collect_libs(cc_linking):
+def _collect_libs(cc_linking):
     libs = []
     for params in _extract_link_params(cc_linking):
         libs += [lib.artifact() for lib in params.libraries_to_link]

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -106,17 +106,17 @@ def create_attrs(attr_struct, configure_name, configure_script, **kwargs):
      to the resulting struct, adding or replacing attributes passed in 'configure_name',
      'configure_script', and '**kwargs' parameters.
     """
-    dict = {}
+    attrs = {}
     for key in CC_EXTERNAL_RULE_ATTRIBUTES:
         if not key.startswith("_") and hasattr(attr_struct, key):
-            dict[key] = getattr(attr_struct, key)
+            attrs[key] = getattr(attr_struct, key)
 
-    dict["configure_name"] = configure_name
-    dict["configure_script"] = configure_script
+    attrs["configure_name"] = configure_name
+    attrs["configure_script"] = configure_script
 
     for arg in kwargs:
-        dict[arg] = kwargs[arg]
-    return struct(**dict)
+        attrs[arg] = kwargs[arg]
+    return struct(**attrs)
 
 ForeignCcDeps = provider(
     doc = """Provider to pass transitive information about external libraries.""",

--- a/tools/build_defs/version.bzl
+++ b/tools/build_defs/version.bzl
@@ -1,1 +1,1 @@
-VERSION = "0.0.1"
+VERSION = "0.0.2"


### PR DESCRIPTION
- to have the same interface as cc_library to hide the "implementation details",
so that the information about the install directory and its contents of non-direct external dependencies of external library was available for external build
- this is particularly needed for configure-make rule, where we do not control the way needed libraries are found, so we want to provide the install directory and the -L, -I flags (include and library directories to be searched) consistently,
pointing to the directories under $EXT_BUILD_DEPS
- as a side effect, *.la files that contained links to absolute paths of dependencies (pointing somewhere under ...sandbox/bazel-out/...) now will point to directories under $EXT_BUILD_DEPS and so will be replaced correctly/will not point to paths under the previous sandbox