### PR TITLE
Put examples/crosstool into .bazelignore

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,1 @@
+examples/cmake_crosstool


### PR DESCRIPTION
Since it is a separate workspace