### PR TITLE
Solution for building without sandbox and EXT_BUILD_DEPS containing files from building this same target for other (host, other target) configuration

### DIFF
--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -232,7 +232,7 @@ def cc_external_rule_impl(ctx, attrs):
         set_cc_envs,
         "export EXT_BUILD_ROOT=##pwd##",
         "export BUILD_TMPDIR=##tmpdir##",
-        "export EXT_BUILD_DEPS=$$EXT_BUILD_ROOT$$/bazel_foreign_cc_deps_" + lib_name,
+        "export EXT_BUILD_DEPS=##tmpdir##",
         "export INSTALLDIR=$$EXT_BUILD_ROOT$$/" + empty.file.dirname + "/" + lib_name,
     ]
 
@@ -243,7 +243,6 @@ def cc_external_rule_impl(ctx, attrs):
         "##script_prelude##",
         "\n".join(define_variables),
         "##path## $$EXT_BUILD_ROOT$$",
-        "##mkdirs## $$EXT_BUILD_DEPS$$",
         "##mkdirs## $$INSTALLDIR$$",
         _print_env(),
         "\n".join(_copy_deps_and_tools(inputs)),


### PR DESCRIPTION
When executed without sandbox, target- and host- configured targets are created in the same execution root with the same names.
Apparently, it is not the problem for build outputs, but deps directory that is created by script.
What is even more problematic is that this directory can be accessed while building this target in parallel for different configurations. So even if we clean it before using, we might break the build of the parallel target.

Solution: create temp directory to be used as deps directory.
(Additionally, this demonstrates the benefits of sandboxed execution.)

How to execute without sandbox:
bazel build/test --spawn_strategy=standalone

How to reproduce the problem: 
For instance, have the results of cmake_external/configure_make be consumed by genrule in tools attribute.
Tools attribute of the genrule is expecting the passed label to exist/ be built for the host configuration.
This way, if you build genrule using your cmake_external target *and*  this cmake_external target with the same command, cmake_external target will be built two times - for host and target.