### PR TITLE
Replace depset with list for copts in cc_toolchain_util.bzl

### DIFF
--- a/tools/build_defs/old_11_2018/cc_toolchain_util.bzl
+++ b/tools/build_defs/old_11_2018/cc_toolchain_util.bzl
@@ -269,7 +269,7 @@ def get_env_vars(ctx):
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
     )
-    copts = ctx.attr.copts if hasattr(ctx.attr, "copts") else depset()
+    copts = ctx.attr.copts if hasattr(ctx.attr, "copts") else []
 
     vars = dict()
 
@@ -331,7 +331,7 @@ def get_flags_info(ctx):
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
     )
-    copts = ctx.attr.copts if hasattr(ctx.attr, "copts") else depset()
+    copts = ctx.attr.copts if hasattr(ctx.attr, "copts") else []
 
     return CxxFlagsInfo(
         cc = cc_common.get_memory_inefficient_command_line(


### PR DESCRIPTION
This fixes the ternary expression to generate `copts` to return a `list` instead of a `depset()` if no copts are specified.

This is because in Bazel 0.21.0, the usage of depset for copts has already been deprecated and will cause the following error:

```
ERROR: /[...]/BUILD.bazel:3:1: in cmake_external rule //:[...]:
Traceback (most recent call last):
	File "/[...]/BUILD.bazel", line 3
		cmake_external(name = '[...]')
	File "/private/var/tmp/_bazel_pkv/d8dc550ca3f9391c84581bff74017c12/external/rules_foreign_cc/tools/build_defs/cmake.bzl", line 34, in _cmake_external
		cc_external_rule_impl(ctx, attrs)
	File "/private/var/tmp/_bazel_pkv/d8dc550ca3f9391c84581bff74017c12/external/foreign_cc_impl/framework.bzl", line 273, in cc_external_rule_impl
		attrs.create_configure_script(ConfigureParameters(ctx = ctx, a...))
	File "/private/var/tmp/_bazel_pkv/d8dc550ca3f9391c84581bff74017c12/external/rules_foreign_cc/tools/build_defs/cmake.bzl", line 43, in attrs.create_configure_script
		get_flags_info(ctx)
	File "/private/var/tmp/_bazel_pkv/d8dc550ca3f9391c84581bff74017c12/external/foreign_cc_impl/cc_toolchain_util.bzl", line 336, in get_flags_info
		CxxFlagsInfo(cc = cc_common.get_memory_ineffi...)), <5 more arguments>)
	File "/private/var/tmp/_bazel_pkv/d8dc550ca3f9391c84581bff74017c12/external/foreign_cc_impl/cc_toolchain_util.bzl", line 337, in CxxFlagsInfo
		cc_common.get_memory_inefficient_command_line(feature_configuration = feature_..., <2 more arguments>)
	File "/private/var/tmp/_bazel_pkv/d8dc550ca3f9391c84581bff74017c12/external/foreign_cc_impl/cc_toolchain_util.bzl", line 340, in cc_common.get_memory_inefficient_command_line
		cc_common.create_compile_variables(feature_configuration = feature_..., <2 more arguments>)
Passing depset into user flags is deprecated (see --incompatible_disable_depset_in_cc_user_flags), use list instead.
```

```
$ bazel version
INFO: Invocation ID: b6cc8594-78e5-4539-9d70-0af4e1a3b17f
Build label: 0.21.0
Build target: bazel-out/darwin-opt/bin/src/main/java/com/google/devtools/build/lib/bazel/BazelServer_deploy.jar
Build time: Wed Dec 19 12:57:09 2018 (1545224229)
Build timestamp: 1545224229
Build timestamp as int: 1545224229
```