### PR TITLE
Allow to specify working directory for cmake_external

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,9 @@ attrs: {
     # cache_entries - the rule makes only a poor guess about the target system,
     # it is better to specify it manually.
     "generate_crosstool_file": attr.bool(mandatory = False, default = False),
+    # Working directory, with the main CMakeLists.txt
+    # (otherwise, the top directory of the lib_source label files is used.)
+    "working_directory": attr.string(mandatory = False, default = ""),
     #
     # From framework.bzl:
     # 

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -31,6 +31,7 @@ test_suite(
         "//simple_make:test_lib",
         "//cmake_hello_world_variant:test_hello_world",
         "//cmake_synthetic:test_bazel_transitive_deps",
+        "//cmake_working_dir:test_lib",
     ],
 )
 

--- a/examples/cmake_working_dir/BUILD
+++ b/examples/cmake_working_dir/BUILD
@@ -1,0 +1,24 @@
+load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+
+filegroup(
+    name = "sources",
+    srcs = glob(["source_root/**"], exclude_directories = 0),
+)
+
+cmake_external(
+    name = "liba",
+    lib_source = ":sources",
+    # This demonstrates the usage of the working directory:
+    # the directory where the "main" CMakeLists.txt file resides.
+    working_directory = "cmake_dir",
+)
+
+cc_test(
+    name = "test_lib",
+    srcs = [
+        "test_liba.cpp",
+    ],
+    deps = [
+        ":liba",
+    ],
+)

--- a/examples/cmake_working_dir/source_root/cmake_dir/CMakeLists.txt
+++ b/examples/cmake_working_dir/source_root/cmake_dir/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 2.8.4)
+
+project(liba)
+
+set(LIBA_SRC ../src/liba.cpp ../src/liba.h)
+
+add_library(liba_static STATIC ${LIBA_SRC})
+
+set_target_properties(liba_static PROPERTIES OUTPUT_NAME "liba")
+IF (WIN32)
+  set_target_properties(liba_static PROPERTIES ARCHIVE_OUTPUT_NAME "liba")
+ELSE()
+  set_target_properties(liba_static PROPERTIES ARCHIVE_OUTPUT_NAME "a")
+ENDIF()
+set_target_properties(liba_static PROPERTIES PUBLIC_HEADER "../src/liba.h")
+
+set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
+
+install(FILES ../src/liba.h DESTINATION include)
+
+install(TARGETS liba_static
+  EXPORT liba_targets
+  ARCHIVE DESTINATION lib
+  INCLUDES DESTINATION include
+  PUBLIC_HEADER DESTINATION include
+  )
+target_include_directories(liba_static INTERFACE
+    $<INSTALL_INTERFACE:include>
+)
+
+install(EXPORT liba_targets
+  DESTINATION lib/cmake/liba
+  FILE liba-config.cmake)

--- a/examples/cmake_working_dir/source_root/src/liba.cpp
+++ b/examples/cmake_working_dir/source_root/src/liba.cpp
@@ -1,0 +1,5 @@
+#include "liba.h"
+
+std::string hello_liba(void) {
+	return "Hello from LIBA!";
+}

--- a/examples/cmake_working_dir/source_root/src/liba.cpp
+++ b/examples/cmake_working_dir/source_root/src/liba.cpp
@@ -1,5 +1,5 @@
 #include "liba.h"
 
 std::string hello_liba(void) {
-	return "Hello from LIBA!";
+  return "Hello from LIBA!";
 }

--- a/examples/cmake_working_dir/source_root/src/liba.h
+++ b/examples/cmake_working_dir/source_root/src/liba.h
@@ -1,0 +1,9 @@
+#ifndef LIBA_H_
+#define LIBA_H_ (1)
+
+#include <stdio.h>
+#include <string>
+
+std::string hello_liba(void);
+
+#endif

--- a/examples/cmake_working_dir/test_liba.cpp
+++ b/examples/cmake_working_dir/test_liba.cpp
@@ -1,0 +1,13 @@
+#include "liba.h"
+
+#include <iostream>
+#include <string>
+
+int main(int argc, char* argv[])
+{
+  std:: string result = hello_liba();
+  if (result != "Hello from LIBA!") {
+    throw std::runtime_error("Wrong result: " + result);
+  }
+  std::cout << "Everything's fine!";
+}

--- a/tools/build_defs/cmake.bzl
+++ b/tools/build_defs/cmake.bzl
@@ -58,6 +58,8 @@ def _create_configure_script(configureParameters):
     inputs = configureParameters.inputs
 
     root = detect_root(ctx.attr.lib_source)
+    if len(ctx.attr.working_directory) > 0:
+        root = root + "/" + ctx.attr.working_directory
 
     tools = get_tools_info(ctx)
     # CMake will replace <TARGET> with the actual output file
@@ -112,6 +114,9 @@ def _attrs():
         # cache_entries - the rule makes only a poor guess about the target system,
         # it is better to specify it manually.
         "generate_crosstool_file": attr.bool(mandatory = False, default = False),
+        # Working directory, with the main CMakeLists.txt
+        # (otherwise, the top directory of the lib_source label files is used.)
+        "working_directory": attr.string(mandatory = False, default = ""),
     })
     return attrs
 

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -588,10 +588,29 @@ def _define_inputs(attrs):
         deps_compilation_info = cc_info_merged.compilation_context,
         deps_linking_info = cc_info_merged.linking_context,
         ext_build_dirs = ext_build_dirs,
-        declared_inputs = attrs.lib_source.files.to_list() + bazel_libs + tools_files +
-                          attrs.additional_inputs +
-                          cc_info_merged.compilation_context.headers.to_list() + ext_build_dirs,
+        declared_inputs = filter_containing_dirs_from_inputs(attrs.lib_source.files.to_list())
+            + bazel_libs
+            + tools_files
+            + attrs.additional_inputs
+            + cc_info_merged.compilation_context.headers.to_list()
+            + ext_build_dirs,
     )
+
+"""When the directories are also passed in the filegroup with the sources,
+we get into a situation when we have containing in the sources list,
+which is not allowed by Bazel (execroot creation code fails).
+The parent directories will be created for us in the execroot anyway,
+so we filter them out."""
+def filter_containing_dirs_from_inputs(input_files_list):
+    # This puts directories in front of their children in list
+    sorted_list = sorted(input_files_list)
+    contains_map = {}
+    for input in input_files_list:
+        # If the immediate parent directory is already in the list, remove it
+        if contains_map.get(input.dirname):
+            contains_map.pop(input.dirname)
+        contains_map[input.path] = input
+    return contains_map.values()
 
 def uniq_list_keep_order(list):
     result = []


### PR DESCRIPTION
For LLVM case, when main CMakeLists.txt is in the /llvm subdirectory in the source tree