### PR TITLE
Adapt rules_foreign_cc for working with libtool instead of ar.

### DIFF
--- a/.bazelci/config.yaml
+++ b/.bazelci/config.yaml
@@ -1,5 +1,4 @@
 ---
-bazel: last_rc
 tasks:
   ubuntu1804:
     platform: ubuntu1804

--- a/.bazelci/config.yaml
+++ b/.bazelci/config.yaml
@@ -1,4 +1,5 @@
 ---
+bazel: last_rc
 tasks:
   ubuntu1804:
     platform: ubuntu1804

--- a/examples/cc_configure_make/BUILD
+++ b/examples/cc_configure_make/BUILD
@@ -9,6 +9,14 @@ configure_make(
     ],
     lib_source = "@libevent//:all",
     out_lib_dir = "lib",
+    # libevent script uses it's own libtool for linking;
+    # so do not specify linker tool for it
+    # (otherwise, if the libtool from bazel's toolchain is supplied,
+    # the build script has problems with passing output file to libtool)
+    # see #315
+    configure_env_vars = {
+        "AR": "",
+    },
 )
 
 cc_test(

--- a/tools/build_defs/cc_toolchain_util.bzl
+++ b/tools/build_defs/cc_toolchain_util.bzl
@@ -274,10 +274,12 @@ def get_tools_info(ctx):
         ),
     )
 
-def get_flags_info(ctx):
+def get_flags_info(ctx, link_output_file = None):
     """ Takes information about flags from cc_toolchain, returns CxxFlagsInfo
     Args:
         ctx - rule context
+        link_output_file - output file to be specified in the link command line
+        flags
     """
     cc_toolchain_ = find_cpp_toolchain(ctx)
     feature_configuration = _configure_features(
@@ -325,6 +327,7 @@ def get_flags_info(ctx):
                 feature_configuration = feature_configuration,
                 is_using_linker = False,
                 is_linking_dynamic_library = False,
+                output_file = link_output_file,
             ),
         ),
         cxx_linker_executable = cc_common.get_memory_inefficient_command_line(

--- a/tools/build_defs/cmake.bzl
+++ b/tools/build_defs/cmake.bzl
@@ -60,7 +60,8 @@ def _create_configure_script(configureParameters):
     root = detect_root(ctx.attr.lib_source)
 
     tools = get_tools_info(ctx)
-    flags = get_flags_info(ctx)
+    # CMake will replace <TARGET> with the actual output file
+    flags = get_flags_info(ctx, "<TARGET>")
     no_toolchain_file = ctx.attr.cache_entries.get("CMAKE_TOOLCHAIN_FILE") or not ctx.attr.generate_crosstool_file
 
     define_install_prefix = "export INSTALL_PREFIX=\"" + _get_install_prefix(ctx) + "\"\n"

--- a/tools/build_defs/cmake_script.bzl
+++ b/tools/build_defs/cmake_script.bzl
@@ -104,6 +104,8 @@ _CMAKE_CACHE_ENTRIES_CROSSTOOL = {
     "CMAKE_SYSTEM_NAME": struct(value = "CMAKE_SYSTEM_NAME", replace = True),
     "CMAKE_AR": struct(value = "CMAKE_AR", replace = True),
     "CMAKE_RANLIB": struct(value = "CMAKE_RANLIB", replace = True),
+    "CMAKE_C_ARCHIVE_CREATE": struct(value = "CMAKE_C_ARCHIVE_CREATE", replace = False),
+    "CMAKE_CXX_ARCHIVE_CREATE": struct(value = "CMAKE_CXX_ARCHIVE_CREATE", replace = False),
     "CMAKE_CXX_LINK_EXECUTABLE": struct(value = "CMAKE_CXX_LINK_EXECUTABLE", replace = True),
     "CMAKE_C_FLAGS": struct(value = "CMAKE_C_FLAGS_INIT", replace = False),
     "CMAKE_CXX_FLAGS": struct(value = "CMAKE_CXX_FLAGS_INIT", replace = False),
@@ -233,6 +235,11 @@ def _fill_crossfile_from_toolchain(workspace_name, target_os, tools, flags):
 
     if tools.cxx_linker_static:
         dict["CMAKE_AR"] = _absolutize(workspace_name, tools.cxx_linker_static, True)
+        if tools.cxx_linker_static.endswith("/libtool"):
+            dict["CMAKE_C_ARCHIVE_CREATE"] = "<CMAKE_AR> %s <OBJECTS>" % \
+            " ".join(flags.cxx_linker_static)
+            dict["CMAKE_CXX_ARCHIVE_CREATE"] = "<CMAKE_AR> %s <OBJECTS>" % \
+            " ".join(flags.cxx_linker_static)
 
     if tools.cxx_linker_executable and tools.cxx_linker_executable != tools.cxx:
         normalized_path = _absolutize(workspace_name, tools.cxx_linker_executable)


### PR DESCRIPTION
- for CMake, pass "<TARGET>" as the output file when forming linker flags with cc_common. CMake will later replace <TARGET> with the actual output file. Fill CMAKE_C_CREATE_ARCHIVE and CMAKE_CXX_CREATE_ARCHIVE CMake variables with 'CMAKE_AR %Bazel-link-flags% <OBJECTS>' call, where CMAKE_AR will take the path to libtool.
Related documentation: https://cmake.org/cmake/help/v3.15/variable/CMAKE_LANG_ARCHIVE_CREATE.html?highlight=cmake_%20lang%20_archive_create

- for configure_make, for the libevent example, we need to skip specifying the libtool from Bazel's toolchain as a linker, because libevent script uses it's own libtool and manages to pass the output file to it, but not to the libtool we are passing. Let it do so as it is a customized script.
Do it with specifying empty string for the $AR environment variable.
Other examples with configure_make work fine.

This fixes https://github.com/bazelbuild/bazel/issues/9258