### PR TITLE
Detect CMakeLists.txt when building CMake projects.

### DIFF
--- a/tools/build_defs/cmake.bzl
+++ b/tools/build_defs/cmake.bzl
@@ -57,7 +57,7 @@ def _create_configure_script(configureParameters):
     ctx = configureParameters.ctx
     inputs = configureParameters.inputs
 
-    root = detect_root(ctx.attr.lib_source)
+    root = detect_root(ctx.attr.lib_source, contains_file="CMakeLists.txt")
 
     tools = get_tools_info(ctx)
     # CMake will replace <TARGET> with the actual output file

--- a/tools/build_defs/detect_root.bzl
+++ b/tools/build_defs/detect_root.bzl
@@ -1,8 +1,11 @@
-def detect_root(source):
+def detect_root(source, contains_file=None):
     """Detects the path to the topmost directory of the 'source' outputs.
-    To be used with external build systems to point to the source code/tools directories.
-"""
 
+    To be used with external build systems to point to the source code/tools directories.
+
+    Args:
+        contains_file: If not None, find topmost directory containing a file with this name.
+    """
     root = ""
     sources = source.files.to_list()
     if (root and len(root) > 0) or len(sources) == 0:
@@ -14,6 +17,8 @@ def detect_root(source):
 
     # find topmost directory
     for file in sources:
+        if contains_file and file.basename != contains_file:
+            continue
         file_level = _get_level(file.path)
         if level == -1 or level > file_level:
             root = file.path
@@ -21,6 +26,9 @@ def detect_root(source):
             num_at_level = 1
         elif level == file_level:
             num_at_level += 1
+
+    if contains_file and root.endswith("/" + contains_file):
+        root = root.rpartition("/" + contains_file)[0]
 
     if num_at_level == 1:
         return root


### PR DESCRIPTION
Instead of pointing `cmake` to the source root, detect the topmost directory that contains a `CMakeLists.txt` file and point `cmake` there. This is required for projects that do not ship a `CMakeLists.txt` in their root directory, e.g. `lz4`, `zstd` or `llvm`.

This mostly obsoletes https://github.com/bazelbuild/rules_foreign_cc/pull/358, although an argument like `cmake_relative_root` might still be required for projects that ship multiple top-level directories containing a `CMakeLists.txt` (but then again an alternative there would be to just delete the rest from the repository using `patch_cmds`.)

This should be a backwards-compatible change and no update to the documentation should be necessary.