### PR TITLE
Binary files produced by cmake_external should be declared as runfiles;

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -18,6 +18,7 @@ test_suite(
     name = "tests",
     tests = tests_with_synthetic + [
         "//examples/cmake_hello_world_lib/shared:test_libhello",
+        "//examples/cmake_hello_world_lib/binary:test_binary",
     ],
 )
 

--- a/examples/cmake_hello_world_lib/binary/BUILD
+++ b/examples/cmake_hello_world_lib/binary/BUILD
@@ -1,0 +1,39 @@
+# example code is taken from https://github.com/Akagi201/learning-cmake/tree/master/hello-world-lib
+# for test only
+load("//tools/build_defs:test_binary.bzl", "binary_test")
+
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)
+
+load("//tools/build_defs:cmake.bzl", "cmake_external")
+
+cmake_external(
+    name = "libhello",
+    binaries = select({
+        "@bazel_tools//src/conditions:windows": ["hello.exe"],
+        "@bazel_tools//src/conditions:darwin": ["hello"],
+        "//conditions:default": ["hello"],
+    }),
+    # Probably this variable should be set by default.
+    # Apparently, it needs to be set for shared libraries on Mac OS
+    cache_entries = {
+        "CMAKE_MACOSX_RPATH": "True",
+    },
+    lib_source = ":srcs",
+)
+
+filegroup(
+    name = "binary",
+    srcs = [":libhello"],
+    output_group = "hello",
+)
+
+binary_test(
+    name = "test_binary",
+    binary = ":binary",
+    args = ["me"],
+    expected_output = "Hello, me!",
+)

--- a/examples/cmake_hello_world_lib/binary/CMakeLists.txt
+++ b/examples/cmake_hello_world_lib/binary/CMakeLists.txt
@@ -1,0 +1,8 @@
+# taken from https://github.com/Akagi201/learning-cmake/tree/master/hello-world-lib
+# for test only
+
+cmake_minimum_required(VERSION 2.8.4)
+
+project(hellolib LANGUAGES C)
+
+add_subdirectory(src)

--- a/examples/cmake_hello_world_lib/binary/src/CMakeLists.txt
+++ b/examples/cmake_hello_world_lib/binary/src/CMakeLists.txt
@@ -1,0 +1,37 @@
+# taken from https://github.com/Akagi201/learning-cmake/tree/master/hello-world-lib
+# for test only
+
+cmake_minimum_required(VERSION 2.8.4)
+
+add_library(hello_lib STATIC hello.c hello.h)
+
+IF (WIN32)
+  set(LIB_NAME "libhello")
+ELSE()
+  set(LIB_NAME "hello")
+ENDIF()
+
+set_target_properties(hello_lib PROPERTIES
+  OUTPUT_NAME ${LIB_NAME}
+  )
+
+add_executable(myapp main.c)
+target_link_libraries(myapp hello_lib)
+target_include_directories(myapp PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+)
+set_target_properties(myapp PROPERTIES
+  OUTPUT_NAME hello
+  )
+
+install(
+ TARGETS
+ hello_lib
+ ARCHIVE DESTINATION lib
+)
+
+install(
+  TARGETS myapp DESTINATION bin
+)
+
+install(FILES hello.h DESTINATION include)

--- a/examples/cmake_hello_world_lib/binary/src/hello.c
+++ b/examples/cmake_hello_world_lib/binary/src/hello.c
@@ -1,0 +1,5 @@
+#include "hello.h"
+
+void hello_func(char* name) {
+	printf("Hello, %s!", name);
+}

--- a/examples/cmake_hello_world_lib/binary/src/hello.h
+++ b/examples/cmake_hello_world_lib/binary/src/hello.h
@@ -1,0 +1,8 @@
+#ifndef HELLO_H_
+#define HELLO_H_ (1)
+
+#include <stdio.h>
+
+void hello_func(char*);
+
+#endif

--- a/examples/cmake_hello_world_lib/binary/src/main.c
+++ b/examples/cmake_hello_world_lib/binary/src/main.c
@@ -1,0 +1,7 @@
+#include "hello.h"
+
+int main(int argc, char* argv[])
+{
+  hello_func(argv[1]);
+  return 0;
+}

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -293,11 +293,9 @@ def cc_external_rule_impl(ctx, attrs):
         include_dir_name = attrs.out_include_dir,
     )
     return [
-        DefaultInfo(files = depset(direct = rule_outputs)),
-        OutputGroupInfo(
-            gen_dir = depset([installdir_copy.file]),
-            out_binary_files = depset(outputs.out_binary_files),
-        ),
+        DefaultInfo(files = depset(direct = rule_outputs),
+                    runfiles = ctx.runfiles(files = outputs.out_binary_files)),
+        OutputGroupInfo(**_declare_output_groups(installdir_copy.file, outputs.out_binary_files)),
         ForeignCcDeps(artifacts = depset(
             [externally_built],
             transitive = _get_transitive_artifacts(attrs.deps),
@@ -306,6 +304,13 @@ def cc_external_rule_impl(ctx, attrs):
         out_cc_info.compilation_info,
         out_cc_info.linking_info,
     ]
+
+def _declare_output_groups(installdir, outputs):
+    dict_ = {}
+    dict_["gen_dir"] = depset([installdir])
+    for output in outputs:
+        dict_[output.basename] = [output]
+    return dict_
 
 def _get_transitive_artifacts(deps):
     artifacts = []

--- a/tools/build_defs/test_binary.bzl
+++ b/tools/build_defs/test_binary.bzl
@@ -1,0 +1,36 @@
+def _test_binary(ctx):
+    # todo: why does it work?
+    binary_path = ctx.attr.binary[DefaultInfo].default_runfiles.files.to_list()[0].short_path
+
+    script = [
+        "bin_path={binary}".format(binary = binary_path),
+        "result_{name}=$($bin_path {args})".format(
+            name = ctx.label.name,
+            binary = binary_path,
+            args = " ".join(ctx.attr.args),
+        ),
+        "if [[ \"$result_{name}*\" != \"{expected}*\" ]]; then exit -1; fi".format(
+            name = ctx.label.name,
+            expected = ctx.attr.expected_output,
+        ),
+    ]
+
+    print("script: " + "\n".join(script))
+
+    ctx.actions.write(
+        output = ctx.outputs.executable,
+        content = "\n".join(script),
+    )
+
+    runfiles = ctx.runfiles(files = ctx.files.binary + ctx.files.data)
+    return [DefaultInfo(runfiles = runfiles)]
+
+binary_test = rule(
+    implementation = _test_binary,
+    attrs = {
+        "binary": attr.label(mandatory = True, allow_single_file = True),
+        "data": attr.label_list(mandatory = False, default = []),
+        "expected_output": attr.string(mandatory = True),
+    },
+    test = True,
+)


### PR DESCRIPTION
also, put each of binary files into OutputGroupInfo under its name.

Add CMake test for building a binary and using that binary in a test, which expects a target with a runfile.
Had to write a generic test rule for invoking a binary which produces some output.