### PR TITLE
Switch to rules_jvm_external

### DIFF
--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -27,20 +27,30 @@ android_ndk_repository(
     name = "androidndk",
 )
 
-# TODO(jin): replace legacy gmaven_rules targets with `maven_install` from the new rules_jvm_external
-RULES_JVM_EXTERNAL_TAG = "1.0"
-RULES_JVM_EXTERNAL_SHA = "48e0f1aab74fabba98feb8825459ef08dcc75618d381dff63ec9d4dd9860deaa"
+RULES_JVM_EXTERNAL_TAG = "2.3"
+
+RULES_JVM_EXTERNAL_SHA = "375b1592e3f4e0a46e6236e19fc30c8020c438803d4d49b13b40aaacd2703c30"
 
 http_archive(
-    name = "gmaven_rules",
-    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
+    name = "rules_jvm_external",
     sha256 = RULES_JVM_EXTERNAL_SHA,
+    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
     url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
 )
 
-load("@gmaven_rules//:gmaven.bzl", "gmaven_rules")
+load("@rules_jvm_external//:defs.bzl", "maven_install")
 
-gmaven_rules()
+maven_install(
+    artifacts = [
+        "com.android.support.constraint:constraint-layout:aar:1.1.2",
+        "com.android.support:appcompat-v7:aar:26.1.0",
+    ],
+    repositories = [
+        "https://jcenter.bintray.com/",
+        "https://maven.google.com",
+        "https://repo1.maven.org/maven2",
+    ],
+)
 
 load(":examples_repositories.bzl", "include_examples_repositories")
 

--- a/examples/cmake_android/BUILD
+++ b/examples/cmake_android/BUILD
@@ -1,5 +1,4 @@
 load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
-load("@gmaven_rules//:defs.bzl", "gmaven_artifact")
 
 cmake_external(
     name = "libhello",
@@ -23,8 +22,8 @@ android_library(
     resource_files = glob(["res/**/*"]),
     deps = [
         ":hello_lib_usage_example",
-        gmaven_artifact("com.android.support:appcompat-v7:aar:26.1.0"),
-        gmaven_artifact("com.android.support.constraint:constraint-layout:aar:1.1.2"),
+        "@maven//:com_android_support_appcompat_v7",
+        "@maven//:com_android_support_constraint_constraint_layout",
     ],
 )
 


### PR DESCRIPTION
The previous gmaven_rules usage was broken, this is the new supported
way to download these dependencies.