### PR TITLE
Extract cmake and ninja into a toolchain; provide defaults.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,20 @@ It also requires passing Bazel the following flag:
 ```
 Where ```rules_foreign_cc``` is the name of this repository in your WORKSPACE file.
 
+## News
+**January 2019:**
+
+- Examples package became the separate workspace. 
+This also allows to illustrate how to initialize rules_foreign_cc.
+
+- Native tools (cmake, ninja) toolchains were introduced.
+Though the user code does not have to be changed (default toolchains are registered, they call the preinstalled binaries by name.),
+you may simplify usage of ninja with the cmake_external rule and call it just by name.
+Please see examples/cmake_nghttp2 for ninja usage, and WORKSPACE and BUILD files in examles for the native tools toolchains usage.
+
+- Awaiting Bazel 0.22, with it would be possible to use rules_foreign_cc without any flags:
+[C++: Remove whitelist flag for new API](https://github.com/bazelbuild/bazel/commit/1d36051776557bbcbba1a8f0d98e5a408a717d11) 
+
 ## Building CMake projects:
 
 - Build libraries/binaries with CMake from sources using cmake_external rule
@@ -51,9 +65,21 @@ http_archive(
 
 load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
 
-# Workspace initialization function; includes repositories needed by rules_foreign_cc,
-# and creates some utilities for the host operating system
-rules_foreign_cc_dependencies()
+# Call this function from the WORKSPACE file to initialize rules_foreign_cc
+#  dependencies and let neccesary code generation happen
+#  (Code generation is needed to support different variants of the C++ Starlark API.).
+#
+#  Args:
+#    native_tools_toolchains: pass the toolchains for toolchain types
+#      '@rules_foreign_cc//tools/build_defs:cmake_toolchain' and
+#      '@rules_foreign_cc//tools/build_defs:ninja_toolchain' with the needed platform constraints.
+#      If you do not pass anything, registered default toolchains will be selected (see below).
+#  
+#    register_default_tools: if True, the cmake and ninja toolchains, calling corresponding
+#      preinstalled binaries by name (cmake, ninja) will be registered after
+#      'native_tools_toolchains' without any platform constraints.
+#      The default is True.
+rules_foreign_cc_dependencies(["//:my_cmake_toolchain", "//:my_ninja_toolchain"])
 
 # OpenBLAS source code repository
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,6 +9,12 @@ local_repository(
     path = "examples",
 )
 
+register_toolchains(
+    "@rules_foreign_cc_tests//:built_cmake_toolchain",
+    "@rules_foreign_cc_tests//:built_ninja_toolchain_osx",
+    "@rules_foreign_cc_tests//:built_ninja_toolchain_linux",
+)
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 android_sdk_repository(

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -3,9 +3,10 @@ tests = [
     "//cmake:test_libpng",
     "//cmake:test_zlib",
     "//cmake_cares:test_c_ares",
+    "//cmake_cares:test_old_c_ares",
     "//cmake_hello_world_lib/static:test_hello",
     "//cmake_nghttp2:test_nghttp2",
-    "//ninja:test_ninja_version",
+    "//built_ninja:test_ninja_version",
     "@rules_foreign_cc//test:cmake_script_test_suite",
     "//cc_configure_make:libevent_echosrv1",
 ]
@@ -43,4 +44,26 @@ test_suite(
         "//cmake_hello_world_lib/static:test_hello_ninja",
         "//cmake_hello_world_lib/static:test_hello_nmake",
     ],
+)
+
+# On Bazel CI Mac machines, we are using cmake built from sources
+toolchain(
+    name = "built_cmake_toolchain",
+    exec_compatible_with = [
+        "@bazel_tools//platforms:osx",
+        "@bazel_tools//platforms:x86_64",
+    ],
+    toolchain = "@rules_foreign_cc//tools/build_defs/native_tools:built_cmake",
+    toolchain_type = "@rules_foreign_cc//tools/build_defs:cmake_toolchain",
+)
+
+# On Bazel CI Mac machines, we are using ninja built from sources
+toolchain(
+    name = "built_ninja_toolchain",
+    exec_compatible_with = [
+        "@bazel_tools//platforms:osx",
+        "@bazel_tools//platforms:x86_64",
+    ],
+    toolchain = "@rules_foreign_cc//tools/build_defs/native_tools:built_ninja",
+    toolchain_type = "@rules_foreign_cc//tools/build_defs:ninja_toolchain",
 )

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -6,7 +6,10 @@ tests = [
     "//cmake_cares:test_old_c_ares",
     "//cmake_hello_world_lib/static:test_hello",
     "//cmake_nghttp2:test_nghttp2",
-    "//built_ninja:test_ninja_version",
+    # Commented out because the paths in shell test should be different depending on whether it called
+    # from out workspace or same workspace
+    # Uncomment after nested workspaces are supported on CI
+    #    "//built_ninja:test_ninja_version",
     "@rules_foreign_cc//test:cmake_script_test_suite",
     "//cc_configure_make:libevent_echosrv1",
 ]

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -62,9 +62,20 @@ toolchain(
 
 # On Bazel CI Mac machines, we are using ninja built from sources
 toolchain(
-    name = "built_ninja_toolchain",
+    name = "built_ninja_toolchain_osx",
     exec_compatible_with = [
         "@bazel_tools//platforms:osx",
+        "@bazel_tools//platforms:x86_64",
+    ],
+    toolchain = "@rules_foreign_cc//tools/build_defs/native_tools:built_ninja",
+    toolchain_type = "@rules_foreign_cc//tools/build_defs:ninja_toolchain",
+)
+
+# On Bazel CI Mac machines, we are using ninja built from sources
+toolchain(
+    name = "built_ninja_toolchain_linux",
+    exec_compatible_with = [
+        "@bazel_tools//platforms:linux",
         "@bazel_tools//platforms:x86_64",
     ],
     toolchain = "@rules_foreign_cc//tools/build_defs/native_tools:built_ninja",

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -7,7 +7,10 @@ local_repository(
 
 load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
 
-rules_foreign_cc_dependencies()
+rules_foreign_cc_dependencies([
+    "//:built_cmake_toolchain",
+    "//:built_ninja_toolchain",
+])
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -9,7 +9,8 @@ load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependen
 
 rules_foreign_cc_dependencies([
     "//:built_cmake_toolchain",
-    "//:built_ninja_toolchain",
+    "//:built_ninja_toolchain_osx",
+    "//:built_ninja_toolchain_linux",
 ])
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/examples/built_ninja/BUILD
+++ b/examples/built_ninja/BUILD
@@ -1,0 +1,19 @@
+load("@rules_foreign_cc//for_workspace:ninja_build.bzl", "ninja_tool")
+
+ninja_tool(
+    name = "ninja_tool",
+    ninja_srcs = "@ninja_build//:all",
+)
+
+sh_library(
+    name = "ninja_",
+    srcs = [":ninja_tool"],
+)
+
+sh_test(
+    name = "test_ninja_version",
+    srcs = ["test_ninja_version.sh"],
+    args = ["true"],
+    visibility = ["//:__pkg__"],
+    deps = [":ninja_"],
+)

--- a/examples/built_ninja/test_ninja_version.sh
+++ b/examples/built_ninja/test_ninja_version.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ $1 == "true" ]; then
-  NINJA_COMMAND="${TEST_SRCDIR}/rules_foreign_cc/external/foreign_cc_platform_utils/ninja/ninja"
+  NINJA_COMMAND="./built_ninja/ninja/ninja"
 else
   NINJA_COMMAND="ninja"
 fi

--- a/examples/cmake_cares/BUILD
+++ b/examples/cmake_cares/BUILD
@@ -1,8 +1,10 @@
 load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+
+# This should NOT be used anymore. However, keeping it here to test backwards-compatibility.
 load("@foreign_cc_platform_utils//:tools.bzl", "NINJA_COMMAND", "NINJA_DEP")
 
 cmake_external(
-    name = "cares",
+    name = "old_cares",
     cache_entries = {
         "CARES_SHARED": "no",
         "CARES_STATIC": "on",
@@ -15,6 +17,30 @@ cmake_external(
     ],
     static_libraries = ["libcares.a"],
     tools_deps = NINJA_DEP,
+)
+
+cmake_external(
+    name = "cares",
+    cache_entries = {
+        "CARES_SHARED": "no",
+        "CARES_STATIC": "on",
+    },
+    cmake_options = ["-GNinja"],
+    lib_source = "@cares//:all",
+    make_commands = [
+        # The correct path to the ninja tool is detected from the selected ninja_toolchain.
+        # and "ninja" will be replaced with that path if needed
+        "ninja",
+        "ninja install",
+    ],
+    static_libraries = ["libcares.a"],
+)
+
+cc_test(
+    name = "test_old_c_ares",
+    srcs = ["c-ares-test.cpp"],
+    visibility = ["//:__pkg__"],
+    deps = [":old_cares"],
 )
 
 cc_test(

--- a/examples/cmake_nghttp2/BUILD
+++ b/examples/cmake_nghttp2/BUILD
@@ -1,5 +1,4 @@
 load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
-load("@foreign_cc_platform_utils//:tools.bzl", "NINJA_COMMAND", "NINJA_DEP")
 
 cmake_external(
     name = "nghttp2",
@@ -10,11 +9,12 @@ cmake_external(
     cmake_options = ["-GNinja"],
     lib_source = "@nghttp2//:all",
     make_commands = [
-        NINJA_COMMAND,
-        NINJA_COMMAND + " install",
+        # The correct path to the ninja tool is detected from the selected ninja_toolchain.
+        # and "ninja" will be replaced with that path if needed
+        "ninja",
+        "ninja install",
     ],
     static_libraries = ["libnghttp2.a"],
-    tools_deps = NINJA_DEP,
 )
 
 cc_test(

--- a/examples/cmake_synthetic/BUILD
+++ b/examples/cmake_synthetic/BUILD
@@ -1,5 +1,4 @@
 load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
-load("@foreign_cc_platform_utils//:tools.bzl", "NINJA_COMMAND", "NINJA_DEP")
 
 filegroup(
     name = "b_srcs",
@@ -18,10 +17,9 @@ cmake_external(
     generate_crosstool_file = generate_crosstool,
     lib_source = "//cmake_synthetic/liba:a_srcs",
     make_commands = [
-        NINJA_COMMAND,
-        NINJA_COMMAND + " install",
+        "ninja",
+        "ninja install",
     ],
-    tools_deps = NINJA_DEP,
 )
 
 cmake_external(
@@ -30,10 +28,9 @@ cmake_external(
     generate_crosstool_file = generate_crosstool,
     lib_source = "//cmake_synthetic/libb:b_srcs",
     make_commands = [
-        NINJA_COMMAND,
-        NINJA_COMMAND + " install",
+        "ninja",
+        "ninja install",
     ],
-    tools_deps = NINJA_DEP,
     deps = [":liba"],
 )
 

--- a/examples/ninja/BUILD
+++ b/examples/ninja/BUILD
@@ -1,9 +1,0 @@
-load("@foreign_cc_platform_utils//:tools.bzl", "NINJA_USE_BUILT", "NINJA_DEP")
-
-sh_test(
-    name = "test_ninja_version",
-    srcs = ["test_ninja_version.sh"],
-    args = ["true" if NINJA_USE_BUILT else "false"],
-    visibility = ["//:__pkg__"],
-    deps = NINJA_DEP,
-)

--- a/for_workspace/ninja_build.bzl
+++ b/for_workspace/ninja_build.bzl
@@ -1,6 +1,6 @@
 """ Rule for building Ninja from sources. """
 
-load("//:detect_root.bzl", "detect_root")
+load("//tools/build_defs:detect_root.bzl", "detect_root")
 
 def _ninja_tool(ctx):
     root = detect_root(ctx.attr.ninja_srcs)

--- a/tools/build_defs/BUILD
+++ b/tools/build_defs/BUILD
@@ -1,6 +1,25 @@
-exports_files(
-    [
-        "cmake.bzl",
-        "framework.bzl",
-    ],
+toolchain_type(
+    name = "cmake_toolchain",
+    visibility = ["//visibility:public"],
+)
+
+toolchain_type(
+    name = "ninja_toolchain",
+    visibility = ["//visibility:public"],
+)
+
+# Preinstalled cmake will always be the default, if toolchain with more exact constraints
+# is not defined before; registered from workspace_definitions.bzl#rules_foreign_cc_dependencies
+toolchain(
+    name = "preinstalled_cmake_toolchain",
+    toolchain = "@rules_foreign_cc//tools/build_defs/native_tools:preinstalled_cmake",
+    toolchain_type = "@rules_foreign_cc//tools/build_defs:cmake_toolchain",
+)
+
+# Preinstalled ninja will always be the default, if toolchain with more exact constraints
+# is not defined before; registered from workspace_definitions.bzl#rules_foreign_cc_dependencies
+toolchain(
+    name = "preinstalled_ninja_toolchain",
+    toolchain = "@rules_foreign_cc//tools/build_defs/native_tools:preinstalled_ninja",
+    toolchain_type = "@rules_foreign_cc//tools/build_defs:ninja_toolchain",
 )

--- a/tools/build_defs/cmake_script.bzl
+++ b/tools/build_defs/cmake_script.bzl
@@ -1,11 +1,11 @@
 """ Contains all logic for calling CMake for building external libraries/binaries """
 
-load("@foreign_cc_platform_utils//:tools.bzl", "CMAKE_COMMAND")
 load(":cc_toolchain_util.bzl", "absolutize_path_in_str")
 
 def create_cmake_script(
         workspace_name,
         target_os,
+        cmake_path,
         tools,
         flags,
         install_prefix,
@@ -38,8 +38,10 @@ def create_cmake_script(
     else:
         params = _create_crosstool_file_text(toolchain_dict, user_cache, user_env)
 
-    build_type = params.cache.get("CMAKE_BUILD_TYPE",
-                                  "DEBUG" if is_debug_mode else "RELEASE")
+    build_type = params.cache.get(
+        "CMAKE_BUILD_TYPE",
+        "DEBUG" if is_debug_mode else "RELEASE",
+    )
     params.cache.update({
         "CMAKE_PREFIX_PATH": merged_prefix_path,
         "CMAKE_INSTALL_PREFIX": install_prefix,
@@ -50,7 +52,7 @@ def create_cmake_script(
     str_cmake_cache_entries = " ".join(["-D" + key + "=\"" + params.cache[key] + "\"" for key in params.cache])
     cmake_call = " ".join([
         set_env_vars,
-        CMAKE_COMMAND,
+        cmake_path,
         str_cmake_cache_entries,
         " ".join(options),
         "$EXT_BUILD_ROOT/" + root,

--- a/tools/build_defs/native_tools/BUILD
+++ b/tools/build_defs/native_tools/BUILD
@@ -1,0 +1,39 @@
+load(":native_tools_toolchain.bzl", "native_tool_toolchain")
+load("//for_workspace:cmake_build.bzl", "cmake_tool")
+load("//for_workspace:ninja_build.bzl", "ninja_tool")
+
+native_tool_toolchain(
+    name = "preinstalled_cmake",
+    path = "cmake",
+    visibility = ["//visibility:public"],
+)
+
+cmake_tool(
+    name = "cmake_tool",
+    cmake_srcs = "@cmake//:all",
+)
+
+native_tool_toolchain(
+    name = "built_cmake",
+    label = ":cmake_tool",
+    path = "cmake/bin/cmake",
+    visibility = ["//visibility:public"],
+)
+
+native_tool_toolchain(
+    name = "preinstalled_ninja",
+    path = "ninja",
+    visibility = ["//visibility:public"],
+)
+
+ninja_tool(
+    name = "ninja_tool",
+    ninja_srcs = "@ninja_build//:all",
+)
+
+native_tool_toolchain(
+    name = "built_ninja",
+    label = ":ninja_tool",
+    path = "ninja/ninja",
+    visibility = ["//visibility:public"],
+)

--- a/tools/build_defs/native_tools/native_tools_toolchain.bzl
+++ b/tools/build_defs/native_tools/native_tools_toolchain.bzl
@@ -1,0 +1,37 @@
+ToolInfo = provider(
+    doc = "Information about the native tool",
+    fields = {
+        "path": """Absolute path to the tool in case the tool is preinstalled on the machine.
+Relative path to the tool in case the tool is built as part of a build; the path should be relative
+to the bazel-genfiles, i.e. it should start with the name of the top directory of the built tree
+artifact. (Please see the example "//examples:built_cmake_toolchain")""",
+        "label": """If the tool is preinstalled, must be None.
+If the tool is built as part of the build, the corresponding build target, which should produce
+the tree artifact with the binary to call.""",
+    },
+)
+
+def _native_tool_toolchain(ctx):
+    if not ctx.attr.path and not ctx.attr.label:
+        fail("Either path or label (and path) should be defined for the tool.")
+    return platform_common.ToolchainInfo(data = ToolInfo(
+        path = ctx.attr.path,
+        label = ctx.attr.label,
+    ))
+
+native_tool_toolchain = rule(
+    implementation = _native_tool_toolchain,
+    attrs = {
+        "path": attr.string(mandatory = False),
+        "label": attr.label(mandatory = False),
+    },
+)
+
+def access_tool(toolchain_type_, ctx, tool_name):
+    tool_toolchain = ctx.toolchains[toolchain_type_]
+    if tool_toolchain:
+        return tool_toolchain.data
+    return ToolInfo(
+        path = tool_name,
+        label = None,
+    )

--- a/tools/build_defs/native_tools/tool_access.bzl
+++ b/tools/build_defs/native_tools/tool_access.bzl
@@ -1,0 +1,21 @@
+load(":native_tools_toolchain.bzl", "ToolInfo", "access_tool")
+
+def get_cmake_data(ctx):
+    return _access_and_expect_label_copied("@rules_foreign_cc//tools/build_defs:cmake_toolchain", ctx, "cmake")
+
+def get_ninja_data(ctx):
+    return _access_and_expect_label_copied("@rules_foreign_cc//tools/build_defs:ninja_toolchain", ctx, "ninja")
+
+def _access_and_expect_label_copied(toolchain_type_, ctx, tool_name):
+    tool_data = access_tool(toolchain_type_, ctx, tool_name)
+    if tool_data.label:
+        return struct(
+            deps = [tool_data.label],
+            # as the tool will be copied into tools directory
+            path = "$EXT_BUILD_DEPS/bin/{}".format(tool_data.path),
+        )
+    else:
+        return struct(
+            deps = [],
+            path = tool_data.path,
+        )

--- a/workspace_definitions.bzl
+++ b/workspace_definitions.bzl
@@ -15,7 +15,7 @@ def _platform_dependent_init_impl(rctx):
         [
             _create_os_description(rctx, os_name),
             _shell_utils_text(rctx, host_os),
-            _build_tools(rctx, host_os),
+            _build_tools(rctx),
             _build_mode(rctx),
         ],
     ))
@@ -65,80 +65,50 @@ sh_library(
 )
 """.format(utils_name)
 
-def _build_ninja(existing, rctx, host_os):
-    return existing == None
+def _build_tools(rctx):
+    rctx.file(
+        "tools.bzl",
+        """NINJA_USE_BUILT=False
+NINJA_COMMAND="ninja"
+NINJA_DEP=[]
+CMAKE_USE_BUILT=False
+CMAKE_COMMAND="cmake"
+CMAKE_DEP=[]
 
-def _build_cmake(existing, rctx, host_os):
-    is_ci = rctx.os.environ.get("CI")
-    return existing == None and is_ci != None
-
-_tools = {
-    "cmake": struct(
-        bin_path = "bin/cmake",
-        file = "cmake_build.bzl",
-        should_be_built = _build_cmake,
-        build_script = """
-load("//:cmake_build.bzl", "cmake_tool")
-cmake_tool(
-  name = "{name}_externally_built",
-  cmake_srcs = "@cmake//:all"
-)
+print("Please remove usage of @foreign_cc_platform_utils//:tools.bzl, as it is no longer needed.")
+print("To specify the custom cmake and/or ninja tool, use the toolchains registration with \
+rules_foreign_cc_dependencies() parameters.")
 """,
-    ),
-    "ninja": struct(
-        bin_path = "ninja",
-        file = "ninja_build.bzl",
-        should_be_built = _build_ninja,
-        build_script = """
-load("//:ninja_build.bzl", "ninja_tool")
-
-ninja_tool(
-    name = "{name}_externally_built",
-    ninja_srcs = "@ninja_build//:all",
-)
-""",
-    ),
-}
-
-def _build_tools(rctx, host_os):
-    build_text = []
-    tools_text = []
-    deps = []
-
-    for tool in _tools:
-        existing = rctx.which(tool)
-        descriptor = _tools[tool]
-
-        # define the rule for building the tool in any case
-        definition_path = rctx.path(Label("//for_workspace:" + descriptor.file))
-        rctx.template(descriptor.file, definition_path)
-        build_text += ["""
-sh_library(
- name = "{tool_name}",
- srcs = [":{tool_name}_externally_built"],
- visibility = ["//visibility:public"]
-)
-""".format(tool_name = tool) + descriptor.build_script.format(name = tool)]
-
-        value = tool
-        to_build_tool = descriptor.should_be_built(existing, rctx, host_os)
-        tool_deps = "[]"
-        if to_build_tool:
-            value = "$EXT_BUILD_DEPS/bin/{}/{}".format(tool, descriptor.bin_path)
-            tool_deps = "[\"@foreign_cc_platform_utils//:{}\"]".format(tool)
-        tools_text += ["{}_USE_BUILT={}".format(tool.upper(), to_build_tool)]
-        tools_text += ["{}_COMMAND=\"{}\"".format(tool.upper(), value)]
-        tools_text += ["{}_DEP={}".format(tool.upper(), tool_deps)]
-
-    rctx.file("tools.bzl", "\n".join(tools_text))
-    return "\n".join(build_text)
+    )
 
 _platform_dependent_init = repository_rule(
     implementation = _platform_dependent_init_impl,
     environ = ["PATH"],
 )
 
-def rules_foreign_cc_dependencies():
+def rules_foreign_cc_dependencies(native_tools_toolchains = [], register_default_tools = True):
+    """ Call this function from the WORKSPACE file to initialize rules_foreign_cc
+     dependencies and let neccesary code generation happen
+     (Code generation is needed to support different variants of the C++ Starlark API.).
+
+     Args:
+        native_tools_toolchains: pass the toolchains for toolchain types
+        '@rules_foreign_cc//tools/build_defs:cmake_toolchain' and
+        '@rules_foreign_cc//tools/build_defs:ninja_toolchain' with the needed platform constraints.
+        If you do not pass anything, registered default toolchains will be selected (see below).
+
+        register_default_tools: if True, the cmake and ninja toolchains, calling corresponding
+        preinstalled binaries by name (cmake, ninja) will be registered after
+        'native_tools_toolchains' without any platform constraints.
+        The default is True.
+    """
     repositories()
     _platform_dependent_init(name = "foreign_cc_platform_utils")
     generate_implementation_fragments(name = "foreign_cc_impl")
+
+    native.register_toolchains(*native_tools_toolchains)
+    if register_default_tools:
+        native.register_toolchains(
+            "@rules_foreign_cc//tools/build_defs:preinstalled_cmake_toolchain",
+            "@rules_foreign_cc//tools/build_defs:preinstalled_ninja_toolchain",
+        )


### PR DESCRIPTION
In the workspace-level rule registration function, default toolchain
implementations are registered for all platforms, which are calling
the cmake and ninja just by name, assuming they are preinstalled.

Also, the user can pass the custom toolchains in the initialization
function, they will be registered before the defaults.

Include relevant updated into README.