### PR TITLE
Be resilient with Bazel-built transitive dependencies duplicates

### DIFF
--- a/.bazelci/config.yaml
+++ b/.bazelci/config.yaml
@@ -5,7 +5,6 @@ tasks:
     working_directory: examples
     build_targets:
       - "//cmake_android:app"
-      - "//cmake_synthetic:lib_with_duplicate_transitive_bazel_deps"
     test_targets:
     - "//:tests"
   ubuntu1604:

--- a/.bazelci/config.yaml
+++ b/.bazelci/config.yaml
@@ -5,6 +5,7 @@ tasks:
     working_directory: examples
     build_targets:
       - "//cmake_android:app"
+      - "//cmake_synthetic:lib_with_duplicate_transitive_bazel_deps"
     test_targets:
     - "//:tests"
   ubuntu1604:

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -30,6 +30,7 @@ test_suite(
         "//configure_with_bazel_transitive:test",
         "//simple_make:test_lib",
         "//cmake_hello_world_variant:test_hello_world",
+        "//cmake_synthetic:test_bazel_transitive_deps",
     ],
 )
 

--- a/examples/cmake_synthetic/BUILD
+++ b/examples/cmake_synthetic/BUILD
@@ -1,4 +1,5 @@
 load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 generate_crosstool = select({
     "@bazel_tools//src/conditions:windows": True,
@@ -46,6 +47,11 @@ cmake_external(
         "ninja install",
     ],
     deps = ["//cmake_synthetic/liba:lib_a_bazel", "//cmake_synthetic/libb:lib_b_bazel"],
+)
+
+build_test(
+    name = "test_bazel_transitive_deps",
+    targets = [":lib_with_duplicate_transitive_bazel_deps"],
 )
 
 cc_test(

--- a/examples/cmake_synthetic/BUILD
+++ b/examples/cmake_synthetic/BUILD
@@ -31,6 +31,23 @@ cmake_external(
     deps = [":liba"],
 )
 
+cmake_external(
+    name = "lib_with_duplicate_transitive_bazel_deps",
+    lib_name = "libc",
+    cmake_options = ["-GNinja"],
+    cache_entries = {
+        "LIBA_DIR": "$$EXT_BUILD_DEPS$$",
+        "LIBB_DIR": "$$EXT_BUILD_DEPS$$",
+    },
+    generate_crosstool_file = generate_crosstool,
+    lib_source = "//cmake_synthetic/libc:c_srcs",
+    make_commands = [
+        "ninja",
+        "ninja install",
+    ],
+    deps = ["//cmake_synthetic/liba:lib_a_bazel", "//cmake_synthetic/libb:lib_b_bazel"],
+)
+
 cc_test(
     name = "test_libs",
     srcs = [

--- a/examples/cmake_synthetic/libb/BUILD
+++ b/examples/cmake_synthetic/libb/BUILD
@@ -3,3 +3,12 @@ filegroup(
     srcs = glob(["**"]),
     visibility = ["//visibility:public"],
 )
+
+cc_library(
+    name = "lib_b_bazel",
+    srcs = ["src/libb.cpp"],
+    hdrs = ["src/libb.h"],
+    includes = ["src"],
+    visibility = ["//visibility:public"],
+    deps = ["//cmake_synthetic/liba:lib_a_bazel"],
+)

--- a/examples/cmake_synthetic/libc/BUILD
+++ b/examples/cmake_synthetic/libc/BUILD
@@ -1,0 +1,5 @@
+filegroup(
+    name = "c_srcs",
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)

--- a/examples/cmake_synthetic/libc/CMakeLists.txt
+++ b/examples/cmake_synthetic/libc/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 2.8.4)
+
+project(libc)
+
+add_subdirectory(src)

--- a/examples/cmake_synthetic/libc/src/CMakeLists.txt
+++ b/examples/cmake_synthetic/libc/src/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 2.8.4)
+
+set(libc_SRC libc.cpp libc.h)
+
+add_library(libc_static STATIC ${libc_SRC})
+set_target_properties(libc_static PROPERTIES OUTPUT_NAME "libc")
+IF (WIN32)
+  set_target_properties(libc_static PROPERTIES ARCHIVE_OUTPUT_NAME "libc")
+ELSE()
+  set_target_properties(libc_static PROPERTIES ARCHIVE_OUTPUT_NAME "c")
+ENDIF()
+
+#find_package(LIBA NAMES alib liba libliba liba++)
+#find_package(LIBB NAMES blib libb liblibb)
+
+# LIBA_INCLUDE_DIRS is not set, so giving the path relative to liba_config.cmake
+# would be happy to improve that
+target_link_libraries(libc_static PUBLIC ${LIBA_DIR}/lib/liblib_a_bazel.a)
+target_include_directories(libc_static PUBLIC ${LIBA_DIR}/include)
+
+target_link_libraries(libc_static PUBLIC ${LIBB_DIR}/lib/liblib_b_bazel.a)
+target_include_directories(libc_static PUBLIC ${LIBB_DIR}/include)
+
+set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
+
+install(TARGETS libc_static ARCHIVE DESTINATION lib)
+
+install(FILES libc.h DESTINATION include)

--- a/examples/cmake_synthetic/libc/src/libc.cpp
+++ b/examples/cmake_synthetic/libc/src/libc.cpp
@@ -1,0 +1,5 @@
+#include "libc.h"
+
+std::string hello_libc(void) {
+  return hello_liba() + " " + hello_libb() + " Hello from LIBC!";
+}

--- a/examples/cmake_synthetic/libc/src/libc.h
+++ b/examples/cmake_synthetic/libc/src/libc.h
@@ -1,0 +1,11 @@
+#ifndef LIBC_H_
+#define LIBC_H_ (1)
+
+#include <stdio.h>
+#include <string>
+#include "liba.h"
+#include "libb.h"
+
+std::string hello_libc(void);
+
+#endif

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -443,6 +443,8 @@ def _copy_deps_and_tools(files):
     return lines
 
 def _symlink_contents_to_dir(dir_name, files_list):
+    # It is possible that some duplicate libraries will be passed as inputs
+    # to cmake_external or configure_make. Filter duplicates out here.
     files_list = collections.uniq(files_list)
     if len(files_list) == 0:
         return []

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -443,6 +443,7 @@ def _copy_deps_and_tools(files):
     return lines
 
 def _symlink_contents_to_dir(dir_name, files_list):
+    files_list = collections.uniq(files_list)
     if len(files_list) == 0:
         return []
     lines = ["##mkdirs## $$EXT_BUILD_DEPS$$/" + dir_name]


### PR DESCRIPTION
- it is possible that some duplicate libraries, built with Bazel, will be passed as inputs to cmake_external or configure_make. rules_foreign_cc should filter duplicates out rather then fail.
- add a test (which just builds the target) //cmake_synthetic:lib_with_duplicate_transitive_bazel_deps