### PR TITLE
Pass --copt, --cxxopt, --conlyopt, --linkopt to cmake_external/config…

### DIFF
--- a/.bazelci/config.yaml
+++ b/.bazelci/config.yaml
@@ -20,3 +20,23 @@ tasks:
     working_directory: examples
     test_targets:
       - "//:win_tests"
+  ubuntu1804_flags:
+    platform: ubuntu1804
+    working_directory: test/standard_cxx_flags_test
+    test_targets:
+      - "//:flags_test"
+  ubuntu1604_flags:
+    platform: ubuntu1604
+    working_directory: test/standard_cxx_flags_test
+    test_targets:
+      - "//:flags_test"
+  macos_flags:
+    platform: macos
+    working_directory: test/standard_cxx_flags_test
+    test_targets:
+      - "//:flags_test"
+  windows_flags:
+    platform: windows
+    working_directory: test/standard_cxx_flags_test
+    test_targets:
+      - "//:flags_test"

--- a/.bazelignore
+++ b/.bazelignore
@@ -1,2 +1,3 @@
 examples
 toolchains_examples
+test/standard_cxx_flags_test

--- a/test/standard_cxx_flags_test/.bazelrc
+++ b/test/standard_cxx_flags_test/.bazelrc
@@ -1,0 +1,1 @@
+build --copt="-fblah0" --cxxopt="-fblah1" --conlyopt="-fblah2" --linkopt="-fblah3"

--- a/test/standard_cxx_flags_test/BUILD
+++ b/test/standard_cxx_flags_test/BUILD
@@ -1,0 +1,3 @@
+load(":tests.bzl", "flags_test")
+
+flags_test(name = "flags_test")

--- a/test/standard_cxx_flags_test/WORKSPACE
+++ b/test/standard_cxx_flags_test/WORKSPACE
@@ -1,0 +1,10 @@
+workspace(name = "standard_cxx_flags_test")
+
+local_repository(
+    name = "rules_foreign_cc",
+    path = "../.."
+)
+
+load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
+
+rules_foreign_cc_dependencies()

--- a/test/standard_cxx_flags_test/tests.bzl
+++ b/test/standard_cxx_flags_test/tests.bzl
@@ -1,0 +1,44 @@
+""" TODO """
+
+load("@rules_foreign_cc//tools/build_defs:cc_toolchain_util.bzl", "CxxFlagsInfo", "get_flags_info")
+
+def _impl(ctx):
+    flags = get_flags_info(ctx)
+
+    assert_contains_once(flags.assemble, "-fblah0")
+    assert_contains_once(flags.assemble, "-fblah2")
+
+    assert_contains_once(flags.cc, "-fblah0")
+    assert_contains_once(flags.cc, "-fblah2")
+
+    assert_contains_once(flags.cxx, "-fblah0")
+    assert_contains_once(flags.cxx, "-fblah1")
+
+    assert_contains_once(flags.cxx_linker_executable, "-fblah3")
+    assert_contains_once(flags.cxx_linker_shared, "-fblah3")
+    assert_contains_once(flags.cxx_linker_static, "-fblah3")
+
+# to satisfy test rule requirement to be executable
+    ctx.actions.write(
+        output = ctx.outputs.executable,
+        content = "",
+    )
+
+def assert_contains_once(arr, value):
+    cnt = 0
+    for elem in arr:
+        if elem == value:
+            cnt = cnt + 1
+    if cnt == 0:
+        fail("Did not find " + value)
+    if cnt > 1:
+        fail("Value is included multiple times: " + value)
+
+flags_test = rule(
+    implementation = _impl,
+    attrs = {
+        "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
+    },
+    fragments = ["cpp"],
+    test = True,
+)


### PR DESCRIPTION
…ure_make rules

- explicitly pass the values of these options to corresponding compilation/link flags lists; add them to the end of the lists of they are not already there
- please see the test in test/standard_cxx_flags_test