### PR TITLE
Add a GNU Make toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,15 +88,20 @@ load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependen
 #
 #  Args:
 #    native_tools_toolchains: pass the toolchains for toolchain types
+#      '@rules_foreign_cc//tools/build_defs:make_toolchain',
 #      '@rules_foreign_cc//tools/build_defs:cmake_toolchain' and
 #      '@rules_foreign_cc//tools/build_defs:ninja_toolchain' with the needed platform constraints.
 #      If you do not pass anything, registered default toolchains will be selected (see below).
 #  
-#    register_default_tools: if True, the cmake and ninja toolchains, calling corresponding
-#      preinstalled binaries by name (cmake, ninja) will be registered after
+#    register_default_tools: if True, the make, cmake and ninja toolchains, calling corresponding
+#      preinstalled binaries by name (make, cmake, ninja) will be registered after
 #      'native_tools_toolchains' without any platform constraints.
 #      The default is True.
-rules_foreign_cc_dependencies(["//:my_cmake_toolchain", "//:my_ninja_toolchain"])
+rules_foreign_cc_dependencies([
+    "//:my_make_toolchain",
+    "//:my_cmake_toolchain",
+    "//:my_ninja_toolchain",
+])
 
 # OpenBLAS source code repository
 http_archive(

--- a/examples/build_make_itself/BUILD
+++ b/examples/build_make_itself/BUILD
@@ -1,0 +1,6 @@
+load("@rules_foreign_cc//for_workspace:make_build.bzl", "make_tool")
+
+make_tool(
+    name = "maketool",
+    make_srcs = "@make//:all",
+)

--- a/for_workspace/BUILD
+++ b/for_workspace/BUILD
@@ -1,5 +1,6 @@
 exports_files(
     [
+        "make_build.bzl",
         "cmake_build.bzl",
         "ninja_build.bzl",
         "install_ws_dependency.bzl",

--- a/for_workspace/make_build.bzl
+++ b/for_workspace/make_build.bzl
@@ -1,0 +1,47 @@
+""" Rule for building GNU Make from sources. """
+
+load("//tools/build_defs:detect_root.bzl", "detect_root")
+load("@rules_foreign_cc//tools/build_defs:shell_script_helper.bzl", "convert_shell_script")
+
+def _make_tool(ctx):
+    root = detect_root(ctx.attr.make_srcs)
+
+    make = ctx.actions.declare_directory("make")
+    script = [
+        "export BUILD_DIR=##pwd##",
+        "export BUILD_TMPDIR=##tmpdir##",
+        "##copy_dir_contents_to_dir## ./{} $BUILD_TMPDIR".format(root),
+        "cd $$BUILD_TMPDIR$$",
+        "./configure --prefix=$$BUILD_DIR$$/{}".format(make.path),
+        "./build.sh",
+        "./make install",
+    ]
+    script_text = convert_shell_script(ctx, script)
+
+    ctx.actions.run_shell(
+        mnemonic = "BootstrapMake",
+        inputs = ctx.attr.make_srcs.files,
+        outputs = [make],
+        tools = [],
+        use_default_shell_env = True,
+        command = script_text,
+        execution_requirements = {"block-network": ""},
+    )
+
+    return [DefaultInfo(files = depset([make]))]
+
+""" Rule for building Make. Invokes configure script and make install.
+  Attributes:
+    make_srcs - target with the Make sources
+"""
+make_tool = rule(
+    attrs = {
+        "make_srcs": attr.label(mandatory = True),
+    },
+    fragments = ["cpp"],
+    output_to_genfiles = True,
+    implementation = _make_tool,
+    toolchains = [
+        "@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains:shell_commands",
+    ],
+)

--- a/for_workspace/repositories.bzl
+++ b/for_workspace/repositories.bzl
@@ -15,6 +15,16 @@ def repositories():
     )
 
     http_archive(
+        name = "make",
+        build_file_content = _all_content,
+        sha256 = "e05fdde47c5f7ca45cb697e973894ff4f5d79e13b750ed57d7b66d8defc78e19",
+        strip_prefix = "make-4.3",
+        urls = [
+            "http://mirror.rit.edu/gnu/make/make-4.3.tar.gz",
+        ],
+    )
+
+    http_archive(
         name = "ninja_build",
         build_file_content = _all_content,
         sha256 = "3810318b08489435f8efc19c05525e80a993af5a55baa0dfeae0465a9d45f99f",

--- a/tools/build_defs/BUILD
+++ b/tools/build_defs/BUILD
@@ -8,6 +8,11 @@ toolchain_type(
     visibility = ["//visibility:public"],
 )
 
+toolchain_type(
+    name = "make_toolchain",
+    visibility = ["//visibility:public"],
+)
+
 # Preinstalled cmake will always be the default, if toolchain with more exact constraints
 # is not defined before; registered from workspace_definitions.bzl#rules_foreign_cc_dependencies
 toolchain(
@@ -22,4 +27,12 @@ toolchain(
     name = "preinstalled_ninja_toolchain",
     toolchain = "@rules_foreign_cc//tools/build_defs/native_tools:preinstalled_ninja",
     toolchain_type = "@rules_foreign_cc//tools/build_defs:ninja_toolchain",
+)
+
+# Preinstalled make will always be the default, if toolchain with more exact constraints
+# is not defined before; registered from workspace_definitions.bzl#rules_foreign_cc_dependencies
+toolchain(
+    name = "preinstalled_make_toolchain",
+    toolchain = "@rules_foreign_cc//tools/build_defs/native_tools:preinstalled_make",
+    toolchain_type = "@rules_foreign_cc//tools/build_defs:make_toolchain",
 )

--- a/tools/build_defs/cmake.bzl
+++ b/tools/build_defs/cmake.bzl
@@ -18,13 +18,20 @@ load(
     "is_debug_mode",
 )
 load(":cmake_script.bzl", "create_cmake_script")
-load("//tools/build_defs/native_tools:tool_access.bzl", "get_cmake_data", "get_ninja_data")
+load("//tools/build_defs/shell_toolchain/toolchains:access.bzl", "create_context")
+load(
+    "//tools/build_defs/native_tools:tool_access.bzl",
+    "get_cmake_data",
+    "get_ninja_data",
+    "get_make_data",
+)
 load("@rules_foreign_cc//tools/build_defs:shell_script_helper.bzl", "os_name")
 
 def _cmake_external(ctx):
     cmake_data = get_cmake_data(ctx)
+    make_data = get_make_data(ctx)
 
-    tools_deps = ctx.attr.tools_deps + cmake_data.deps
+    tools_deps = ctx.attr.tools_deps + cmake_data.deps + make_data.deps
 
     ninja_data = get_ninja_data(ctx)
     make_commands = ctx.attr.make_commands
@@ -40,6 +47,7 @@ def _cmake_external(ctx):
         tools_deps = tools_deps,
         cmake_path = cmake_data.path,
         ninja_path = ninja_data.path,
+        make_path = make_data.path,
         make_commands = make_commands,
     )
 
@@ -133,6 +141,7 @@ cmake_external = rule(
     toolchains = [
         "@rules_foreign_cc//tools/build_defs:cmake_toolchain",
         "@rules_foreign_cc//tools/build_defs:ninja_toolchain",
+        "@rules_foreign_cc//tools/build_defs:make_toolchain",
         "@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains:shell_commands",
         "@bazel_tools//tools/cpp:toolchain_type",
     ],

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -236,6 +236,13 @@ def cc_external_rule_impl(ctx, attrs):
         "export INSTALLDIR=$$EXT_BUILD_ROOT$$/" + empty.file.dirname + "/" + lib_name,
     ]
 
+    make_commands = []
+    for line in attrs.make_commands:
+        if line == "make" or line.startswith("make "):
+            make_commands.append(line.replace("make", attrs.make_path, 1))
+        else:
+            make_commands.append(line)
+
     script_lines = [
         "##echo## \"\"",
         "##echo## \"{}\"".format(version_and_lib),
@@ -248,7 +255,7 @@ def cc_external_rule_impl(ctx, attrs):
         "\n".join(_copy_deps_and_tools(inputs)),
         "cd $$BUILD_TMPDIR$$",
         attrs.create_configure_script(ConfigureParameters(ctx = ctx, attrs = attrs, inputs = inputs)),
-        "\n".join(attrs.make_commands),
+        "\n".join(make_commands),
         attrs.postfix_script or "",
         # replace references to the root directory when building ($BUILD_TMPDIR)
         # and the root where the dependencies were installed ($EXT_BUILD_DEPS)

--- a/tools/build_defs/make.bzl
+++ b/tools/build_defs/make.bzl
@@ -14,12 +14,19 @@ load(
     "get_tools_info",
 )
 load(":configure_script.bzl", "create_make_script")
+load("//tools/build_defs/native_tools:tool_access.bzl", "get_make_data")
 
 def _make(ctx):
+    make_data = get_make_data(ctx)
+
+    tools_deps = ctx.attr.tools_deps + make_data.deps
+
     attrs = create_attrs(
         ctx.attr,
         configure_name = "GNUMake",
         create_configure_script = _create_make_script,
+        tools_deps = tools_deps,
+        make_path = make_data.path,
         make_commands = [],
     )
     return cc_external_rule_impl(ctx, attrs)
@@ -35,10 +42,12 @@ def _create_make_script(configureParameters):
     flags = get_flags_info(ctx)
 
     make_commands = ctx.attr.make_commands or [
-        "make {keep_going} -C $$EXT_BUILD_ROOT$$/{root}".format(
+        "{make} {keep_going} -C $$EXT_BUILD_ROOT$$/{root}".format(
+            make=configureParameters.attrs.make_path,
             keep_going="-k" if ctx.attr.keep_going else "",
             root=root),
-        "make -C $$EXT_BUILD_ROOT$$/{root} install PREFIX={prefix}".format(
+        "{make} -C $$EXT_BUILD_ROOT$$/{root} install PREFIX={prefix}".format(
+            make=configureParameters.attrs.make_path,
             root=root,
             prefix=install_prefix),
     ]
@@ -98,6 +107,7 @@ make = rule(
     output_to_genfiles = True,
     implementation = _make,
     toolchains = [
+        "@rules_foreign_cc//tools/build_defs:make_toolchain",
         "@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains:shell_commands",
         "@bazel_tools//tools/cpp:toolchain_type",
     ],

--- a/tools/build_defs/make.bzl
+++ b/tools/build_defs/make.bzl
@@ -35,8 +35,12 @@ def _create_make_script(configureParameters):
     flags = get_flags_info(ctx)
 
     make_commands = ctx.attr.make_commands or [
-        "make %s -C $$EXT_BUILD_ROOT$$/%s" % ("-k" if ctx.attr.keep_going else "", root),
-        "make -C $$EXT_BUILD_ROOT$$/%s install PREFIX=%s" % (root, install_prefix),
+        "make {keep_going} -C $$EXT_BUILD_ROOT$$/{root}".format(
+            keep_going="-k" if ctx.attr.keep_going else "",
+            root=root),
+        "make -C $$EXT_BUILD_ROOT$$/{root} install PREFIX={prefix}".format(
+            root=root,
+            prefix=install_prefix),
     ]
 
     return create_make_script(

--- a/tools/build_defs/native_tools/BUILD
+++ b/tools/build_defs/native_tools/BUILD
@@ -1,6 +1,25 @@
 load(":native_tools_toolchain.bzl", "native_tool_toolchain")
+load("//for_workspace:make_build.bzl", "make_tool")
 load("//for_workspace:cmake_build.bzl", "cmake_tool")
 load("//for_workspace:ninja_build.bzl", "ninja_tool")
+
+native_tool_toolchain(
+    name = "preinstalled_make",
+    path = "make",
+    visibility = ["//visibility:public"],
+)
+
+make_tool(
+    name = "make_tool",
+    make_srcs = "@make//:all",
+)
+
+native_tool_toolchain(
+    name = "built_make",
+    path = "make/bin/make",
+    target = ":make_tool",
+    visibility = ["//visibility:public"],
+)
 
 native_tool_toolchain(
     name = "preinstalled_cmake",
@@ -35,11 +54,5 @@ native_tool_toolchain(
     name = "built_ninja",
     path = "ninja/ninja",
     target = ":ninja_tool",
-    visibility = ["//visibility:public"],
-)
-
-native_tool_toolchain(
-    name = "preinstalled_make",
-    path = "make",
     visibility = ["//visibility:public"],
 )

--- a/tools/build_defs/native_tools/BUILD
+++ b/tools/build_defs/native_tools/BUILD
@@ -37,3 +37,9 @@ native_tool_toolchain(
     target = ":ninja_tool",
     visibility = ["//visibility:public"],
 )
+
+native_tool_toolchain(
+    name = "preinstalled_make",
+    path = "make",
+    visibility = ["//visibility:public"],
+)

--- a/tools/build_defs/native_tools/tool_access.bzl
+++ b/tools/build_defs/native_tools/tool_access.bzl
@@ -6,6 +6,9 @@ def get_cmake_data(ctx):
 def get_ninja_data(ctx):
     return _access_and_expect_label_copied("@rules_foreign_cc//tools/build_defs:ninja_toolchain", ctx, "ninja")
 
+def get_make_data(ctx):
+    return _access_and_expect_label_copied("@rules_foreign_cc//tools/build_defs:make_toolchain", ctx, "make")
+
 def _access_and_expect_label_copied(toolchain_type_, ctx, tool_name):
     tool_data = access_tool(toolchain_type_, ctx, tool_name)
     if tool_data.target:

--- a/workspace_definitions.bzl
+++ b/workspace_definitions.bzl
@@ -98,4 +98,5 @@ def rules_foreign_cc_dependencies(
         native.register_toolchains(
             "@rules_foreign_cc//tools/build_defs:preinstalled_cmake_toolchain",
             "@rules_foreign_cc//tools/build_defs:preinstalled_ninja_toolchain",
+            "@rules_foreign_cc//tools/build_defs:preinstalled_make_toolchain",
         )


### PR DESCRIPTION
This change adds a new toolchain type, `make_toolchain`. I have also added an implementation that uses the pre-installed toolchain (no shipped `make` yet, will add that shortly too.)

The goal is to use the `make` binary path provided by the toolchain. This way, one can configure a custom toolchain that, for example, runs `emmake make` instead of `make`, to target Emscripten. (At least this is my use case). Another use case is to use a vendored Make, instead of relying on the system `make` binary in the execution environment.

TODO:

- [x] Add a bootstrap rule for vendored `make`, just like the one for `cmake` and `ninja`.

Fixes #372.