### PR TITLE
Add make_env_vars for make call as well

### DIFF
--- a/tools/build_defs/configure_script.bzl
+++ b/tools/build_defs/configure_script.bzl
@@ -48,7 +48,7 @@ def create_make_script(
         make_commands,
         prefix):
     env_vars_string = get_env_vars(workspace_name, tools, flags, user_vars, deps, inputs)
-    script = []
+    script = [env_vars_string]
     for ext_dir in inputs.ext_build_dirs:
         script += ["##increment_pkg_config_path## $$EXT_BUILD_ROOT$$/" + ext_dir.path]
 


### PR DESCRIPTION
`env_vars_string` already used in `create_configure_script`, but in `create_make_script` function `env_vars_string` variable exists, but unused.

And overall I guess it's correct approach to pass env variables to make command as well so users can configure it's behaviour.

Use case and test example is rocksdb
```
make(
    name = "rocksdb",
    lib_source = "@rocksdb//:all",
    # Current workaround is to override make_commands and pass env variables directly
    make_commands = ["ROCKSDB_DISABLE_ZLIB=1 ROCKSDB_DISABLE_BZIP=1 make -j 6 static_lib",
                     "cp librocksdb.a $$INSTALLDIR$$/lib/librocksdb.a",
                     "cp -RL include $$INSTALLDIR$$",
    ],
    # Issue is that following env not set for make command
    make_env_vars = {
        "ROCKSDB_DISABLE_ZLIB": "1",
        "ROCKSDB_DISABLE_BZIP": "1",
    },
    static_libraries = ["librocksdb.a"],
)
```