### PR TITLE
For configure_make, allow to run configure in place

### DIFF
--- a/tools/build_defs/configure.bzl
+++ b/tools/build_defs/configure.bzl
@@ -53,6 +53,7 @@ def _create_configure_script(configureParameters):
         ctx.attr.configure_command,
         ctx.attr.deps,
         inputs,
+        ctx.attr.configure_in_place,
     )
     return "\n".join([define_install_prefix, configure])
 
@@ -72,14 +73,32 @@ def _get_install_prefix(ctx):
 def _attrs():
     attrs = dict(CC_EXTERNAL_RULE_ATTRIBUTES)
     attrs.update({
-        # default: configure
+        # The name of the configuration script file, default: configure.
+        # The file must be in the root of the source directory.
         "configure_command": attr.string(default = "configure"),
+        # Any options to be put on the 'configure' command line.
         "configure_options": attr.string_list(),
+        # Environment variables to be set for the 'configure' invocation.
         "configure_env_vars": attr.string_dict(),
+        # Install prefix, i.e. relative path to where to install the result of the build.
+        # Passed to the 'configure' script with --prefix flag.
         "install_prefix": attr.string(mandatory = False),
+        # Set to True if 'configure' should be invoked in place, i.e. from its enclosing
+        # directory.
+        "configure_in_place": attr.bool(mandatory = False, default = False),
     })
     return attrs
 
+""" Rule for building external libraries with configure-make pattern.
+ Some 'configure' script is invoked with --prefix=install (by default),
+ and other parameters for compilation and linking, taken from Bazel C/C++
+ toolchain and passed dependencies.
+ After configuration, GNU Make is called.
+
+ Attributes:
+   See line comments in _attrs() method.
+ Other attributes are documented in framework.bzl:CC_EXTERNAL_RULE_ATTRIBUTES
+"""
 configure_make = rule(
     attrs = _attrs(),
     fragments = ["cpp"],

--- a/tools/build_defs/configure_script.bzl
+++ b/tools/build_defs/configure_script.bzl
@@ -12,7 +12,8 @@ def create_configure_script(
         is_debug,
         configure_command,
         deps,
-        inputs):
+        inputs,
+        configure_in_place):
     vars = _get_configure_variables(tools, flags, user_vars)
     deps_flags = _define_deps_flags(deps, inputs)
 
@@ -28,10 +29,17 @@ def create_configure_script(
 
     script += ["echo \"PKG_CONFIG_PATH=$$PKG_CONFIG_PATH$$\""]
 
-    script += ["{env_vars} \"$$EXT_BUILD_ROOT$$/{root}/{configure}\" --prefix=$$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$ {user_options}".format(
-        env_vars = env_vars_string,
+    configure_path = "$$EXT_BUILD_ROOT$$/{root}/{configure}".format(
         root = root,
         configure = configure_command,
+    )
+    if (configure_in_place):
+        script += ["##symlink_contents_to_dir## $$EXT_BUILD_ROOT$$/{} $$BUILD_TMPDIR$$".format(root)]
+        configure_path = "$$BUILD_TMPDIR$$/{}".format(configure_command)
+
+    script += ["{env_vars} \"{configure}\" --prefix=$$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$ {user_options}".format(
+        env_vars = env_vars_string,
+        configure = configure_path,
         user_options = " ".join(user_options),
     )]
     return "\n".join(script)


### PR DESCRIPTION
Some configure scripts rely on being called from their parent directory (they call other files as if they are in the same directory). For this case, we should copy/symlink the contents of the directory under our build root, and run configure from there.

New attribute in configure_make rule: "configure_in_place".

Also, add documentation for configure_make.