### PR TITLE
Improve the boost rule including user_options attribute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # rules_foreign_cc
+[![Build status](https://badge.buildkite.com/c28afbf846e2077715c753dda1f4b820cdcc46cc6cde16503c.svg)](https://buildkite.com/bazel/rules-foreign-cc)
 
 Rules for building C/C++ projects using foreign build systems inside Bazel projects.
 

--- a/examples/boost/BUILD
+++ b/examples/boost/BUILD
@@ -1,6 +1,16 @@
 load("//tools/build_defs:boost_build.bzl", "boost_build")
 
 boost_build(
-    name = "boost",
-    lib_source = "@boost//:all"
+    name = "boost_regex",
+    lib_source = "@boost//:all",
+    shared_libraries = ["libboost_regex.so.1.68.0"],
+    static_libraries = ["libboost_regex.a"],
+    user_options = ["--with-regex"],
+)
+
+boost_build(
+    name = "boost_filesystem",
+    lib_source = "@boost//:all",
+    static_libraries = ["libboost_filesystem.a"],
+    user_options = ["--with-filesystem"],
 )

--- a/examples/cmake_pcl/BUILD
+++ b/examples/cmake_pcl/BUILD
@@ -4,7 +4,50 @@ load("//tools/build_defs:boost_build.bzl", "boost_build")
 # This takes something about 10 minutes
 boost_build(
     name = "boost",
-    lib_source = "@boost//:all"
+    lib_source = "@boost//:all",
+    static_libraries = [
+        "libboost_atomic.a",
+        "libboost_chrono.a",
+        "libboost_container.a",
+        "libboost_context.a",
+        "libboost_contract.a",
+        "libboost_coroutine.a",
+        "libboost_date_time.a",
+        "libboost_exception.a",
+        "libboost_fiber.a",
+        "libboost_filesystem.a",
+        "libboost_graph.a",
+        "libboost_iostreams.a",
+        "libboost_locale.a",
+        "libboost_log.a",
+        "libboost_log_setup.a",
+        "libboost_math_c99.a",
+        "libboost_math_c99f.a",
+        "libboost_math_c99l.a",
+        "libboost_math_tr1.a",
+        "libboost_math_tr1f.a",
+        "libboost_math_tr1l.a",
+        "libboost_numpy27.a",
+        "libboost_prg_exec_monitor.a",
+        "libboost_program_options.a",
+        "libboost_python27.a",
+        "libboost_random.a",
+        "libboost_regex.a",
+        "libboost_serialization.a",
+        "libboost_signals.a",
+        "libboost_stacktrace_addr2line.a",
+        "libboost_stacktrace_backtrace.a",
+        "libboost_stacktrace_basic.a",
+        "libboost_stacktrace_noop.a",
+        "libboost_system.a",
+        "libboost_test_exec_monitor.a",
+        "libboost_thread.a",
+        "libboost_timer.a",
+        "libboost_type_erasure.a",
+        "libboost_unit_test_framework.a",
+        "libboost_wave.a",
+        "libboost_wserialization.a",
+    ],
 )
 
 cmake_external(
@@ -24,11 +67,10 @@ cmake_external(
         "BLAS_LIBRARIES": "$EXT_BUILD_DEPS/openblas/lib/libopenblas.a",
     },
     headers_only = True,
-    out_include_dir = "include/eigen3",
     lib_source = "@eigen//:all",
+    out_include_dir = "include/eigen3",
     deps = [":openblas"],
 )
-
 
 cmake_external(
     name = "flann",
@@ -67,8 +109,8 @@ cmake_external(
     lib_source = "@pcl//:all",
     out_include_dir = "include/pcl-1.8",
     deps = [
+        ":boost",
         ":eigen",
         ":flann",
-        ":boost"
     ],
 )

--- a/tools/build_defs/boost_build.bzl
+++ b/tools/build_defs/boost_build.bzl
@@ -13,50 +13,7 @@ def _boost_build(ctx):
         ctx.attr,
         configure_name = "BuildBoost",
         create_configure_script = _create_configure_script,
-        make_commands = ["./b2 install --prefix=."],
-        static_libraries = [
-            "libboost_atomic.a",
-            "libboost_chrono.a",
-            "libboost_container.a",
-            "libboost_context.a",
-            "libboost_contract.a",
-            "libboost_coroutine.a",
-            "libboost_date_time.a",
-            "libboost_exception.a",
-            "libboost_fiber.a",
-            "libboost_filesystem.a",
-            "libboost_graph.a",
-            "libboost_iostreams.a",
-            "libboost_locale.a",
-            "libboost_log.a",
-            "libboost_log_setup.a",
-            "libboost_math_c99.a",
-            "libboost_math_c99f.a",
-            "libboost_math_c99l.a",
-            "libboost_math_tr1.a",
-            "libboost_math_tr1f.a",
-            "libboost_math_tr1l.a",
-            "libboost_numpy27.a",
-            "libboost_prg_exec_monitor.a",
-            "libboost_program_options.a",
-            "libboost_python27.a",
-            "libboost_random.a",
-            "libboost_regex.a",
-            "libboost_serialization.a",
-            "libboost_signals.a",
-            "libboost_stacktrace_addr2line.a",
-            "libboost_stacktrace_backtrace.a",
-            "libboost_stacktrace_basic.a",
-            "libboost_stacktrace_noop.a",
-            "libboost_system.a",
-            "libboost_test_exec_monitor.a",
-            "libboost_thread.a",
-            "libboost_timer.a",
-            "libboost_type_erasure.a",
-            "libboost_unit_test_framework.a",
-            "libboost_wave.a",
-            "libboost_wserialization.a",
-        ],
+        make_commands = ["./b2 install {} --prefix=.".format(" ".join(ctx.attr.user_options))],
     )
     return cc_external_rule_impl(ctx, attrs)
 
@@ -70,12 +27,20 @@ def _create_configure_script(configureParameters):
         "./bootstrap.sh",
     ])
 
+def _attrs():
+    attrs = dict(CC_EXTERNAL_RULE_ATTRIBUTES)
+    attrs.update({
+        # any additional flags to pass to b2
+        "user_options": attr.string_list(mandatory = False),
+    })
+    return attrs
+
 """ Rule for building Boost. Invokes bootstrap.sh and then b2 install.
   Attributes:
     boost_srcs - target with the boost sources
 """
 boost_build = rule(
-    attrs = CC_EXTERNAL_RULE_ATTRIBUTES,
+    attrs = _attrs(),
     fragments = ["cpp"],
     output_to_genfiles = True,
     implementation = _boost_build,


### PR DESCRIPTION
Then --with-<library> parameter can be passed to build only that library
Modify examples to demonstrate how to use it.
However, building examples takes too long time, so do not include them into the tests.