### PR TITLE
Improve cygwin compatibility

### DIFF
--- a/tools/build_defs/shell_toolchain/toolchains/impl/windows_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/windows_commands.bzl
@@ -6,7 +6,7 @@ def os_name():
     return "windows"
 
 def pwd():
-    return "$(pwd -W)"
+    return "$(type -t cygpath > /dev/null && cygpath $(pwd) -w || pwd -W)"
 
 def echo(text):
     return "printf \"{text}\"".format(text = text)


### PR DESCRIPTION
Use `cygpath` in case it is available, `pwd` otherwhise. `pwd -W` does not work within Cygwin.