### PR TITLE
For Bazel-built dependencies, do not symlink generic directories under includes

### DIFF
--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -450,15 +450,11 @@ def _symlink_contents_to_dir(dir_name, files_list):
         return []
     lines = ["##mkdirs## $$EXT_BUILD_DEPS$$/" + dir_name]
 
-    paths_list = []
     for file in files_list:
-        paths_list += [_file_path(file).strip()]
-
-    for path in paths_list:
-        # Filter out empty subpaths
-        # (current directory may be passed as quote_includes, but we should not symlink it)
-        if path and path != ".":
-            lines += ["##symlink_contents_to_dir## $$EXT_BUILD_ROOT$$/{} $$EXT_BUILD_DEPS$$/{}".format(path, dir_name)]
+      path = _file_path(file).strip()
+      if path:
+        lines += ["##symlink_contents_to_dir## \
+$$EXT_BUILD_ROOT$$/{} $$EXT_BUILD_DEPS$$/{}".format(path, dir_name)]
 
     return lines
 
@@ -615,11 +611,11 @@ def get_foreign_cc_dep(dep):
 
 # consider optimization here to do not iterate both collections
 def _get_headers(compilation_info):
-    # NB: current directory (".") is passed by quote_includes;
-    # ignore it by now, will be filtered by symlinking code.
-    include_dirs = collections.uniq(compilation_info.system_includes.to_list() +
-                                    compilation_info.includes.to_list() +
-                                    compilation_info.quote_includes.to_list())
+    include_dirs = compilation_info.system_includes.to_list() + \
+      compilation_info.includes.to_list()
+    # do not use quote includes, currently they do not contain
+    # library-specific information
+    include_dirs = collections.uniq(include_dirs)
     headers = []
     for header in compilation_info.headers.to_list():
         path = header.path


### PR DESCRIPTION
For consuming Bazel-built targets as dependencies, do not use quote_includes from CcInfo, as they are not used for anything related to the particular library, but contain references to the gendir and bin directories, which seems hardly useful. (We expect Bazel targets to describe their include directories and headers explicitly).

Rules_foreign_cc also currently is not using CcInfo.quote_includes.
Having them leads to symlinking directory trees without any reason.
Tests: we already have tests for transitive Bazel dependencies (//cmake_synthetic:test_bazel_transitive_deps, //cmake_with_bazel_transitive:test, //configure_with_bazel_transitive:test)