### PR TITLE
cmake_external: allow user to suppress computed cache entries

### DIFF
--- a/test/cmake_text_tests.bzl
+++ b/test/cmake_text_tests.bzl
@@ -224,10 +224,12 @@ def _merge_flag_values_no_toolchain_file_test(ctx):
     user_env = {}
     user_cache = {
         "CMAKE_CXX_FLAGS": "-Fbat",
+        # test that the computed value is not used
+        "CMAKE_BUILD_TYPE": "",
     }
 
     script = create_cmake_script("ws", "linux", "cmake", tools, flags, "test_rule", "external/test_rule", True, user_cache, user_env, [])
-    expected = """CC=\"/usr/bin/gcc\" CXX=\"/usr/bin/gcc\" CXXFLAGS=\"foo=\\\"bar\\\" -Fbat" cmake -DCMAKE_AR=\"/usr/bin/ar\" -DCMAKE_PREFIX_PATH=\"$EXT_BUILD_DEPS\" -DCMAKE_INSTALL_PREFIX=\"test_rule\" -DCMAKE_BUILD_TYPE=\"DEBUG\"  $EXT_BUILD_ROOT/external/test_rule"""
+    expected = """CC=\"/usr/bin/gcc\" CXX=\"/usr/bin/gcc\" CXXFLAGS=\"foo=\\\"bar\\\" -Fbat" cmake -DCMAKE_AR=\"/usr/bin/ar\" -DCMAKE_PREFIX_PATH=\"$EXT_BUILD_DEPS\" -DCMAKE_INSTALL_PREFIX=\"test_rule\"  $EXT_BUILD_ROOT/external/test_rule"""
     asserts.equals(env, expected, script)
 
     unittest.end(env)

--- a/tools/build_defs/cmake_script.bzl
+++ b/tools/build_defs/cmake_script.bzl
@@ -48,6 +48,12 @@ def create_cmake_script(
         "CMAKE_BUILD_TYPE": build_type,
     })
 
+    # Give user the ability to suppress some value, taken from Bazel's toolchain,
+    # or to suppress calculated CMAKE_BUILD_TYPE
+    # If the user passes "CMAKE_BUILD_TYPE": "" (empty string),
+    # CMAKE_BUILD_TYPE will not be passed to CMake
+    wipe_empty_values(params.cache, user_cache)
+
     set_env_vars = " ".join([key + "=\"" + params.env[key] + "\"" for key in params.env])
     str_cmake_cache_entries = " ".join(["-D" + key + "=\"" + params.cache[key] + "\"" for key in params.cache])
     cmake_call = " ".join([
@@ -59,6 +65,11 @@ def create_cmake_script(
     ])
 
     return "\n".join(params.commands + [cmake_call])
+
+def wipe_empty_values(cache, user_cache):
+    for key in user_cache:
+        if len(user_cache.get(key)) == 0:
+            cache.pop(key)
 
 # From CMake documentation: ;-list of directories specifying installation prefixes to be searched...
 def _merge_prefix_path(user_cache):


### PR DESCRIPTION
If the user passes empty string for some cache entry, for instance,
CMAKE_BUILD_TYPE, then the corresponding computed value
(computed from the Bazel's build type or Bazel C/C++ toolchain)
should not be used.
I.e., user passes "CMAKE_BUILD_TYPE": "", and there will be no
-DCMAKE_BUILD_TYPE in the cmake call.