### PR TITLE
configure_script: make sure to define EXT_BUILD_DEPS for pkg-config

### DIFF
--- a/tools/build_defs/configure_script.bzl
+++ b/tools/build_defs/configure_script.bzl
@@ -21,6 +21,7 @@ def create_configure_script(
         script += ["##increment_pkg_config_path## $$EXT_BUILD_ROOT$$/" + ext_dir.path]
 
     script += ["echo \"PKG_CONFIG_PATH=$$PKG_CONFIG_PATH$$\""]
+    script += ["export PKG_CONFIG=\"pkg-config --define-variable=EXT_BUILD_DEPS=$$EXT_BUILD_DEPS$$\""]
 
     configure_path = "$$EXT_BUILD_ROOT$$/{root}/{configure}".format(
         root = root,
@@ -53,6 +54,7 @@ def create_make_script(
         script += ["##increment_pkg_config_path## $$EXT_BUILD_ROOT$$/" + ext_dir.path]
 
     script += ["echo \"PKG_CONFIG_PATH=$$PKG_CONFIG_PATH$$\""]
+    script += ["export PKG_CONFIG=\"pkg-config --define-variable=EXT_BUILD_DEPS=$$EXT_BUILD_DEPS$$\""]
 
     script += ["##symlink_contents_to_dir## $$EXT_BUILD_ROOT$$/{} $$BUILD_TMPDIR$$".format(root)]
     script += ["" + " && ".join(make_commands)]


### PR DESCRIPTION
Because we insert that variable into .pc files we build.
So if other packages try to use them it needs to be defined.

My proposed fix that I mentioned in issue #365