### PR TITLE
Fix patch file for nghttp2

### DIFF
--- a/examples/nghttp2.patch
+++ b/examples/nghttp2.patch
@@ -2,7 +2,7 @@ diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
 index 17e422b2..e58070f5 100644
 --- a/lib/CMakeLists.txt
 +++ b/lib/CMakeLists.txt
-@@ -52,6 +52,7 @@
+@@ -56,6 +56,7 @@
      COMPILE_FLAGS "${WARNCFLAGS}"
      VERSION ${LT_VERSION} SOVERSION ${LT_SOVERSION}
      ARCHIVE_OUTPUT_NAME nghttp2


### PR DESCRIPTION
The line number doesn't match the exact location of the position of the content. This is tolerable with patch command line tool, but it won't work with a more strict patch implementation.
Context: https://github.com/bazelbuild/bazel/pulls