### PR TITLE
Windows, tests: fix for native test wrapper

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,11 +6,9 @@ rules_foreign_cc_dependencies([
     "@rules_foreign_cc_tests//:built_cmake_toolchain",
     "@rules_foreign_cc_tests//:built_ninja_toolchain_osx",
     "@rules_foreign_cc_tests//:built_ninja_toolchain_linux",
+    "@bazel_skylib//toolchains/unittest:cmd_toolchain",
+    "@bazel_skylib//toolchains/unittest:bash_toolchain",
 ])
-
-load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
-
-bazel_skylib_workspace()
 
 local_repository(
     name = "rules_foreign_cc_tests",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,6 +8,10 @@ rules_foreign_cc_dependencies([
     "@rules_foreign_cc_tests//:built_ninja_toolchain_linux",
 ])
 
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
 local_repository(
     name = "rules_foreign_cc_tests",
     path = "examples",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,8 +6,6 @@ rules_foreign_cc_dependencies([
     "@rules_foreign_cc_tests//:built_cmake_toolchain",
     "@rules_foreign_cc_tests//:built_ninja_toolchain_osx",
     "@rules_foreign_cc_tests//:built_ninja_toolchain_linux",
-    "@bazel_skylib//toolchains/unittest:cmd_toolchain",
-    "@bazel_skylib//toolchains/unittest:bash_toolchain",
 ])
 
 local_repository(

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -17,11 +17,6 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 
-native.register_toolchains(
-    "@bazel_skylib//toolchains/unittest:cmd_toolchain",
-    "@bazel_skylib//toolchains/unittest:bash_toolchain",
-)
-
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 android_sdk_repository(

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -13,6 +13,15 @@ rules_foreign_cc_dependencies([
     "//:built_ninja_toolchain_linux",
 ])
 
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
+native.register_toolchains(
+    "@bazel_skylib//toolchains/unittest:cmd_toolchain",
+    "@bazel_skylib//toolchains/unittest:bash_toolchain",
+)
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 android_sdk_repository(

--- a/examples/cmake_crosstool/WORKSPACE
+++ b/examples/cmake_crosstool/WORKSPACE
@@ -16,6 +16,10 @@ load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependen
 
 rules_foreign_cc_dependencies()
 
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
 local_repository(
     name = "cmake_hello_world_lib",
     path = "../cmake_hello_world_lib/static",

--- a/examples/with_prebuilt_ninja_artefact/WORKSPACE
+++ b/examples/with_prebuilt_ninja_artefact/WORKSPACE
@@ -13,6 +13,10 @@ rules_foreign_cc_dependencies([
     "@prebuilt_ninja_artefact_example//:prebuilt_ninja_artefact_toolchain",
 ])
 
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
 http_archive(
     name = "ninja_artefact",
     build_file_content = """filegroup(name = "all", srcs = glob(["**"]), visibility = ["//visibility:public"])""",

--- a/for_workspace/repositories.bzl
+++ b/for_workspace/repositories.bzl
@@ -7,13 +7,9 @@ def repositories():
 
     http_archive(
         name = "bazel_skylib",
-        build_file_content = _all_content,
-        sha256 = "eb5c57e4c12e68c0c20bc774bfbc60a568e800d025557bc4ea022c6479acc867",
-        strip_prefix = "bazel-skylib-0.6.0",
         type = "tar.gz",
-        urls = [
-            "https://github.com/bazelbuild/bazel-skylib/archive/0.6.0.tar.gz",
-        ],
+        url = "https://github.com/bazelbuild/bazel-skylib/releases/download/0.8.0/bazel-skylib.0.8.0.tar.gz",
+        sha256 = "2ef429f5d7ce7111263289644d233707dba35e39696377ebab8b0bc701f7818e",
     )
 
     http_archive(

--- a/test/cmake_text_tests.bzl
+++ b/test/cmake_text_tests.bzl
@@ -20,7 +20,7 @@ def _absolutize_test(ctx):
         res = export_for_test.absolutize("ws", case)
         asserts.equals(env, cases[case], res)
 
-    unittest.end(env)
+    return unittest.end(env)
 
 def _tail_extraction_test(ctx):
     env = unittest.begin(ctx)
@@ -34,7 +34,7 @@ def _tail_extraction_test(ctx):
     res = export_for_test.tail_if_starts_with("--option=value", "--option")
     asserts.equals(env, "=value", res)
 
-    unittest.end(env)
+    return unittest.end(env)
 
 def _find_flag_value_test(ctx):
     env = unittest.begin(ctx)
@@ -65,7 +65,7 @@ def _find_flag_value_test(ctx):
         res = export_for_test.find_flag_value(case, "gcc_toolchain")
         asserts.false(env, "/abc/def" == res, msg = "Equals: " + str(case))
 
-    unittest.end(env)
+    return unittest.end(env)
 
 def _fill_crossfile_from_toolchain_test(ctx):
     env = unittest.begin(ctx)
@@ -108,7 +108,7 @@ def _fill_crossfile_from_toolchain_test(ctx):
     for key in expected:
         asserts.equals(env, expected[key], res[key])
 
-    unittest.end(env)
+    return unittest.end(env)
 
 def _move_dict_values_test(ctx):
     env = unittest.begin(ctx)
@@ -149,7 +149,7 @@ def _move_dict_values_test(ctx):
     asserts.equals(env, 1, len(source_env))
     asserts.equals(env, 1, len(source_cache))
 
-    unittest.end(env)
+    return unittest.end(env)
 
 def _reverse_descriptor_dict_test(ctx):
     env = unittest.begin(ctx)
@@ -170,7 +170,7 @@ def _reverse_descriptor_dict_test(ctx):
     for key in expected:
         asserts.equals(env, expected[key], res[key])
 
-    unittest.end(env)
+    return unittest.end(env)
 
 def _merge_toolchain_and_user_values_test(ctx):
     env = unittest.begin(ctx)
@@ -202,7 +202,7 @@ def _merge_toolchain_and_user_values_test(ctx):
     for key in expected_target:
         asserts.equals(env, expected_target[key], res[key])
 
-    unittest.end(env)
+    return unittest.end(env)
 
 def _merge_flag_values_no_toolchain_file_test(ctx):
     env = unittest.begin(ctx)
@@ -232,7 +232,7 @@ def _merge_flag_values_no_toolchain_file_test(ctx):
     expected = """CC=\"/usr/bin/gcc\" CXX=\"/usr/bin/gcc\" CXXFLAGS=\"foo=\\\"bar\\\" -Fbat" cmake -DCMAKE_AR=\"/usr/bin/ar\" -DCMAKE_PREFIX_PATH=\"$EXT_BUILD_DEPS\" -DCMAKE_INSTALL_PREFIX=\"test_rule\"  $EXT_BUILD_ROOT/external/test_rule"""
     asserts.equals(env, expected, script)
 
-    unittest.end(env)
+    return unittest.end(env)
 
 def _create_min_cmake_script_no_toolchain_file_test(ctx):
     env = unittest.begin(ctx)
@@ -261,7 +261,7 @@ def _create_min_cmake_script_no_toolchain_file_test(ctx):
     expected = "CC=\"/usr/bin/gcc\" CXX=\"/usr/bin/gcc\" CFLAGS=\"-U_FORTIFY_SOURCE -fstack-protector -Wall\" CXXFLAGS=\"-U_FORTIFY_SOURCE -fstack-protector -Wall\" ASMFLAGS=\"-U_FORTIFY_SOURCE -fstack-protector -Wall\" cmake -DCMAKE_AR=\"/usr/bin/ar\" -DCMAKE_SHARED_LINKER_FLAGS=\"-shared -fuse-ld=gold\" -DCMAKE_EXE_LINKER_FLAGS=\"-fuse-ld=gold -Wl -no-as-needed\" -DNOFORTRAN=\"on\" -DCMAKE_PREFIX_PATH=\"$EXT_BUILD_DEPS;/abc/def\" -DCMAKE_INSTALL_PREFIX=\"test_rule\" -DCMAKE_BUILD_TYPE=\"DEBUG\" -GNinja $EXT_BUILD_ROOT/external/test_rule"
     asserts.equals(env, expected, script)
 
-    unittest.end(env)
+    return unittest.end(env)
 
 def _create_min_cmake_script_toolchain_file_test(ctx):
     env = unittest.begin(ctx)
@@ -301,7 +301,7 @@ EOF
  cmake -DNOFORTRAN="on" -DCMAKE_TOOLCHAIN_FILE="crosstool_bazel.cmake" -DCMAKE_PREFIX_PATH="$EXT_BUILD_DEPS" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_BUILD_TYPE=\"DEBUG\" -GNinja $EXT_BUILD_ROOT/external/test_rule"""
     asserts.equals(env, expected.splitlines(), script.splitlines())
 
-    unittest.end(env)
+    return unittest.end(env)
 
 def _create_cmake_script_no_toolchain_file_test(ctx):
     env = unittest.begin(ctx)
@@ -338,7 +338,7 @@ def _create_cmake_script_no_toolchain_file_test(ctx):
     expected = "CC=\"sink-cc-value\" CXX=\"sink-cxx-value\" CFLAGS=\"-cc-flag -gcc_toolchain cc-toolchain --from-env --additional-flag\" CXXFLAGS=\"--quoted=\\\"abc def\\\" --sysroot=/abc/sysroot --gcc_toolchain cxx-toolchain\" ASMFLAGS=\"assemble assemble-user\" CUSTOM_ENV=\"YES\" cmake -DCMAKE_AR=\"/cxx_linker_static\" -DCMAKE_CXX_LINK_EXECUTABLE=\"became\" -DCMAKE_SHARED_LINKER_FLAGS=\"shared1 shared2\" -DCMAKE_EXE_LINKER_FLAGS=\"executable\" -DCUSTOM_CACHE=\"YES\" -DCMAKE_BUILD_TYPE=\"user_type\" -DCMAKE_PREFIX_PATH=\"$EXT_BUILD_DEPS\" -DCMAKE_INSTALL_PREFIX=\"test_rule\" -GNinja $EXT_BUILD_ROOT/external/test_rule"
     asserts.equals(env, expected, script)
 
-    unittest.end(env)
+    return unittest.end(env)
 
 def _create_cmake_script_toolchain_file_test(ctx):
     env = unittest.begin(ctx)
@@ -390,7 +390,7 @@ EOF
 CUSTOM_ENV="YES" cmake -DCUSTOM_CACHE="YES" -DCMAKE_TOOLCHAIN_FILE="crosstool_bazel.cmake" -DCMAKE_PREFIX_PATH="$EXT_BUILD_DEPS" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_BUILD_TYPE=\"DEBUG\" -GNinja $EXT_BUILD_ROOT/external/test_rule"""
     asserts.equals(env, expected.splitlines(), script.splitlines())
 
-    unittest.end(env)
+    return unittest.end(env)
 
 absolutize_test = unittest.make(_absolutize_test)
 tail_extraction_test = unittest.make(_tail_extraction_test)

--- a/test/convert_shell_script_test.bzl
+++ b/test/convert_shell_script_test.bzl
@@ -40,7 +40,7 @@ def _replace_vars_test(ctx):
         result = replace_var_ref(case, shell_context)
         asserts.equals(env, cases[case], result)
 
-    unittest.end(env)
+    return unittest.end(env)
 
 def _replace_vars_win_test(ctx):
     env = unittest.begin(ctx)
@@ -65,7 +65,7 @@ def _replace_vars_win_test(ctx):
         result = replace_var_ref(case, shell_context)
         asserts.equals(env, cases[case], result)
 
-    unittest.end(env)
+    return unittest.end(env)
 
 def _funny_fun(a, b):
     return a + "_" + b
@@ -86,7 +86,7 @@ def _split_arguments_test(ctx):
         result = split_arguments(case)
         asserts.equals(env, cases[case], result)
 
-    unittest.end(env)
+    return unittest.end(env)
 
 def _export_var(name, value):
     return "export1 {}={}".format(
@@ -127,7 +127,7 @@ def _do_function_call_test(ctx):
         result = do_function_call(case, shell_context)
         asserts.equals(env, cases[case], result)
 
-    unittest.end(env)
+    return unittest.end(env)
 
 def _touch(path):
     text = "call_touch $1"
@@ -187,7 +187,7 @@ fi
         asserts.equals(env, cases[case]["call"], result)
         asserts.equals(env, cases[case]["text"], shell_context.prelude.values()[0])
 
-    unittest.end(env)
+    return unittest.end(env)
 
 def _symlink_contents_to_dir(source, target):
     text = """local target="$2"
@@ -266,7 +266,7 @@ symlink_contents_to_dir a b"""
     result = convert_shell_script_by_context(shell_context, script)
     asserts.equals(env, expected, result)
 
-    unittest.end(env)
+    return unittest.end(env)
 
 replace_vars_test = unittest.make(_replace_vars_test)
 replace_vars_win_test = unittest.make(_replace_vars_win_test)

--- a/workspace_definitions.bzl
+++ b/workspace_definitions.bzl
@@ -103,8 +103,3 @@ def rules_foreign_cc_dependencies(
             "@rules_foreign_cc//tools/build_defs:preinstalled_cmake_toolchain",
             "@rules_foreign_cc//tools/build_defs:preinstalled_ninja_toolchain",
         )
-
-    native.register_toolchains(
-        "@bazel_skylib//toolchains/unittest:cmd_toolchain",
-        "@bazel_skylib//toolchains/unittest:bash_toolchain",
-    )

--- a/workspace_definitions.bzl
+++ b/workspace_definitions.bzl
@@ -61,7 +61,8 @@ def rules_foreign_cc_dependencies(
         native_tools_toolchains = [],
         register_default_tools = True,
         additonal_shell_toolchain_mappings = [],
-        additonal_shell_toolchain_package = None):
+        additonal_shell_toolchain_package = None,
+        ):
     """ Call this function from the WORKSPACE file to initialize rules_foreign_cc
      dependencies and let neccesary code generation happen
      (Code generation is needed to support different variants of the C++ Starlark API.).
@@ -102,3 +103,8 @@ def rules_foreign_cc_dependencies(
             "@rules_foreign_cc//tools/build_defs:preinstalled_cmake_toolchain",
             "@rules_foreign_cc//tools/build_defs:preinstalled_ninja_toolchain",
         )
+
+    native.register_toolchains(
+        "@bazel_skylib//toolchains/unittest:cmd_toolchain",
+        "@bazel_skylib//toolchains/unittest:bash_toolchain",
+    )


### PR DESCRIPTION
In this PR:

- Update `@bazel_skylib` to 0.8.0, which has a
  Windows-compatible unittest.bzl

- Fix unittest-using tests. Correct usage of
  `unittest.end(env)` is to return its value.

Result: //test:all now passes with Bazel 0.25.0rc3
and --incompatible_windows_native_test_wrapper