### PR TITLE
implements exports - not meant for submission

### DIFF
--- a/for_workspace/utils_unix.sh
+++ b/for_workspace/utils_unix.sh
@@ -17,7 +17,7 @@ function path() {
 function replace_in_files() {
   if [ -d "$1" ]; then
     find -L $1 -print -type f \
-     \( -name "*.pc" -or -name "*.la" -or -name "*-config" \) \
+     \( -name "*.pc" -or -name "*.la" -or -name "*-config.cmake" -or -name "*Config.cmake" \) \
     -exec sed -i 's@'"$2"'@'"$3"'@g' {} ';'
   fi
 }

--- a/tools/build_defs/cmake_script.bzl
+++ b/tools/build_defs/cmake_script.bzl
@@ -176,7 +176,7 @@ def _move_dict_values(target, source, descriptor_map):
                 target[existing.value] = _merge(target[existing.value], value)
 
 def _merge(str1, str2):
-    return str1.strip("\"'") + " " + str2.strip("\"'")
+    return str1 + " " + str2
 
 def _fill_crossfile_from_toolchain(workspace_name, target_os, tools, flags):
     os_name = "Linux"

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -491,7 +491,7 @@ def _define_inputs(attrs):
     deps_and_exports = []
     deps_and_exports_set = {}
     for dep in attrs.deps:
-        for export in dep[ExportInfo] + dep:
+        for export in dep[ExportInfo] + [dep]:
             if not deps_and_exports_set.get(export):
                 deps_and_exports_set[export] = 1
                 deps_and_exports += [export]

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -303,7 +303,7 @@ def cc_external_rule_impl(ctx, attrs):
     return [
         DefaultInfo(files = depset(direct = rule_outputs)),
         OutputGroupInfo(**_declare_output_groups(installdir_copy.file, outputs.out_binary_files)),
-        ExportInfo(exports = depset(attrs.exports))
+        ExportInfo(exports = depset(attrs.exports)),
         ForeignCcDeps(artifacts = depset(
             [externally_built],
             transitive = _get_transitive_artifacts(attrs.deps),

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -306,7 +306,7 @@ def cc_external_rule_impl(ctx, attrs):
         ExportInfo(exports = attrs.exports),
         ForeignCcDeps(artifacts = depset(
             [externally_built],
-            transitive = _get_transitive_artifacts(attrs.deps),
+            transitive = _get_transitive_artifacts(attrs.deps, attrs.exports),
         )),
         cc_common.create_cc_skylark_info(ctx = ctx),
         out_cc_info.compilation_info,
@@ -320,9 +320,9 @@ def _declare_output_groups(installdir, outputs):
         dict_[output.basename] = [output]
     return dict_
 
-def _get_transitive_artifacts(deps):
+def _get_transitive_artifacts(deps, exports):
     artifacts = []
-    for dep in deps:
+    for dep in deps + exports:
         foreign_dep = get_foreign_cc_dep(dep)
         if foreign_dep:
             artifacts += [foreign_dep.artifacts]

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -294,6 +294,8 @@ def cc_external_rule_impl(ctx, attrs):
         env = env,
     )
 
+    print("after `run_shell`")
+
     externally_built = ForeignCcArtifact(
         gen_dir = installdir_copy.file,
         bin_dir_name = attrs.out_bin_dir,

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -254,7 +254,7 @@ def cc_external_rule_impl(ctx, attrs):
         "mkdir -p $EXT_BUILD_DEPS",
         "mkdir -p $INSTALLDIR",
         _print_env(),
-        "trap \"{ rm -rf $BUILD_TMPDIR $EXT_BUILD_ROOT/bazel_foreign_cc_deps_" + lib_name + "; }\" EXIT",
+        #"trap \"{ rm -rf $BUILD_TMPDIR $EXT_BUILD_ROOT/bazel_foreign_cc_deps_" + lib_name + "; }\" EXIT",
         "\n".join(_copy_deps_and_tools(inputs)),
         # replace placeholder with the dependencies root
         "define_absolute_paths $EXT_BUILD_DEPS $EXT_BUILD_DEPS",

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -303,7 +303,7 @@ def cc_external_rule_impl(ctx, attrs):
     return [
         DefaultInfo(files = depset(direct = rule_outputs)),
         OutputGroupInfo(**_declare_output_groups(installdir_copy.file, outputs.out_binary_files)),
-        ExportInfo(exports = depset(attrs.exports)),
+        ExportInfo(exports = attrs.exports),
         ForeignCcDeps(artifacts = depset(
             [externally_built],
             transitive = _get_transitive_artifacts(attrs.deps),

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -320,7 +320,7 @@ def _declare_output_groups(installdir, outputs):
         dict_[output.basename] = [output]
     return dict_
 
-def _get_transitive_artifacts(deps, exports):
+def _get_transitive_artifacts(deps):
     artifacts = []
     for dep in deps:
         for export in dep[ExportInfo].exports + [dep]:

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -495,7 +495,7 @@ def _define_inputs(attrs):
             if not deps_and_exports_set.get(export):
                 export_id = export.label.package + export.label.name
                 deps_and_exports_set[export_id] = 1
-                deps_and_exports += [export_id]
+                deps_and_exports += [export]
 
     for dep in deps_and_exports:
         external_deps = get_foreign_cc_dep(dep)

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -493,8 +493,9 @@ def _define_inputs(attrs):
     for dep in attrs.deps:
         for export in dep[ExportInfo].exports + [dep]:
             if not deps_and_exports_set.get(export):
-                deps_and_exports_set[export] = 1
-                deps_and_exports += [export]
+                export_id = export.label.package + export.label.name
+                deps_and_exports_set[export_id] = 1
+                deps_and_exports += [export_id]
 
     for dep in deps_and_exports:
         external_deps = get_foreign_cc_dep(dep)

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -325,9 +325,12 @@ def _declare_output_groups(installdir, outputs):
 def _get_transitive_artifacts(deps):
     artifacts = []
     for dep in deps:
+        print("Get transitive artifacts for {}".format(dep))
         for export in dep[ExportInfo].exports + [dep]:
+            print("Export: {}".format(export))
             foreign_dep = get_foreign_cc_dep(export)
             if foreign_dep:
+                print("Foreign dep: {}".format(foreign_dep))
                 artifacts += [foreign_dep.artifacts]
     return artifacts
 
@@ -497,6 +500,7 @@ def _define_inputs(attrs):
         for export in dep[ExportInfo].exports + [dep]:
             if not deps_and_exports_set.get(export):
                 export_id = export.label.package + export.label.name
+                print("export_id: {}".format(export_id))
                 deps_and_exports_set[export_id] = 1
                 deps_and_exports += [export]
 

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -491,7 +491,7 @@ def _define_inputs(attrs):
     deps_and_exports = []
     deps_and_exports_set = {}
     for dep in attrs.deps:
-        for export in dep[ExportInfo] + [dep]:
+        for export in dep[ExportInfo].exports + [dep]:
             if not deps_and_exports_set.get(export):
                 deps_and_exports_set[export] = 1
                 deps_and_exports += [export]

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -254,7 +254,7 @@ def cc_external_rule_impl(ctx, attrs):
         "mkdir -p $EXT_BUILD_DEPS",
         "mkdir -p $INSTALLDIR",
         _print_env(),
-        #"trap \"{ rm -rf $BUILD_TMPDIR $EXT_BUILD_ROOT/bazel_foreign_cc_deps_" + lib_name + "; }\" EXIT",
+        "trap \"{ rm -rf $BUILD_TMPDIR $EXT_BUILD_ROOT/bazel_foreign_cc_deps_" + lib_name + "; }\" EXIT",
         "\n".join(_copy_deps_and_tools(inputs)),
         # replace placeholder with the dependencies root
         "define_absolute_paths $EXT_BUILD_DEPS $EXT_BUILD_DEPS",

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -306,7 +306,7 @@ def cc_external_rule_impl(ctx, attrs):
         ExportInfo(exports = attrs.exports),
         ForeignCcDeps(artifacts = depset(
             [externally_built],
-            transitive = _get_transitive_artifacts(attrs.deps, attrs.exports),
+            transitive = _get_transitive_artifacts(attrs.deps),
         )),
         cc_common.create_cc_skylark_info(ctx = ctx),
         out_cc_info.compilation_info,
@@ -322,10 +322,11 @@ def _declare_output_groups(installdir, outputs):
 
 def _get_transitive_artifacts(deps, exports):
     artifacts = []
-    for dep in deps + exports:
-        foreign_dep = get_foreign_cc_dep(dep)
-        if foreign_dep:
-            artifacts += [foreign_dep.artifacts]
+    for dep in deps:
+        for export in dep[ExportInfo].exports + [dep]:
+            foreign_dep = get_foreign_cc_dep(export)
+            if foreign_dep:
+                artifacts += [foreign_dep.artifacts]
     return artifacts
 
 def _print_env():


### PR DESCRIPTION
hi @irengrig!

I was hoping if you had a moment to lend your expertise, I cannot for the life of me figure out why this does not work. I'm trying to add functionality that allows target A to declare target B such that any target C that depends on A will also depend on B.

AFAICT, I am treating exports of a dep exactly the same as a dep, e.g. adding B as an export of A and then having C depend on A should yield exactly the same results as just having C depend on A and B directly. However, I have tested it and this is not the case. Do you happen to see where I'm going wrong?

Thank so much for your help

Edit: relevant changes are in framework.bzl