### PR TITLE
Add working example for #241

### DIFF
--- a/examples/apache_httpd/BUILD
+++ b/examples/apache_httpd/BUILD
@@ -1,0 +1,94 @@
+load("@rules_foreign_cc//tools/build_defs:configure.bzl", "configure_make")
+
+configure_make(
+    name = "apr",
+    lib_source = "@apr//:all",
+    static_libraries = ["libapr-1.a"],
+    shared_libraries = ["libapr-1.so"],
+)
+
+configure_make(
+    name = "apr_util",
+    lib_source = "@apr_util//:all",
+    deps = [":apr"],
+    configure_options = [
+        "--with-apr=$EXT_BUILD_DEPS/apr",
+        ],
+    static_libraries = ["libaprutil-1.a"],
+    shared_libraries = ["libaprutil-1.so"],
+)
+
+configure_make(
+    name = "pcre",
+    lib_source = "@pcre//:all",
+    static_libraries = ["libpcre.a"],
+    shared_libraries = ["libpcre.so.1"],
+)
+
+configure_make(
+    name = "apache_httpd",
+    configure_options = [
+        "--with-apr=$EXT_BUILD_DEPS/apr",
+        "--with-apr-util=$EXT_BUILD_DEPS/apr_util",
+        "--with-pcre=$EXT_BUILD_DEPS/pcre",
+        "CFLAGS='-Dredacted=\"redacted\"'",
+    ],
+    lib_source = "@apache_httpd//:all",
+    binaries = [
+        "httpd",
+    ],
+    deps = [
+        ":apr",
+        ":apr_util",
+        ":pcre",
+    ],
+    visibility = [
+        "//visibility:public"
+        ],
+)
+
+filegroup(
+    name = "httpd_dir",
+    srcs = [
+        ":apache_httpd",
+    ],
+    output_group = "gen_dir"
+)
+
+filegroup(
+    name = "pcre_dir",
+    srcs = [
+        ":pcre",
+    ],
+    output_group = "gen_dir"
+)
+
+filegroup(
+    name = "apr_dir",
+    srcs = [
+        ":apr",
+    ],
+    output_group = "gen_dir"
+)
+
+filegroup(
+    name = "apr_util_dir",
+    srcs = [
+        ":apr_util",
+    ],
+    output_group = "gen_dir"
+)
+
+sh_test(
+    name = "test",
+    srcs = [
+        "t.sh",
+    ],
+    args = ["$(location httpd_dir)/bin/httpd $(location pcre_dir)/lib $(location apr_dir)/lib $(location apr_util_dir)/lib"],
+    data = [
+        ":httpd_dir",
+        ":apr_dir",
+        ":apr_util_dir",
+        ":pcre_dir",
+    ],
+)

--- a/examples/apache_httpd/t.sh
+++ b/examples/apache_httpd/t.sh
@@ -1,0 +1,4 @@
+CUR_DIR=$(pwd)
+export LD_LIBRARY_PATH=$CUR_DIR/$2:$CUR_DIR/$3:$CUR_DIR/$4
+
+$1

--- a/examples/examples_repositories.bzl
+++ b/examples/examples_repositories.bzl
@@ -121,3 +121,31 @@ def include_examples_repositories():
         strip_prefix = "bison-3.3",
         urls = ["http://ftp.gnu.org/gnu/bison/bison-3.3.tar.gz"],
     )
+
+    http_archive(
+        name = "apache_httpd",
+        build_file_content = all_content,
+        strip_prefix = "httpd-2.4.39",
+        urls = ["https://www-us.apache.org/dist/httpd/httpd-2.4.39.tar.gz"],
+    )
+
+    http_archive(
+        name = "pcre",
+        build_file_content = all_content,
+        strip_prefix = "pcre-8.43",
+        urls = ["https://ftp.pcre.org/pub/pcre/pcre-8.43.tar.gz"],
+    )
+
+    http_archive(
+        name = "apr",
+        build_file_content = all_content,
+        strip_prefix = "apr-1.6.5",
+        urls = ["https://www-eu.apache.org/dist//apr/apr-1.6.5.tar.gz"],
+    )
+
+    http_archive(
+        name = "apr_util",
+        build_file_content = all_content,
+        strip_prefix = "apr-util-1.6.1",
+        urls = ["https://www-us.apache.org/dist//apr/apr-util-1.6.1.tar.gz"],
+    )


### PR DESCRIPTION
An example of building Apache Httpd and run it in a script.
Demonstrates usage of LD_LIBRARY_PATH for binding shared libraries.

As I was not able to make the created httpd executable to absorb what I was passing to the configuration script with "-Wl,-rpath -Wl,<libdir>" 
- I tried passing $ORIGIN to <libdir>, or something else, but the problem is the Apache configuration script also invokes libtool and passes the current directory as RPATH, and I can not think of a nice way of avoiding this.

So passing the runtime paths to the built shared libraries in LD_LIBRARY_PATH seems a good option.
I may write a wrapper rule/function for running executables this way; this may be already a case with Bazel C/C++ platform, I will clarify this.

Related issue: #241 