### PR TITLE
Correction for what tests to run on CI on Windows with Bazel 0.22.0

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -1,3 +1,6 @@
+load("@foreign_cc_platform_utils//:bazel_version.bzl", "BAZEL_VERSION")
+load(":select_windows_tests.bzl", "select_windows_tests")
+
 tests = [
     "//cmake:test_libgd",
     "//cmake:test_libpng",
@@ -39,15 +42,33 @@ test_suite(
     tests = tests + ["//configure_gnuplot:configure_libgd_tests"],
 )
 
+# As Bazel 0.22.0 is broken for rules_foreign_cc on Windows, we do not want to run any tests
+# with this version on CI
+# So we are selecting the list of tests to run according to recorded-in-workspace
+# Bazel version.
+# But list of tests can not be empty! Instead, have a test that just prints the Bazel version.
+windows_tests = select_windows_tests(
+    BAZEL_VERSION,
+    tests + [
+        #        "//cmake_synthetic:test_libs",
+        #        "//configure_gnuplot:configure_libgd_tests",
+        "//cmake_hello_world_lib/static:test_hello_ninja",
+        #        "//cmake_hello_world_lib/static:test_hello_nmake",
+    ],
+    [":bazel_version"],
+)
+
 test_suite(
     name = "win_tests",
     tags = ["windows"],
-    tests = tests + [
-#        "//cmake_synthetic:test_libs",
-#        "//configure_gnuplot:configure_libgd_tests",
-        "//cmake_hello_world_lib/static:test_hello_ninja",
-#        "//cmake_hello_world_lib/static:test_hello_nmake",
-    ],
+    tests = windows_tests,
+)
+
+sh_test(
+    name = "bazel_version",
+    srcs = ["print_bazel_version.sh"],
+    args = [BAZEL_VERSION],
+    tags = ["windows"],
 )
 
 # On Bazel CI Mac machines, we are using cmake built from sources

--- a/examples/print_bazel_version.sh
+++ b/examples/print_bazel_version.sh
@@ -1,0 +1,1 @@
+echo "Bazel version: $1"

--- a/examples/select_windows_tests.bzl
+++ b/examples/select_windows_tests.bzl
@@ -1,0 +1,4 @@
+def select_windows_tests(version_, long_, short_):
+    if (version_ == "0.22.0"):
+        return short_
+    return long_

--- a/workspace_definitions.bzl
+++ b/workspace_definitions.bzl
@@ -13,6 +13,7 @@ def _read_build_options_impl(rctx):
             _build_mode(rctx),
         ],
     ))
+    rctx.file("bazel_version.bzl", "BAZEL_VERSION=\"{}\"".format(native.bazel_version))
 
 def _build_mode(rctx):
     path = rctx.path(Label("//for_workspace:compilation_mode.bzl"))


### PR DESCRIPTION
As Bazel 0.22.0 is broken for rules_foreign_cc on Windows, we do not want to run any tests with this version on CI. So we are selecting the list of tests to run according to recorded-in-workspace Bazel version.
But list of tests can not be empty! Instead, have a test that just prints the Bazel version.