### PR TITLE
Fix replace_in_files function in windows_commands.bzl

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -17,7 +17,6 @@ tests = [
     "@rules_foreign_cc//test:shell_script_conversion_suite",
     "@rules_foreign_cc//test:utils_test_suite",
     "//cc_configure_make:libevent_echosrv1",
-    "//cmake_hello_world_variant:test_hello_world",
 ]
 
 test_suite(
@@ -29,6 +28,7 @@ test_suite(
         "//cmake_hello_world_lib/shared:test_libhello",
         "//cmake_hello_world_lib/binary:test_binary",
         "//configure_with_bazel_transitive:test",
+        "//cmake_hello_world_variant:test_hello_world",
     ],
 )
 
@@ -57,6 +57,7 @@ windows_tests = select_windows_tests(
         #        "//cmake_synthetic:test_libs",
         #        "//configure_gnuplot:configure_libgd_tests",
         "//cmake_hello_world_lib/static:test_hello_ninja",
+        "//cmake_hello_world_variant:test_hello_world",
         #        "//cmake_hello_world_lib/static:test_hello_nmake",
     ],
     [":bazel_version"],

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -17,6 +17,7 @@ tests = [
     "@rules_foreign_cc//test:shell_script_conversion_suite",
     "@rules_foreign_cc//test:utils_test_suite",
     "//cc_configure_make:libevent_echosrv1",
+    "//cmake_hello_world_variant:test_hello_world",
 ]
 
 test_suite(

--- a/examples/cmake_hello_world_variant/BUILD
+++ b/examples/cmake_hello_world_variant/BUILD
@@ -1,0 +1,35 @@
+load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+
+cmake_external(
+    name = "hello_world",
+    binaries = select({
+        "@bazel_tools//src/conditions:windows": ["CMakeHelloWorld.exe"],
+        "@bazel_tools//src/conditions:darwin": ["CMakeHelloWorld"],
+        "//conditions:default": ["CMakeHelloWorld"],
+    }),
+    cmake_options = ["-GNinja"],
+    generate_crosstool_file = True,
+    lib_source = "@cmake_hello_world_variant_src//:all",
+    make_commands = [
+        "ninja",
+        "ninja install",
+    ],
+)
+
+filegroup(
+    name = "binary",
+    srcs = [":hello_world"],
+    output_group = select({
+                           "@bazel_tools//src/conditions:windows": "CMakeHelloWorld.exe",
+                           "@bazel_tools//src/conditions:darwin": "CMakeHelloWorld",
+                           "//conditions:default": "CMakeHelloWorld",
+                       }),
+)
+
+sh_test(
+    name = "test_hello_world",
+    srcs = ["test_hello_world.sh"],
+    args = ["$(location binary)"],
+    data = [":binary"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)

--- a/examples/cmake_hello_world_variant/BUILD
+++ b/examples/cmake_hello_world_variant/BUILD
@@ -20,10 +20,10 @@ filegroup(
     name = "binary",
     srcs = [":hello_world"],
     output_group = select({
-                           "@bazel_tools//src/conditions:windows": "CMakeHelloWorld.exe",
-                           "@bazel_tools//src/conditions:darwin": "CMakeHelloWorld",
-                           "//conditions:default": "CMakeHelloWorld",
-                       }),
+        "@bazel_tools//src/conditions:windows": "CMakeHelloWorld.exe",
+        "@bazel_tools//src/conditions:darwin": "CMakeHelloWorld",
+        "//conditions:default": "CMakeHelloWorld",
+    }),
 )
 
 sh_test(
@@ -31,5 +31,6 @@ sh_test(
     srcs = ["test_hello_world.sh"],
     args = ["$(location binary)"],
     data = [":binary"],
+    tags = ["windows"],
     deps = ["@bazel_tools//tools/bash/runfiles"],
 )

--- a/examples/cmake_hello_world_variant/test_hello_world.sh
+++ b/examples/cmake_hello_world_variant/test_hello_world.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization ---
+# The runfiles library itself defines rlocation which you would need to look
+# up the library's runtime location, thus we have a chicken-and-egg problem.
+#
+# Copy-pasted from Bazel's Bash runfiles library (tools/bash/runfiles/runfiles.bash).
+set -euo pipefail
+if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  if [[ -f "$0.runfiles_manifest" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
+  elif [[ -f "$0.runfiles/MANIFEST" ]]; then
+    export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
+  elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+    export RUNFILES_DIR="$0.runfiles"
+  fi
+fi
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
+            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
+else
+  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
+  exit 1
+fi
+# --- end runfiles.bash initialization ---
+
+$(rlocation $TEST_WORKSPACE/$1)

--- a/examples/examples_repositories.bzl
+++ b/examples/examples_repositories.bzl
@@ -149,3 +149,11 @@ def include_examples_repositories():
         strip_prefix = "apr-util-1.6.1",
         urls = ["https://www-us.apache.org/dist//apr/apr-util-1.6.1.tar.gz"],
     )
+
+    http_archive(
+        name = "cmake_hello_world_variant_src",
+        build_file_content = """filegroup(name = "all", srcs = glob(["**"]), visibility = ["//visibility:public"])""",
+        strip_prefix = "cmake-hello-world-master",
+        urls = ["https://github.com/jameskbride/cmake-hello-world/archive/master.zip"],
+        sha256 = "d613cf222bbb05b8cff7a1c03c37345ed33744a4ebaf3a8bfd5f56a76e25ca08",
+    )

--- a/tools/build_defs/shell_toolchain/toolchains/impl/windows_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/windows_commands.bzl
@@ -55,7 +55,9 @@ def define_function(name, text):
 def replace_in_files(dir, from_, to_):
     return FunctionAndCall(
         text = """if [ -d "$1" ]; then
-  $REAL_FIND -L $1 -type f -exec sed -i 's@'"$2"'@'"$3"'@g' {} ';'
+  $REAL_FIND -L $1 -type f \
+  \( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.cmake" \) \
+  -exec sed -i 's@'"$2"'@'"$3"'@g' {} ';'
 fi
 """,
     )


### PR DESCRIPTION
Filter files by types, where the absolute paths need to be replaced.

Fixes #279 