### PR TITLE
Add $EXT_BUILD_ROOT to the path so CROSSTOOL files work

### DIFF
--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -187,6 +187,7 @@ def cc_external_rule_impl(ctx, attrs):
         set_envs,
         "set_platform_env_vars",
         "export EXT_BUILD_ROOT=$BUILD_PWD",
+        "path $EXT_BUILD_ROOT",
         "export BUILD_TMPDIR=$(mktemp -d)",
         "export EXT_BUILD_DEPS=$EXT_BUILD_ROOT/bazel_foreign_cc_deps_" + lib_name,
         "mkdir -p $EXT_BUILD_DEPS",


### PR DESCRIPTION
When using the build in compilers or ones from external rules this works fine because _prefix prepends $EXT_BUILD_ROOT. But when using a CROSSTOOL in the existing workspace the toolchains are given relative paths.

When using a CROSS tool in the WORKSPACE the following error occurs:

```
The CMAKE_CXX_COMPILER:

    tools/compilers/arm/gcc/arm-buildroot-linux-musleabihf-gcc

  is not a full path and was not found in the PATH.

  Tell CMake where to find the compiler by setting either the environment
  variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.
```

Adding $EXT_BUILD_ROOT to the path fixes this issue.