### PR TITLE
Add sha256 to CMake archive

### DIFF
--- a/for_workspace/repositories.bzl
+++ b/for_workspace/repositories.bzl
@@ -27,6 +27,7 @@ def repositories():
     http_archive(
         name = "cmake",
         build_file_content = _all_content,
+        sha256 = "019aa2afdf650d27bd70407e0a8183ce2f3fce0429e82d1ced234aed942c9a0b",
         strip_prefix = "CMake-3.12.1",
         urls = [
             "https://github.com/Kitware/CMake/archive/v3.12.1.tar.gz",


### PR DESCRIPTION
In order to have reproducible builds, we want assurance that the CMake archive downloaded
is the one that is intended. Add the expected sha256 value to achieve this goal.

'bazel sync' will no longer complain about a missing hash value.