### PR TITLE
Bugfix: detect_root would like to fail when handle the pure files case

### DIFF
--- a/tools/build_defs/detect_root.bzl
+++ b/tools/build_defs/detect_root.bzl
@@ -5,29 +5,20 @@ def detect_root(source):
 
     root = ""
     sources = source.files.to_list()
-    if (root and len(root) > 0) or len(sources) == 0:
+
+    if len(sources) == 0:
         return root
 
-    root = ""
-    level = -1
-    num_at_level = 0
+    # is there a predefined maxint?
+    level = 999
 
     # find topmost directory
     for file in sources:
-        file_level = _get_level(file.path)
-        if level == -1 or level > file_level:
-            root = file.path
+        file_level = _get_level(file.dirname)
+        if level > file_level:
+            root = file.dirname
             level = file_level
-            num_at_level = 1
-        elif level == file_level:
-            num_at_level += 1
 
-    if num_at_level == 1:
-        return root
-
-    (before, sep, after) = root.rpartition("/")
-    if before and sep and after:
-        return before
     return root
 
 def _get_level(path):


### PR DESCRIPTION
Rewrite the `detect_root` to make it more simple and fix the bug.

Consider the following file layout and the testcase

```
cmake_hello_world_lib/
└── binary
    ├── CMakeLists.txt
    └── src
        ├── bar
        │   ├── bar.c
        │   ├── bar.h
        │   └── CMakeLists.txt
        ├── CMakeLists.txt
        ├── foo
        │   ├── CMakeLists.txt
        │   ├── foo.c
        │   └── foo.h
        ├── greeting
        │   ├── CMakeLists.txt
        │   ├── greeting.c
        │   └── greeting.h
        └── main.c
```

```
filegroup(
    name = "srcs",
    srcs = glob([
        "cmake_hello_world_lib/binary/**",
    ]),
)

cmake_external(
    name = "cmake_libbar",

    lib_source = ":srcs",

    shared_libraries = ["libbar.so"],
)
```

Prior to this patch, the result of detect_root to handle this case would
return "cmake_hello_world_lib/binary/CMakeLists.txt" which is not correct.

```
<source file cmake_hello_world_lib/binary/CMakeLists.txt>
<source file cmake_hello_world_lib/binary/src/CMakeLists.txt>
<source file cmake_hello_world_lib/binary/src/bar/CMakeLists.txt>
<source file cmake_hello_world_lib/binary/src/bar/bar.c>
<source file cmake_hello_world_lib/binary/src/bar/bar.h>
<source file cmake_hello_world_lib/binary/src/foo/CMakeLists.txt>
<source file cmake_hello_world_lib/binary/src/foo/foo.c>
<source file cmake_hello_world_lib/binary/src/foo/foo.h>
<source file cmake_hello_world_lib/binary/src/greeting/CMakeLists.txt>
<source file cmake_hello_world_lib/binary/src/greeting/greeting.c>
<source file cmake_hello_world_lib/binary/src/greeting/greeting.h>
<source file cmake_hello_world_lib/binary/src/main.c>
```

Signed-off-by: Hu Keping <hukeping@huawei.com>