### PR TITLE
For cmake_external and configure_make, do not prepend relative instal…

### DIFF
--- a/tools/build_defs/cmake.bzl
+++ b/tools/build_defs/cmake.bzl
@@ -90,10 +90,10 @@ def _get_install_prefix(ctx):
         # So if the user passed the absolute value, do not touch it.
         if (prefix.startswith("/")):
             return prefix
-        return prefix if prefix.startswith("./") else "./" + prefix
+        return prefix
     if ctx.attr.lib_name:
-        return "./" + ctx.attr.lib_name
-    return "./" + ctx.attr.name
+        return ctx.attr.lib_name
+    return ctx.attr.name
 
 def _attrs():
     attrs = dict(CC_EXTERNAL_RULE_ATTRIBUTES)

--- a/tools/build_defs/cmake.bzl
+++ b/tools/build_defs/cmake.bzl
@@ -84,13 +84,7 @@ def _create_configure_script(configureParameters):
 
 def _get_install_prefix(ctx):
     if ctx.attr.install_prefix:
-        prefix = ctx.attr.install_prefix
-
-        # If not in sandbox, or after the build, the value can be absolute.
-        # So if the user passed the absolute value, do not touch it.
-        if (prefix.startswith("/")):
-            return prefix
-        return prefix
+        return ctx.attr.install_prefix
     if ctx.attr.lib_name:
         return ctx.attr.lib_name
     return ctx.attr.name

--- a/tools/build_defs/configure.bzl
+++ b/tools/build_defs/configure.bzl
@@ -65,10 +65,10 @@ def _get_install_prefix(ctx):
         # So if the user passed the absolute value, do not touch it.
         if (prefix.startswith("/")):
             return prefix
-        return prefix if prefix.startswith("./") else "./" + prefix
+        return prefix
     if ctx.attr.lib_name:
-        return "./" + ctx.attr.lib_name
-    return "./" + ctx.attr.name
+        return ctx.attr.lib_name
+    return ctx.attr.name
 
 def _attrs():
     attrs = dict(CC_EXTERNAL_RULE_ATTRIBUTES)

--- a/tools/build_defs/configure.bzl
+++ b/tools/build_defs/configure.bzl
@@ -59,13 +59,7 @@ def _create_configure_script(configureParameters):
 
 def _get_install_prefix(ctx):
     if ctx.attr.install_prefix:
-        prefix = ctx.attr.install_prefix
-
-        # If not in sandbox, or after the build, the value can be absolute.
-        # So if the user passed the absolute value, do not touch it.
-        if (prefix.startswith("/")):
-            return prefix
-        return prefix
+        return ctx.attr.install_prefix
     if ctx.attr.lib_name:
         return ctx.attr.lib_name
     return ctx.attr.name


### PR DESCRIPTION
…l prefix path with "./", as it is recognized as relative and gets appended to the current build directory anyway, forming the path /tmp/something/./install_prefix - which does not make much sense.