### PR TITLE
Build under bazel sandbox instead of /tmp, and remove redundant printf

### DIFF
--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -231,9 +231,9 @@ def cc_external_rule_impl(ctx, attrs):
     define_variables = [
         set_cc_envs,
         "export EXT_BUILD_ROOT=##pwd##",
-        "export BUILD_TMPDIR=##tmpdir##",
-        "export EXT_BUILD_DEPS=##tmpdir##",
         "export INSTALLDIR=$$EXT_BUILD_ROOT$$/" + empty.file.dirname + "/" + lib_name,
+        "export BUILD_TMPDIR=$$INSTALLDIR$$/_build_tmpdir",
+        "export EXT_BUILD_DEPS=$$INSTALLDIR$$/_ext_build_deps",
     ]
 
     script_lines = [
@@ -244,6 +244,8 @@ def cc_external_rule_impl(ctx, attrs):
         "\n".join(define_variables),
         "##path## $$EXT_BUILD_ROOT$$",
         "##mkdirs## $$INSTALLDIR$$",
+        "##mkdirs## $$BUILD_TMPDIR$$",
+        "##mkdirs## $$EXT_BUILD_DEPS$$",
         _print_env(),
         "\n".join(_copy_deps_and_tools(inputs)),
         "cd $$BUILD_TMPDIR$$",
@@ -331,8 +333,7 @@ def wrap_outputs(ctx, lib_name, configure_name, script_text):
     cleanup_on_success_function = create_function(
         ctx,
         "cleanup_on_success",
-        """##echo## \"rules_foreign_cc: Cleaning temp directories\"
-rm -rf $BUILD_TMPDIR $EXT_BUILD_DEPS""",
+        """rm -rf $BUILD_TMPDIR $EXT_BUILD_DEPS""",
     )
     cleanup_on_failure_function = create_function(
         ctx,


### PR DESCRIPTION
Build artifacts under /tmp are not cleaned up after a failed build, for
the ease of debugging.  However, this can quickly fill up the /tmp partition
if the build is large.  Build under the sandbox directory instead, and
rely on standard bazel cleanup scheme.

Also remove a print from the cleanup function, which somehow causes empty
newlines to be printed in bazel build output.