### PR TITLE
Prefixes bazel_version so that it doesn't conflict with other libraries.

### DIFF
--- a/tools/build_defs/cc_toolchain_util.bzl
+++ b/tools/build_defs/cc_toolchain_util.bzl
@@ -13,7 +13,7 @@ load(
 )
 load("@bazel_skylib//lib:collections.bzl", "collections")
 load("@bazel_skylib//lib:versions.bzl", "versions")
-load("@bazel_version//:def.bzl", "BAZEL_VERSION")
+load("@rules_foreign_cc_bazel_version//:def.bzl", "BAZEL_VERSION")
 
 LibrariesToLinkInfo = provider(
     doc = "Libraries to be wrapped into CcLinkingInfo",

--- a/workspace_definitions.bzl
+++ b/workspace_definitions.bzl
@@ -88,7 +88,7 @@ def rules_foreign_cc_dependencies(
     """
     repositories()
     _read_build_options(name = "foreign_cc_platform_utils")
-    bazel_version(name="bazel_version")
+    bazel_version(name="rules_foreign_cc_bazel_version")
 
     shell_toolchain_workspace_initalization(
         additonal_shell_toolchain_mappings,


### PR DESCRIPTION
Fixes #327.