### PR TITLE
Double quotes are not properly escaped

### DIFF
--- a/examples/apache_httpd/BUILD
+++ b/examples/apache_httpd/BUILD
@@ -31,7 +31,6 @@ configure_make(
         "--with-apr=$$EXT_BUILD_DEPS$$/apr",
         "--with-apr-util=$$EXT_BUILD_DEPS$$/apr_util",
         "--with-pcre=$$EXT_BUILD_DEPS$$/pcre",
-        "CFLAGS='-Dredacted=\"redacted\"'",
     ],
     lib_source = "@apache_httpd//:all",
     binaries = [

--- a/test/cmake_text_tests.bzl
+++ b/test/cmake_text_tests.bzl
@@ -99,7 +99,7 @@ def _fill_crossfile_from_toolchain_test(ctx):
         "CMAKE_AR": "/cxx_linker_static",
         "CMAKE_CXX_LINK_EXECUTABLE": "$EXT_BUILD_ROOT/ws/cxx_linker_executable <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>",
         "CMAKE_C_FLAGS_INIT": "-cc-flag -gcc_toolchain cc-toolchain",
-        "CMAKE_CXX_FLAGS_INIT": "--quoted=\\\"abc def\\\" --sysroot=/abc/sysroot --gcc_toolchain cxx-toolchain",
+        "CMAKE_CXX_FLAGS_INIT": "--quoted=\\\\\\\"abc def\\\\\\\" --sysroot=/abc/sysroot --gcc_toolchain cxx-toolchain",
         "CMAKE_ASM_FLAGS_INIT": "assemble",
         "CMAKE_SHARED_LINKER_FLAGS_INIT": "shared1 shared2",
         "CMAKE_EXE_LINKER_FLAGS_INIT": "executable",
@@ -234,7 +234,7 @@ def _merge_flag_values_no_toolchain_file_test(ctx):
 
     script = create_cmake_script("ws", "linux", "cmake", tools, flags, "test_rule",
                                  "external/test_rule", True, user_cache, user_env, [])
-    expected = """CC=\"/usr/bin/gcc\" CXX=\"/usr/bin/gcc\" CXXFLAGS=\"foo=\\\"bar\\\" -Fbat" cmake -DCMAKE_AR=\"/usr/bin/ar\" -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DCMAKE_PREFIX_PATH=\"$EXT_BUILD_DEPS\" -DCMAKE_INSTALL_PREFIX=\"test_rule\" -DCMAKE_RANLIB=\"\"  $EXT_BUILD_ROOT/external/test_rule"""
+    expected = """CC=\"/usr/bin/gcc\" CXX=\"/usr/bin/gcc\" CXXFLAGS=\"foo=\\\\\\\"bar\\\\\\\" -Fbat" cmake -DCMAKE_AR=\"/usr/bin/ar\" -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DCMAKE_PREFIX_PATH=\"$EXT_BUILD_DEPS\" -DCMAKE_INSTALL_PREFIX=\"test_rule\" -DCMAKE_RANLIB=\"\"  $EXT_BUILD_ROOT/external/test_rule"""
     asserts.equals(env, expected, script)
 
     return unittest.end(env)
@@ -326,7 +326,7 @@ def _create_min_cmake_script_toolchain_file_test(ctx):
 
     script = create_cmake_script("ws", "linux", "cmake", tools, flags, "test_rule",
                                  "external/test_rule", False, user_cache, user_env, ["-GNinja"])
-    expected = """cat > crosstool_bazel.cmake <<EOF
+    expected = """cat > crosstool_bazel.cmake <<'EOF'
 set(CMAKE_SYSTEM_NAME "Linux")
 set(CMAKE_C_COMPILER "/usr/bin/gcc")
 set(CMAKE_CXX_COMPILER "/usr/bin/gcc")
@@ -377,7 +377,7 @@ def _create_cmake_script_no_toolchain_file_test(ctx):
 
     script = create_cmake_script("ws", "linux", "cmake", tools, flags, "test_rule",
                                  "external/test_rule", True, user_cache, user_env, ["-GNinja"])
-    expected = "CC=\"sink-cc-value\" CXX=\"sink-cxx-value\" CFLAGS=\"-cc-flag -gcc_toolchain cc-toolchain --from-env --additional-flag\" CXXFLAGS=\"--quoted=\\\"abc def\\\" --sysroot=/abc/sysroot --gcc_toolchain cxx-toolchain\" ASMFLAGS=\"assemble assemble-user\" CUSTOM_ENV=\"YES\" cmake -DCMAKE_AR=\"/cxx_linker_static\" -DCMAKE_CXX_LINK_EXECUTABLE=\"became\" -DCMAKE_SHARED_LINKER_FLAGS=\"shared1 shared2\" -DCMAKE_EXE_LINKER_FLAGS=\"executable\" -DCUSTOM_CACHE=\"YES\" -DCMAKE_BUILD_TYPE=\"user_type\" -DCMAKE_PREFIX_PATH=\"$EXT_BUILD_DEPS\" -DCMAKE_INSTALL_PREFIX=\"test_rule\" -DCMAKE_RANLIB=\"\" -GNinja $EXT_BUILD_ROOT/external/test_rule"
+    expected = "CC=\"sink-cc-value\" CXX=\"sink-cxx-value\" CFLAGS=\"-cc-flag -gcc_toolchain cc-toolchain --from-env --additional-flag\" CXXFLAGS=\"--quoted=\\\\\\\"abc def\\\\\\\" --sysroot=/abc/sysroot --gcc_toolchain cxx-toolchain\" ASMFLAGS=\"assemble assemble-user\" CUSTOM_ENV=\"YES\" cmake -DCMAKE_AR=\"/cxx_linker_static\" -DCMAKE_CXX_LINK_EXECUTABLE=\"became\" -DCMAKE_SHARED_LINKER_FLAGS=\"shared1 shared2\" -DCMAKE_EXE_LINKER_FLAGS=\"executable\" -DCUSTOM_CACHE=\"YES\" -DCMAKE_BUILD_TYPE=\"user_type\" -DCMAKE_PREFIX_PATH=\"$EXT_BUILD_DEPS\" -DCMAKE_INSTALL_PREFIX=\"test_rule\" -DCMAKE_RANLIB=\"\" -GNinja $EXT_BUILD_ROOT/external/test_rule"
     asserts.equals(env, expected, script)
 
     return unittest.end(env)
@@ -415,7 +415,7 @@ def _create_cmake_script_toolchain_file_test(ctx):
 
     script = create_cmake_script("ws", "osx", "cmake", tools, flags, "test_rule",
                                  "external/test_rule", False, user_cache, user_env, ["-GNinja"])
-    expected = """cat > crosstool_bazel.cmake <<EOF
+    expected = """cat > crosstool_bazel.cmake <<'EOF'
 set(CMAKE_SYSTEM_NAME "Apple")
 set(CMAKE_SYSROOT "/abc/sysroot")
 set(CMAKE_C_COMPILER_EXTERNAL_TOOLCHAIN "cc-toolchain")
@@ -425,7 +425,7 @@ set(CMAKE_CXX_COMPILER "sink-cxx-value")
 set(CMAKE_AR "/cxx_linker_static" CACHE FILEPATH "Archiver")
 set(CMAKE_CXX_LINK_EXECUTABLE "became")
 set(CMAKE_C_FLAGS_INIT "-cc-flag -gcc_toolchain cc-toolchain --from-env --additional-flag")
-set(CMAKE_CXX_FLAGS_INIT "--quoted=\\\"abc def\\\" --sysroot=/abc/sysroot --gcc_toolchain cxx-toolchain")
+set(CMAKE_CXX_FLAGS_INIT "--quoted=\\\\\\\"abc def\\\\\\\" --sysroot=/abc/sysroot --gcc_toolchain cxx-toolchain")
 set(CMAKE_ASM_FLAGS_INIT "assemble assemble-user")
 set(CMAKE_SHARED_LINKER_FLAGS_INIT "shared1 shared2")
 set(CMAKE_EXE_LINKER_FLAGS_INIT "executable")

--- a/tools/build_defs/cc_toolchain_util.bzl
+++ b/tools/build_defs/cc_toolchain_util.bzl
@@ -393,7 +393,7 @@ def absolutize_path_in_str(workspace_name, root_str, text, force = False):
     return new_text
 
 def _prefix(text, from_str, prefix):
-    text = text.replace('"', '\\"')
+    text = text.replace('"', '\\\\\\"')
     (before, middle, after) = text.partition(from_str)
     if not middle or before.endswith("/"):
         return text

--- a/tools/build_defs/cmake_script.bzl
+++ b/tools/build_defs/cmake_script.bzl
@@ -132,7 +132,7 @@ def _create_crosstool_file_text(toolchain_dict, user_cache, user_env):
         "CMAKE_TOOLCHAIN_FILE": "crosstool_bazel.cmake",
     })
     return struct(
-        commands = ["cat > crosstool_bazel.cmake <<EOF\n" + "\n".join(lines) + "\nEOF\n"],
+        commands = ["cat > crosstool_bazel.cmake <<'EOF'\n" + "\n".join(lines) + "\nEOF\n"],
         env = env_vars,
         cache = cache_entries,
     )


### PR DESCRIPTION
Bazel passes to CFLAGS and CXXFLAGS the redacted values of `__DATE__`,
`__TIMESTAMP__`, and `__TIME__`.

Just a single backslash is not enough. It gets passed into the code
as redacted (without any quotes) and not "redacted". The compiler
complains about the symbol "redacted" not being found for packages
that actually use one of those fields.

Remove hack in apache_httpd/BUILD that was put in place because of this
bug.

Also need to turn off escaping on heredoc when generating
crosstool_bazel.cmake. Without the single quotes around EOF, the
contents of the heredoc are escaped. With single quotes, they are not.

https://stackoverflow.com/a/9870274