### PR TITLE
Guard cc_common.configure_features with a version check

### DIFF
--- a/for_workspace/bazel_version.bzl
+++ b/for_workspace/bazel_version.bzl
@@ -1,0 +1,10 @@
+def _store_bazel_version(repository_ctx):
+    bazel_version = native.bazel_version
+    if len(bazel_version) == 0:
+        print("You're using development build of Bazel, make sure it's recent - version check is disabled.")
+    repository_ctx.file("BUILD", "exports_files(['def.bzl'])")
+    repository_ctx.file("def.bzl", "BAZEL_VERSION='" + bazel_version + "'")
+
+bazel_version = repository_rule(
+    implementation = _store_bazel_version,
+)

--- a/workspace_definitions.bzl
+++ b/workspace_definitions.bzl
@@ -4,6 +4,7 @@ load(
     "//tools/build_defs/shell_toolchain/toolchains:ws_defs.bzl",
     shell_toolchain_workspace_initalization = "workspace_part",
 )
+load("//for_workspace:bazel_version.bzl", "bazel_version")
 
 def _read_build_options_impl(rctx):
     rctx.file("BUILD.bazel", "\n".join(
@@ -91,6 +92,7 @@ def rules_foreign_cc_dependencies(
     """
     repositories()
     _read_build_options(name = "foreign_cc_platform_utils")
+    bazel_version(name="bazel_version")
 
     shell_toolchain_workspace_initalization(
         additonal_shell_toolchain_mappings,


### PR DESCRIPTION
This PR adds @bazel_version repository which contains single def.bzl
file which contains a BAZEL_VERSION constant that can be used to perform
conditional logic bazed on the Bazel version.

As a result, rules_foreing_cc are now compatible with Bazel 0.24 - 0.27
(at least regarding configure_features :)