### PR TITLE
Fix Buildifier warnings

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,12 +25,13 @@ android_ndk_repository(
 
 # TODO(jin): replace legacy gmaven_rules targets with `maven_install` from the new rules_jvm_external
 RULES_JVM_EXTERNAL_TAG = "1.0"
+
 RULES_JVM_EXTERNAL_SHA = "48e0f1aab74fabba98feb8825459ef08dcc75618d381dff63ec9d4dd9860deaa"
 
 http_archive(
     name = "gmaven_rules",
-    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
     sha256 = RULES_JVM_EXTERNAL_SHA,
+    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
     url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
 )
 

--- a/examples/apache_httpd/BUILD
+++ b/examples/apache_httpd/BUILD
@@ -3,30 +3,33 @@ load("@rules_foreign_cc//tools/build_defs:configure.bzl", "configure_make")
 configure_make(
     name = "apr",
     lib_source = "@apr//:all",
-    static_libraries = ["libapr-1.a"],
     shared_libraries = ["libapr-1.so"],
+    static_libraries = ["libapr-1.a"],
 )
 
 configure_make(
     name = "apr_util",
-    lib_source = "@apr_util//:all",
-    deps = [":apr"],
     configure_options = [
         "--with-apr=$$EXT_BUILD_DEPS$$/apr",
-        ],
-    static_libraries = ["libaprutil-1.a"],
+    ],
+    lib_source = "@apr_util//:all",
     shared_libraries = ["libaprutil-1.so"],
+    static_libraries = ["libaprutil-1.a"],
+    deps = [":apr"],
 )
 
 configure_make(
     name = "pcre",
     lib_source = "@pcre//:all",
-    static_libraries = ["libpcre.a"],
     shared_libraries = ["libpcre.so.1"],
+    static_libraries = ["libpcre.a"],
 )
 
 configure_make(
     name = "apache_httpd",
+    binaries = [
+        "httpd",
+    ],
     configure_options = [
         "--with-apr=$$EXT_BUILD_DEPS$$/apr",
         "--with-apr-util=$$EXT_BUILD_DEPS$$/apr_util",
@@ -34,17 +37,14 @@ configure_make(
         "CFLAGS='-Dredacted=\"redacted\"'",
     ],
     lib_source = "@apache_httpd//:all",
-    binaries = [
-        "httpd",
+    visibility = [
+        "//visibility:public",
     ],
     deps = [
         ":apr",
         ":apr_util",
         ":pcre",
     ],
-    visibility = [
-        "//visibility:public"
-        ],
 )
 
 filegroup(
@@ -52,7 +52,7 @@ filegroup(
     srcs = [
         ":apache_httpd",
     ],
-    output_group = "gen_dir"
+    output_group = "gen_dir",
 )
 
 filegroup(
@@ -60,7 +60,7 @@ filegroup(
     srcs = [
         ":pcre",
     ],
-    output_group = "gen_dir"
+    output_group = "gen_dir",
 )
 
 filegroup(
@@ -68,7 +68,7 @@ filegroup(
     srcs = [
         ":apr",
     ],
-    output_group = "gen_dir"
+    output_group = "gen_dir",
 )
 
 filegroup(
@@ -76,7 +76,7 @@ filegroup(
     srcs = [
         ":apr_util",
     ],
-    output_group = "gen_dir"
+    output_group = "gen_dir",
 )
 
 sh_test(
@@ -86,9 +86,9 @@ sh_test(
     ],
     args = ["$(location httpd_dir)/bin/httpd $(location pcre_dir)/lib $(location apr_dir)/lib $(location apr_util_dir)/lib"],
     data = [
-        ":httpd_dir",
         ":apr_dir",
         ":apr_util_dir",
+        ":httpd_dir",
         ":pcre_dir",
     ],
 )

--- a/examples/boost/BUILD
+++ b/examples/boost/BUILD
@@ -2,10 +2,10 @@ load("@rules_foreign_cc//tools/build_defs:boost_build.bzl", "boost_build")
 
 boost_build(
     name = "boost_regex",
+    bootstrap_options = ["--with-toolchain=clang"],
     lib_source = "@boost//:all",
     shared_libraries = ["libboost_regex.so.1.68.0"],
     static_libraries = ["libboost_regex.a"],
-    bootstrap_options = ["--with-toolchain=clang"],
     user_options = ["--with-regex"],
 )
 

--- a/examples/cc_configure_make/BUILD
+++ b/examples/cc_configure_make/BUILD
@@ -2,13 +2,6 @@ load("@rules_foreign_cc//tools/build_defs:configure.bzl", "configure_make")
 
 configure_make(
     name = "libevent",
-    configure_options = [
-        "--enable-shared=no",
-        "--disable-libevent-regress",
-        "--disable-openssl",
-    ],
-    lib_source = "@libevent//:all",
-    out_lib_dir = "lib",
     # libevent script uses it's own libtool for linking;
     # so do not specify linker tool for it
     # (otherwise, if the libtool from bazel's toolchain is supplied,
@@ -17,6 +10,13 @@ configure_make(
     configure_env_vars = {
         "AR": "",
     },
+    configure_options = [
+        "--enable-shared=no",
+        "--disable-libevent-regress",
+        "--disable-openssl",
+    ],
+    lib_source = "@libevent//:all",
+    out_lib_dir = "lib",
 )
 
 cc_test(

--- a/examples/cmake_crosstool/BUILD
+++ b/examples/cmake_crosstool/BUILD
@@ -13,10 +13,10 @@ cc_library(
 
 cmake_external(
     name = "hello_cmake",
-    lib_source = "//static:srcs",
     generate_crosstool_file = True,
-    static_libraries = ["libhello.a"],
+    lib_source = "//static:srcs",
     out_include_dir = "include/version123",
+    static_libraries = ["libhello.a"],
 )
 
 # I do not make it a test, since it is a cross-compilation example,

--- a/examples/cmake_crosstool/static/BUILD
+++ b/examples/cmake_crosstool/static/BUILD
@@ -1,6 +1,8 @@
 # example code is taken from https://github.com/Akagi201/learning-cmake/tree/master/hello-world-lib
 # for test only
 
+load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),
@@ -10,8 +12,6 @@ filegroup(
 exports_files([
     "hello_client.c",
 ])
-
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 
 cmake_external(
     name = "libhello",

--- a/examples/cmake_crosstool/static/BUILD
+++ b/examples/cmake_crosstool/static/BUILD
@@ -8,7 +8,7 @@ filegroup(
 )
 
 exports_files([
-    "hello_client.c"
+    "hello_client.c",
 ])
 
 load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")

--- a/examples/cmake_crosstool/tools/arm_compiler/BUILD
+++ b/examples/cmake_crosstool/tools/arm_compiler/BUILD
@@ -72,7 +72,6 @@ filegroup(
 
 cc_toolchain(
     name = "cc-compiler-armeabi-v7a",
-    toolchain_identifier = "armeabi-v7a",
     all_files = ":linaro_linux_all_files",
     ar_files = "//tools/arm_compiler/linaro_linux_gcc:ar",
     as_files = "//tools/arm_compiler/linaro_linux_gcc:as",
@@ -85,12 +84,12 @@ cc_toolchain(
     static_runtime_libs = [":empty"],
     strip_files = "//tools/arm_compiler/linaro_linux_gcc:strip",
     supports_param_files = 1,
+    toolchain_identifier = "armeabi-v7a",
     visibility = ["//visibility:public"],
 )
 
 cc_toolchain(
     name = "cc-compiler-k8",
-    toolchain_identifier = "local",
     all_files = ":empty",
     ar_files = ":empty",
     as_files = ":empty",
@@ -103,5 +102,6 @@ cc_toolchain(
     static_runtime_libs = [":empty"],
     strip_files = ":empty",
     supports_param_files = 1,
+    toolchain_identifier = "local",
     visibility = ["//visibility:public"],
 )

--- a/examples/cmake_hello_world_lib/binary/BUILD
+++ b/examples/cmake_hello_world_lib/binary/BUILD
@@ -1,14 +1,13 @@
 # example code is taken from https://github.com/Akagi201/learning-cmake/tree/master/hello-world-lib
 # for test only
 load("@bazel_tools//tools/build_rules:test_rules.bzl", "file_test")
+load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),
     visibility = ["//visibility:public"],
 )
-
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 
 cmake_external(
     name = "libhello",

--- a/examples/cmake_hello_world_lib/shared/BUILD
+++ b/examples/cmake_hello_world_lib/shared/BUILD
@@ -1,13 +1,13 @@
 # example code is taken from https://github.com/Akagi201/learning-cmake/tree/master/hello-world-lib
 # for test only
 
+load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),
     visibility = ["//visibility:public"],
 )
-
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 
 cmake_external(
     name = "libhello",

--- a/examples/cmake_hello_world_lib/static/BUILD
+++ b/examples/cmake_hello_world_lib/static/BUILD
@@ -1,13 +1,13 @@
 # example code is taken from https://github.com/Akagi201/learning-cmake/tree/master/hello-world-lib
 # for test only
 
+load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),
     visibility = ["//visibility:public"],
 )
-
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 
 cmake_external(
     name = "libhello",

--- a/examples/cmake_hello_world_lib/static/BUILD
+++ b/examples/cmake_hello_world_lib/static/BUILD
@@ -91,9 +91,9 @@ sh_test(
     srcs = ["test_hello.sh"],
     args = ["$(location libhello_example)"],
     data = [":libhello_example"],
-    deps = ["@bazel_tools//tools/bash/runfiles"],
     tags = ["windows"],
     visibility = ["//:__pkg__"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
 sh_test(
@@ -101,9 +101,9 @@ sh_test(
     srcs = ["test_hello.sh"],
     args = ["$(location libhello_example_ninja)"],
     data = [":libhello_example_ninja"],
-    deps = ["@bazel_tools//tools/bash/runfiles"],
     tags = ["windows"],
     visibility = ["//:__pkg__"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
 sh_test(
@@ -111,9 +111,9 @@ sh_test(
     srcs = ["test_hello.sh"],
     args = ["$(location libhello_example_nmake)"],
     data = [":libhello_example_nmake"],
-    deps = ["@bazel_tools//tools/bash/runfiles"],
     tags = ["windows"],
     visibility = ["//:__pkg__"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
 cmake_external(

--- a/examples/cmake_synthetic/BUILD
+++ b/examples/cmake_synthetic/BUILD
@@ -34,19 +34,22 @@ cmake_external(
 
 cmake_external(
     name = "lib_with_duplicate_transitive_bazel_deps",
-    lib_name = "libc",
-    cmake_options = ["-GNinja"],
     cache_entries = {
         "LIBA_DIR": "$$EXT_BUILD_DEPS$$",
         "LIBB_DIR": "$$EXT_BUILD_DEPS$$",
     },
+    cmake_options = ["-GNinja"],
     generate_crosstool_file = generate_crosstool,
+    lib_name = "libc",
     lib_source = "//cmake_synthetic/libc:c_srcs",
     make_commands = [
         "ninja",
         "ninja install",
     ],
-    deps = ["//cmake_synthetic/liba:lib_a_bazel", "//cmake_synthetic/libb:lib_b_bazel"],
+    deps = [
+        "//cmake_synthetic/liba:lib_a_bazel",
+        "//cmake_synthetic/libb:lib_b_bazel",
+    ],
 )
 
 build_test(

--- a/examples/cmake_working_dir/BUILD
+++ b/examples/cmake_working_dir/BUILD
@@ -2,7 +2,10 @@ load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 
 filegroup(
     name = "sources",
-    srcs = glob(["source_root/**"], exclude_directories = 0),
+    srcs = glob(
+        ["source_root/**"],
+        exclude_directories = 0,
+    ),
 )
 
 cmake_external(

--- a/examples/examples_repositories.bzl
+++ b/examples/examples_repositories.bzl
@@ -82,7 +82,7 @@ def include_examples_repositories():
         name = "nghttp2",
         build_file_content = all_content,
         patch_args = ["-p1"],
-        patch_cmds = ["find . -name '*.sh' -exec sed -i.orig '1s|#!/usr/bin/env sh\$|/bin/sh\$|' {} +"],
+        patch_cmds = ["find . -name '*.sh' -exec sed -i.orig '1s|#!/usr/bin/env sh\\$|/bin/sh\\$|' {} +"],
         patches = ["@rules_foreign_cc_tests//:nghttp2.patch"],
         strip_prefix = "nghttp2-e5b3f9addd49bca27e2f99c5c65a564eb5c0cf6d",
         urls = [

--- a/for_workspace/install_ws_dependency.bzl
+++ b/for_workspace/install_ws_dependency.bzl
@@ -7,10 +7,12 @@ def _generate_install_rule_impl(rctx):
     text = """workspace(name='{ws_name}')
 load("{init_file}", "{init_function}")
 {init_expression}
-""".format(ws_name = rctx.attr.name,
- init_file = rctx.attr.init_file,
-  init_function = rctx.attr.init_function,
-  init_expression = rctx.attr.init_expression)
+""".format(
+        ws_name = rctx.attr.name,
+        init_file = rctx.attr.init_file,
+        init_function = rctx.attr.init_function,
+        init_expression = rctx.attr.init_expression,
+    )
 
     rctx.file("WORKSPACE", text)
     rctx.file("BUILD", "")
@@ -35,5 +37,5 @@ def install_ws_dependency(repo_name, url, strip_prefix, init_file, init_function
         stripPrefix = strip_prefix,
         init_file = init_file,
         init_function = init_function,
-        init_expression = init_expression
+        init_expression = init_expression,
     )

--- a/test/cmake_text_tests.bzl
+++ b/test/cmake_text_tests.bzl
@@ -131,10 +131,16 @@ def _move_dict_values_test(ctx):
         "CMAKE_CXX_LINK_EXECUTABLE": "became",
         "CUSTOM": "YES",
     }
-    export_for_test.move_dict_values(target, source_env,
-    export_for_test.CMAKE_ENV_VARS_FOR_CROSSTOOL)
-    export_for_test.move_dict_values(target, source_cache,
-    export_for_test.CMAKE_CACHE_ENTRIES_CROSSTOOL)
+    export_for_test.move_dict_values(
+        target,
+        source_env,
+        export_for_test.CMAKE_ENV_VARS_FOR_CROSSTOOL,
+    )
+    export_for_test.move_dict_values(
+        target,
+        source_cache,
+        export_for_test.CMAKE_CACHE_ENTRIES_CROSSTOOL,
+    )
 
     expected_target = {
         "CMAKE_C_COMPILER": "sink-cc-value",
@@ -164,10 +170,14 @@ def _reverse_descriptor_dict_test(ctx):
         "CMAKE_C_FLAGS_INIT": struct(value = "CMAKE_C_FLAGS", replace = False),
         "CMAKE_CXX_FLAGS_INIT": struct(value = "CMAKE_CXX_FLAGS", replace = False),
         "CMAKE_ASM_FLAGS_INIT": struct(value = "CMAKE_ASM_FLAGS", replace = False),
-        "CMAKE_STATIC_LINKER_FLAGS_INIT": struct(value = "CMAKE_STATIC_LINKER_FLAGS",
-                                                 replace = False),
-        "CMAKE_SHARED_LINKER_FLAGS_INIT": struct(value = "CMAKE_SHARED_LINKER_FLAGS",
-                                                 replace = False),
+        "CMAKE_STATIC_LINKER_FLAGS_INIT": struct(
+            value = "CMAKE_STATIC_LINKER_FLAGS",
+            replace = False,
+        ),
+        "CMAKE_SHARED_LINKER_FLAGS_INIT": struct(
+            value = "CMAKE_SHARED_LINKER_FLAGS",
+            replace = False,
+        ),
         "CMAKE_EXE_LINKER_FLAGS_INIT": struct(value = "CMAKE_EXE_LINKER_FLAGS", replace = False),
     }
 
@@ -193,8 +203,11 @@ def _merge_toolchain_and_user_values_test(ctx):
         "CUSTOM": "YES",
     }
 
-    res = export_for_test.merge_toolchain_and_user_values(target, source_cache,
-    export_for_test.CMAKE_CACHE_ENTRIES_CROSSTOOL)
+    res = export_for_test.merge_toolchain_and_user_values(
+        target,
+        source_cache,
+        export_for_test.CMAKE_CACHE_ENTRIES_CROSSTOOL,
+    )
 
     expected_target = {
         "CMAKE_C_FLAGS": "-cc-flag -gcc_toolchain cc-toolchain --additional-flag",
@@ -232,8 +245,19 @@ def _merge_flag_values_no_toolchain_file_test(ctx):
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
     }
 
-    script = create_cmake_script("ws", "linux", "cmake", tools, flags, "test_rule",
-                                 "external/test_rule", True, user_cache, user_env, [])
+    script = create_cmake_script(
+        "ws",
+        "linux",
+        "cmake",
+        tools,
+        flags,
+        "test_rule",
+        "external/test_rule",
+        True,
+        user_cache,
+        user_env,
+        [],
+    )
     expected = """CC=\"/usr/bin/gcc\" CXX=\"/usr/bin/gcc\" CXXFLAGS=\"foo=\\\"bar\\\" -Fbat" cmake -DCMAKE_AR=\"/usr/bin/ar\" -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DCMAKE_PREFIX_PATH=\"$EXT_BUILD_DEPS\" -DCMAKE_INSTALL_PREFIX=\"test_rule\" -DCMAKE_RANLIB=\"\"  $EXT_BUILD_ROOT/external/test_rule"""
     asserts.equals(env, expected, script)
 
@@ -262,8 +286,19 @@ def _create_min_cmake_script_no_toolchain_file_test(ctx):
         "CMAKE_PREFIX_PATH": "/abc/def",
     }
 
-    script = create_cmake_script("ws", "linux", "cmake", tools, flags, "test_rule",
-                                 "external/test_rule", True, user_cache, user_env, ["-GNinja"])
+    script = create_cmake_script(
+        "ws",
+        "linux",
+        "cmake",
+        tools,
+        flags,
+        "test_rule",
+        "external/test_rule",
+        True,
+        user_cache,
+        user_env,
+        ["-GNinja"],
+    )
     expected = "CC=\"/usr/bin/gcc\" CXX=\"/usr/bin/gcc\" CFLAGS=\"-U_FORTIFY_SOURCE -fstack-protector -Wall\" CXXFLAGS=\"-U_FORTIFY_SOURCE -fstack-protector -Wall\" ASMFLAGS=\"-U_FORTIFY_SOURCE -fstack-protector -Wall\" cmake -DCMAKE_AR=\"/usr/bin/ar\" -DCMAKE_SHARED_LINKER_FLAGS=\"-shared -fuse-ld=gold\" -DCMAKE_EXE_LINKER_FLAGS=\"-fuse-ld=gold -Wl -no-as-needed\" -DNOFORTRAN=\"on\" -DCMAKE_PREFIX_PATH=\"$EXT_BUILD_DEPS;/abc/def\" -DCMAKE_INSTALL_PREFIX=\"test_rule\" -DCMAKE_BUILD_TYPE=\"Debug\" -DCMAKE_RANLIB=\"\" -GNinja $EXT_BUILD_ROOT/external/test_rule"
     asserts.equals(env, expected, script)
 
@@ -295,8 +330,19 @@ def _create_min_cmake_script_wipe_toolchain_test(ctx):
         "WIPE_ME_IF_PRESENT": "",
     }
 
-    script = create_cmake_script("ws", "linux", "cmake", tools, flags, "test_rule",
-                                 "external/test_rule", True, user_cache, user_env, ["-GNinja"])
+    script = create_cmake_script(
+        "ws",
+        "linux",
+        "cmake",
+        tools,
+        flags,
+        "test_rule",
+        "external/test_rule",
+        True,
+        user_cache,
+        user_env,
+        ["-GNinja"],
+    )
     expected = "CC=\"/usr/bin/gcc\" CXX=\"/usr/bin/gcc\" CFLAGS=\"-U_FORTIFY_SOURCE -fstack-protector -Wall\" CXXFLAGS=\"-U_FORTIFY_SOURCE -fstack-protector -Wall\" ASMFLAGS=\"-U_FORTIFY_SOURCE -fstack-protector -Wall\" cmake -DCMAKE_AR=\"/usr/bin/ar\" -DCMAKE_EXE_LINKER_FLAGS=\"-fuse-ld=gold -Wl -no-as-needed\" -DCMAKE_PREFIX_PATH=\"$EXT_BUILD_DEPS;/abc/def\" -DCMAKE_INSTALL_PREFIX=\"test_rule\" -DCMAKE_BUILD_TYPE=\"Debug\" -DCMAKE_RANLIB=\"\" -GNinja $EXT_BUILD_ROOT/external/test_rule"
     asserts.equals(env, expected, script)
 
@@ -324,8 +370,19 @@ def _create_min_cmake_script_toolchain_file_test(ctx):
         "NOFORTRAN": "on",
     }
 
-    script = create_cmake_script("ws", "linux", "cmake", tools, flags, "test_rule",
-                                 "external/test_rule", False, user_cache, user_env, ["-GNinja"])
+    script = create_cmake_script(
+        "ws",
+        "linux",
+        "cmake",
+        tools,
+        flags,
+        "test_rule",
+        "external/test_rule",
+        False,
+        user_cache,
+        user_env,
+        ["-GNinja"],
+    )
     expected = """cat > crosstool_bazel.cmake <<EOF
 set(CMAKE_SYSTEM_NAME "Linux")
 set(CMAKE_C_COMPILER "/usr/bin/gcc")
@@ -354,8 +411,12 @@ def _create_cmake_script_no_toolchain_file_test(ctx):
     )
     flags = CxxFlagsInfo(
         cc = ["-cc-flag", "-gcc_toolchain", "cc-toolchain"],
-        cxx = ["--quoted=\"abc def\"", "--sysroot=/abc/sysroot", "--gcc_toolchain",
-               "cxx-toolchain"],
+        cxx = [
+            "--quoted=\"abc def\"",
+            "--sysroot=/abc/sysroot",
+            "--gcc_toolchain",
+            "cxx-toolchain",
+        ],
         cxx_linker_shared = ["shared1", "shared2"],
         cxx_linker_static = ["static"],
         cxx_linker_executable = ["executable"],
@@ -375,8 +436,19 @@ def _create_cmake_script_no_toolchain_file_test(ctx):
         "CMAKE_BUILD_TYPE": "user_type",
     }
 
-    script = create_cmake_script("ws", "linux", "cmake", tools, flags, "test_rule",
-                                 "external/test_rule", True, user_cache, user_env, ["-GNinja"])
+    script = create_cmake_script(
+        "ws",
+        "linux",
+        "cmake",
+        tools,
+        flags,
+        "test_rule",
+        "external/test_rule",
+        True,
+        user_cache,
+        user_env,
+        ["-GNinja"],
+    )
     expected = "CC=\"sink-cc-value\" CXX=\"sink-cxx-value\" CFLAGS=\"-cc-flag -gcc_toolchain cc-toolchain --from-env --additional-flag\" CXXFLAGS=\"--quoted=\\\"abc def\\\" --sysroot=/abc/sysroot --gcc_toolchain cxx-toolchain\" ASMFLAGS=\"assemble assemble-user\" CUSTOM_ENV=\"YES\" cmake -DCMAKE_AR=\"/cxx_linker_static\" -DCMAKE_CXX_LINK_EXECUTABLE=\"became\" -DCMAKE_SHARED_LINKER_FLAGS=\"shared1 shared2\" -DCMAKE_EXE_LINKER_FLAGS=\"executable\" -DCUSTOM_CACHE=\"YES\" -DCMAKE_BUILD_TYPE=\"user_type\" -DCMAKE_PREFIX_PATH=\"$EXT_BUILD_DEPS\" -DCMAKE_INSTALL_PREFIX=\"test_rule\" -DCMAKE_RANLIB=\"\" -GNinja $EXT_BUILD_ROOT/external/test_rule"
     asserts.equals(env, expected, script)
 
@@ -393,8 +465,12 @@ def _create_cmake_script_toolchain_file_test(ctx):
     )
     flags = CxxFlagsInfo(
         cc = ["-cc-flag", "-gcc_toolchain", "cc-toolchain"],
-        cxx = ["--quoted=\"abc def\"", "--sysroot=/abc/sysroot", "--gcc_toolchain",
-               "cxx-toolchain"],
+        cxx = [
+            "--quoted=\"abc def\"",
+            "--sysroot=/abc/sysroot",
+            "--gcc_toolchain",
+            "cxx-toolchain",
+        ],
         cxx_linker_shared = ["shared1", "shared2"],
         cxx_linker_static = ["static"],
         cxx_linker_executable = ["executable"],
@@ -413,8 +489,19 @@ def _create_cmake_script_toolchain_file_test(ctx):
         "CUSTOM_CACHE": "YES",
     }
 
-    script = create_cmake_script("ws", "osx", "cmake", tools, flags, "test_rule",
-                                 "external/test_rule", False, user_cache, user_env, ["-GNinja"])
+    script = create_cmake_script(
+        "ws",
+        "osx",
+        "cmake",
+        tools,
+        flags,
+        "test_rule",
+        "external/test_rule",
+        False,
+        user_cache,
+        user_env,
+        ["-GNinja"],
+    )
     expected = """cat > crosstool_bazel.cmake <<EOF
 set(CMAKE_SYSTEM_NAME "Apple")
 set(CMAKE_SYSROOT "/abc/sysroot")

--- a/test/convert_shell_script_test.bzl
+++ b/test/convert_shell_script_test.bzl
@@ -5,7 +5,6 @@ load(
     "//tools/build_defs:shell_script_helper.bzl",
     "convert_shell_script_by_context",
     "do_function_call",
-    "replace_exports",
     "replace_var_ref",
     "split_arguments",
 )

--- a/test/standard_cxx_flags_test/WORKSPACE
+++ b/test/standard_cxx_flags_test/WORKSPACE
@@ -2,7 +2,7 @@ workspace(name = "standard_cxx_flags_test")
 
 local_repository(
     name = "rules_foreign_cc",
-    path = "../.."
+    path = "../..",
 )
 
 load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")

--- a/test/standard_cxx_flags_test/tests.bzl
+++ b/test/standard_cxx_flags_test/tests.bzl
@@ -1,6 +1,6 @@
 """ TODO """
 
-load("@rules_foreign_cc//tools/build_defs:cc_toolchain_util.bzl", "CxxFlagsInfo", "get_flags_info")
+load("@rules_foreign_cc//tools/build_defs:cc_toolchain_util.bzl", "get_flags_info")
 
 def _impl(ctx):
     flags = get_flags_info(ctx)

--- a/test/utils_test.bzl
+++ b/test/utils_test.bzl
@@ -6,9 +6,9 @@ load("//tools/build_defs:framework.bzl", "uniq_list_keep_order")
 def _uniq_list_keep_order_test(ctx):
     env = unittest.begin(ctx)
 
-    list = [1,2,3,1,4,1,2,3,5,1,2,4,7,5]
+    list = [1, 2, 3, 1, 4, 1, 2, 3, 5, 1, 2, 4, 7, 5]
     filtered = uniq_list_keep_order(list)
-    asserts.equals(env, [1,2,3,4,5,7], filtered)
+    asserts.equals(env, [1, 2, 3, 4, 5, 7], filtered)
 
     filteredEmpty = uniq_list_keep_order([])
     asserts.equals(env, [], filteredEmpty)
@@ -20,5 +20,5 @@ uniq_list_keep_order_test = unittest.make(_uniq_list_keep_order_test)
 def utils_test_suite():
     unittest.suite(
         "utils_test_suite",
-        uniq_list_keep_order_test
+        uniq_list_keep_order_test,
     )

--- a/toolchains_examples/fancy_platform_commands.bzl
+++ b/toolchains_examples/fancy_platform_commands.bzl
@@ -46,10 +46,10 @@ fi
 
 def define_function(name, text):
     lines = []
-    lines += ["function " + name + "() {"]
+    lines.append("function " + name + "() {")
     for line_ in text.splitlines():
-        lines += ["  " + line_]
-    lines += ["}"]
+        lines.append("  " + line_)
+    lines.append("}")
     return "\n".join(lines)
 
 def replace_in_files(dir, from_, to_):

--- a/toolchains_examples/fancy_platform_commands.bzl
+++ b/toolchains_examples/fancy_platform_commands.bzl
@@ -55,9 +55,7 @@ def define_function(name, text):
 def replace_in_files(dir, from_, to_):
     return FunctionAndCall(
         text = """if [ -d "$1" ]; then
-  find -L $1 -print -type f \
-  \( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.cmake" \) \
-  -exec sed -i 's@'"$2"'@'"$3"'@g' {} ';'
+  find -L $1 -print -type f   \\( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.cmake" \\)   -exec sed -i 's@'"$2"'@'"$3"'@g' {} ';'
 fi
 """,
     )

--- a/tools/build_defs/cc_toolchain_util.bzl
+++ b/tools/build_defs/cc_toolchain_util.bzl
@@ -385,6 +385,7 @@ def absolutize_path_in_str(workspace_name, root_str, text, force = False):
     new_text = _prefix(text, "external/", root_str)
     if new_text == text:
         new_text = _prefix(text, workspace_name + "/", root_str)
+
     # absolutize relative by adding our working directory
     # this works because we ru on windows under msys now
     if force and new_text == text and not text.startswith("/"):

--- a/tools/build_defs/cc_toolchain_util.bzl
+++ b/tools/build_defs/cc_toolchain_util.bzl
@@ -91,7 +91,7 @@ def _create_libraries_to_link(ctx, files):
     )
 
     for name_ in names:
-        libs += [cc_common.create_library_to_link(
+        libs.append(cc_common.create_library_to_link(
             actions = ctx.actions,
             feature_configuration = feature_configuration,
             cc_toolchain = cc_toolchain,
@@ -100,7 +100,7 @@ def _create_libraries_to_link(ctx, files):
             dynamic_library = shared_map.get(name_),
             interface_library = interface_map.get(name_),
             alwayslink = ctx.attr.alwayslink,
-        )]
+        ))
 
     return libs
 
@@ -112,7 +112,7 @@ def _filter(list_, predicate, inverse):
     for elem in list_:
         check = predicate(elem)
         if not inverse and check or inverse and not check:
-            result += [elem]
+            result.append(elem)
     return result
 
 def _files_map(files_list):
@@ -366,7 +366,7 @@ def _add_if_needed(arr, add_arr):
             if existing == to_add:
                 found = True
         if not found:
-            filtered += [to_add]
+            filtered.append(to_add)
     return arr + filtered
 
 def absolutize_path_in_str(workspace_name, root_str, text, force = False):

--- a/tools/build_defs/cmake.bzl
+++ b/tools/build_defs/cmake.bzl
@@ -18,7 +18,6 @@ load(
     "is_debug_mode",
 )
 load(":cmake_script.bzl", "create_cmake_script")
-load("//tools/build_defs/shell_toolchain/toolchains:access.bzl", "create_context")
 load("//tools/build_defs/native_tools:tool_access.bzl", "get_cmake_data", "get_ninja_data")
 load("@rules_foreign_cc//tools/build_defs:shell_script_helper.bzl", "os_name")
 

--- a/tools/build_defs/cmake.bzl
+++ b/tools/build_defs/cmake.bzl
@@ -62,6 +62,7 @@ def _create_configure_script(configureParameters):
         root = root + "/" + ctx.attr.working_directory
 
     tools = get_tools_info(ctx)
+
     # CMake will replace <TARGET> with the actual output file
     flags = get_flags_info(ctx, "<TARGET>")
     no_toolchain_file = ctx.attr.cache_entries.get("CMAKE_TOOLCHAIN_FILE") or not ctx.attr.generate_crosstool_file

--- a/tools/build_defs/cmake_script.bzl
+++ b/tools/build_defs/cmake_script.bzl
@@ -124,9 +124,9 @@ def _create_crosstool_file_text(toolchain_dict, user_cache, user_env):
     lines = []
     for key in toolchain_dict:
         if ("CMAKE_AR" == key):
-            lines += ["set({} \"{}\" {})".format(key, toolchain_dict[key], "CACHE FILEPATH \"Archiver\"")]
+            lines.append("set({} \"{}\" {})".format(key, toolchain_dict[key], "CACHE FILEPATH \"Archiver\""))
             continue
-        lines += ["set({} \"{}\")".format(key, toolchain_dict[key])]
+        lines.append("set({} \"{}\")".format(key, toolchain_dict[key]))
 
     cache_entries.update({
         "CMAKE_TOOLCHAIN_FILE": "crosstool_bazel.cmake",

--- a/tools/build_defs/cmake_script.bzl
+++ b/tools/build_defs/cmake_script.bzl
@@ -237,9 +237,9 @@ def _fill_crossfile_from_toolchain(workspace_name, target_os, tools, flags):
         dict["CMAKE_AR"] = _absolutize(workspace_name, tools.cxx_linker_static, True)
         if tools.cxx_linker_static.endswith("/libtool"):
             dict["CMAKE_C_ARCHIVE_CREATE"] = "<CMAKE_AR> %s <OBJECTS>" % \
-            " ".join(flags.cxx_linker_static)
+                                             " ".join(flags.cxx_linker_static)
             dict["CMAKE_CXX_ARCHIVE_CREATE"] = "<CMAKE_AR> %s <OBJECTS>" % \
-            " ".join(flags.cxx_linker_static)
+                                               " ".join(flags.cxx_linker_static)
 
     if tools.cxx_linker_executable and tools.cxx_linker_executable != tools.cxx:
         normalized_path = _absolutize(workspace_name, tools.cxx_linker_executable)

--- a/tools/build_defs/configure_script.bzl
+++ b/tools/build_defs/configure_script.bzl
@@ -1,5 +1,5 @@
 load(":cc_toolchain_util.bzl", "absolutize_path_in_str")
-load(":framework.bzl", "ForeignCcDeps", "get_foreign_cc_dep")
+load(":framework.bzl", "get_foreign_cc_dep")
 
 def create_configure_script(
         workspace_name,
@@ -18,23 +18,23 @@ def create_configure_script(
 
     script = []
     for ext_dir in inputs.ext_build_dirs:
-        script += ["##increment_pkg_config_path## $$EXT_BUILD_ROOT$$/" + ext_dir.path]
+        script.append("##increment_pkg_config_path## $$EXT_BUILD_ROOT$$/" + ext_dir.path)
 
-    script += ["echo \"PKG_CONFIG_PATH=$$PKG_CONFIG_PATH$$\""]
+    script.append("echo \"PKG_CONFIG_PATH=$$PKG_CONFIG_PATH$$\"")
 
     configure_path = "$$EXT_BUILD_ROOT$$/{root}/{configure}".format(
         root = root,
         configure = configure_command,
     )
     if (configure_in_place):
-        script += ["##symlink_contents_to_dir## $$EXT_BUILD_ROOT$$/{} $$BUILD_TMPDIR$$".format(root)]
+        script.append("##symlink_contents_to_dir## $$EXT_BUILD_ROOT$$/{} $$BUILD_TMPDIR$$".format(root))
         configure_path = "$$BUILD_TMPDIR$$/{}".format(configure_command)
 
-    script += ["{env_vars} \"{configure}\" --prefix=$$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$ {user_options}".format(
+    script.append("{env_vars} \"{configure}\" --prefix=$$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$ {user_options}".format(
         env_vars = env_vars_string,
         configure = configure_path,
         user_options = " ".join(user_options),
-    )]
+    ))
     return "\n".join(script)
 
 def create_make_script(
@@ -50,12 +50,12 @@ def create_make_script(
     env_vars_string = get_env_vars(workspace_name, tools, flags, user_vars, deps, inputs)
     script = []
     for ext_dir in inputs.ext_build_dirs:
-        script += ["##increment_pkg_config_path## $$EXT_BUILD_ROOT$$/" + ext_dir.path]
+        script.append("##increment_pkg_config_path## $$EXT_BUILD_ROOT$$/" + ext_dir.path)
 
-    script += ["echo \"PKG_CONFIG_PATH=$$PKG_CONFIG_PATH$$\""]
+    script.append("echo \"PKG_CONFIG_PATH=$$PKG_CONFIG_PATH$$\"")
 
-    script += ["##symlink_contents_to_dir## $$EXT_BUILD_ROOT$$/{} $$BUILD_TMPDIR$$".format(root)]
-    script += ["" + " && ".join(make_commands)]
+    script.append("##symlink_contents_to_dir## $$EXT_BUILD_ROOT$$/{} $$BUILD_TMPDIR$$".format(root))
+    script.append("" + " && ".join(make_commands))
     return "\n".join(script)
 
 def get_env_vars(
@@ -87,7 +87,7 @@ def _define_deps_flags(deps, inputs):
         dir_ = lib.dirname
         if not gen_dirs_set.get(dir_):
             gen_dirs_set[dir_] = 1
-            lib_dirs += ["-L$$EXT_BUILD_ROOT$$/" + dir_]
+            lib_dirs.append("-L$$EXT_BUILD_ROOT$$/" + dir_)
 
     include_dirs_set = {}
     for include_dir in inputs.include_dirs:
@@ -113,8 +113,8 @@ def _define_deps_flags(deps, inputs):
                     gen_dirs_set[artifact.gen_dir] = 1
 
                     dir_name = artifact.gen_dir.basename
-                    include_dirs += ["-I$$EXT_BUILD_DEPS$$/{}/{}".format(dir_name, artifact.include_dir_name)]
-                    lib_dirs += ["-L$$EXT_BUILD_DEPS$$/{}/{}".format(dir_name, artifact.lib_dir_name)]
+                    include_dirs.append("-I$$EXT_BUILD_DEPS$$/{}/{}".format(dir_name, artifact.include_dir_name))
+                    lib_dirs.append("-L$$EXT_BUILD_DEPS$$/{}/{}".format(dir_name, artifact.lib_dir_name))
 
     return struct(
         libs = lib_dirs,

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -448,9 +448,9 @@ def _symlink_contents_to_dir(dir_name, files_list):
     lines = ["##mkdirs## $$EXT_BUILD_DEPS$$/" + dir_name]
 
     for file in files_list:
-      path = _file_path(file).strip()
-      if path:
-        lines += ["##symlink_contents_to_dir## \
+        path = _file_path(file).strip()
+        if path:
+            lines += ["##symlink_contents_to_dir## \
 $$EXT_BUILD_ROOT$$/{} $$EXT_BUILD_DEPS$$/{}".format(path, dir_name)]
 
     return lines
@@ -588,12 +588,12 @@ def _define_inputs(attrs):
         deps_compilation_info = cc_info_merged.compilation_context,
         deps_linking_info = cc_info_merged.linking_context,
         ext_build_dirs = ext_build_dirs,
-        declared_inputs = filter_containing_dirs_from_inputs(attrs.lib_source.files.to_list())
-            + bazel_libs
-            + tools_files
-            + attrs.additional_inputs
-            + cc_info_merged.compilation_context.headers.to_list()
-            + ext_build_dirs,
+        declared_inputs = filter_containing_dirs_from_inputs(attrs.lib_source.files.to_list()) +
+                          bazel_libs +
+                          tools_files +
+                          attrs.additional_inputs +
+                          cc_info_merged.compilation_context.headers.to_list() +
+                          ext_build_dirs,
     )
 
 """When the directories are also passed in the filegroup with the sources,
@@ -601,6 +601,7 @@ we get into a situation when we have containing in the sources list,
 which is not allowed by Bazel (execroot creation code fails).
 The parent directories will be created for us in the execroot anyway,
 so we filter them out."""
+
 def filter_containing_dirs_from_inputs(input_files_list):
     # This puts directories in front of their children in list
     sorted_list = sorted(input_files_list)
@@ -628,7 +629,8 @@ def get_foreign_cc_dep(dep):
 # consider optimization here to do not iterate both collections
 def _get_headers(compilation_info):
     include_dirs = compilation_info.system_includes.to_list() + \
-      compilation_info.includes.to_list()
+                   compilation_info.includes.to_list()
+
     # do not use quote includes, currently they do not contain
     # library-specific information
     include_dirs = collections.uniq(include_dirs)

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -391,7 +391,7 @@ def _get_transitive_artifacts(deps):
     for dep in deps:
         foreign_dep = get_foreign_cc_dep(dep)
         if foreign_dep:
-            artifacts += [foreign_dep.artifacts]
+            artifacts.append(foreign_dep.artifacts)
     return artifacts
 
 def _print_env():
@@ -432,10 +432,10 @@ def _copy_deps_and_tools(files):
         lines.append("##symlink_to_dir## $$EXT_BUILD_ROOT$$/{} $$EXT_BUILD_DEPS$$/bin/".format(tool))
 
     for ext_dir in files.ext_build_dirs:
-        lines += ["##symlink_to_dir## $$EXT_BUILD_ROOT$$/{} $$EXT_BUILD_DEPS$$".format(_file_path(ext_dir))]
+        lines.append("##symlink_to_dir## $$EXT_BUILD_ROOT$$/{} $$EXT_BUILD_DEPS$$".format(_file_path(ext_dir)))
 
-    lines += ["##children_to_path## $$EXT_BUILD_DEPS$$/bin"]
-    lines += ["##path## $$EXT_BUILD_DEPS$$/bin"]
+    lines.append("##children_to_path## $$EXT_BUILD_DEPS$$/bin")
+    lines.append("##path## $$EXT_BUILD_DEPS$$/bin")
 
     return lines
 
@@ -450,8 +450,8 @@ def _symlink_contents_to_dir(dir_name, files_list):
     for file in files_list:
         path = _file_path(file).strip()
         if path:
-            lines += ["##symlink_contents_to_dir## \
-$$EXT_BUILD_ROOT$$/{} $$EXT_BUILD_DEPS$$/{}".format(path, dir_name)]
+            lines.append("##symlink_contents_to_dir## \
+$$EXT_BUILD_ROOT$$/{} $$EXT_BUILD_DEPS$$/{}".format(path, dir_name))
 
     return lines
 
@@ -549,7 +549,7 @@ def _define_inputs(attrs):
     for dep in attrs.deps:
         external_deps = get_foreign_cc_dep(dep)
 
-        cc_infos += [dep[CcInfo]]
+        cc_infos.append(dep[CcInfo])
 
         if external_deps:
             ext_build_dirs += [artifact.gen_dir for artifact in external_deps.artifacts.to_list()]
@@ -568,7 +568,7 @@ def _define_inputs(attrs):
     tools_files = []
     for tool in attrs.tools_deps:
         tool_root = detect_root(tool)
-        tools_roots += [tool_root]
+        tools_roots.append(tool_root)
         for file_list in tool.files.to_list():
             tools_files += _list(file_list)
 
@@ -643,7 +643,7 @@ def _get_headers(compilation_info):
                 included = True
                 break
         if not included:
-            headers += [header]
+            headers.append(header)
     return struct(
         headers = headers,
         include_dirs = include_dirs,

--- a/tools/build_defs/native_tools/tool_access.bzl
+++ b/tools/build_defs/native_tools/tool_access.bzl
@@ -1,4 +1,4 @@
-load(":native_tools_toolchain.bzl", "ToolInfo", "access_tool")
+load(":native_tools_toolchain.bzl", "access_tool")
 
 def get_cmake_data(ctx):
     return _access_and_expect_label_copied("@rules_foreign_cc//tools/build_defs:cmake_toolchain", ctx, "cmake")

--- a/tools/build_defs/shell_toolchain/polymorphism/generate_overloads.bzl
+++ b/tools/build_defs/shell_toolchain/polymorphism/generate_overloads.bzl
@@ -30,8 +30,8 @@ def _load_and_wrapper_text(id, file_path, symbols):
     wrapper_statement = "wrapper_{id} = dict({data})".format(id = id, data = data)
     return struct(
         load_ = load_statement,
-        wrapper = wrapper_statement
-      )
+        wrapper = wrapper_statement,
+    )
 
 def id_from_file(file_name):
     (before, middle, after) = file_name.partition(".")

--- a/tools/build_defs/shell_toolchain/polymorphism/generate_overloads.bzl
+++ b/tools/build_defs/shell_toolchain/polymorphism/generate_overloads.bzl
@@ -20,7 +20,7 @@ def get(file_name):
 def _mapping_text(ids):
     data_ = []
     for id in ids:
-        data_ += ["{id} = wrapper_{id}".format(id = id)]
+        data_.append("{id} = wrapper_{id}".format(id = id))
     return "_MAPPING = dict(\n{data}\n)".format(data = ",\n".join(data_))
 
 def _load_and_wrapper_text(id, file_path, symbols):
@@ -55,16 +55,16 @@ def _generate_overloads(rctx):
     wrappers = []
     for file_ in rctx.attr.files:
         id = id_from_file(file_.name)
-        ids += [id]
+        ids.append(id)
         copy = _copy_file(rctx, file_)
         load_and_wrapper = _load_and_wrapper_text(id, copy, symbols)
-        loads += [load_and_wrapper.load_]
-        wrappers += [load_and_wrapper.wrapper]
+        loads.append(load_and_wrapper.load_)
+        wrappers.append(load_and_wrapper.wrapper)
     lines += loads
     lines += wrappers
-    lines += [_mapping_text(ids)]
-    lines += [_provider_text(symbols)]
-    lines += [_getter_text()]
+    lines.append(_mapping_text(ids))
+    lines.append(_provider_text(symbols))
+    lines.append(_getter_text())
 
     rctx.file("toolchain_data_defs.bzl", "\n".join(lines))
     rctx.file("BUILD", "")

--- a/tools/build_defs/shell_toolchain/toolchains/access.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/access.bzl
@@ -1,4 +1,3 @@
-load("@bazel_skylib//lib:types.bzl", "types")
 load("//tools/build_defs/shell_toolchain/toolchains:commands.bzl", "PLATFORM_COMMANDS")
 load(":function_and_call.bzl", "FunctionAndCall")
 

--- a/tools/build_defs/shell_toolchain/toolchains/impl/default_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/default_commands.bzl
@@ -46,10 +46,10 @@ fi
 
 def define_function(name, text):
     lines = []
-    lines += ["function " + name + "() {"]
+    lines.append("function " + name + "() {")
     for line_ in text.splitlines():
-        lines += ["  " + line_]
-    lines += ["}"]
+        lines.append("  " + line_)
+    lines.append("}")
     return "\n".join(lines)
 
 def replace_in_files(dir, from_, to_):

--- a/tools/build_defs/shell_toolchain/toolchains/impl/default_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/default_commands.bzl
@@ -1,6 +1,6 @@
 load("@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains:function_and_call.bzl", "FunctionAndCall")
 
-_REPLACE_VALUE = "\${EXT_BUILD_DEPS}"
+_REPLACE_VALUE = "\\${EXT_BUILD_DEPS}"
 
 def os_name():
     return "linux"
@@ -55,9 +55,7 @@ def define_function(name, text):
 def replace_in_files(dir, from_, to_):
     return FunctionAndCall(
         text = """if [ -d "$1" ]; then
-  find -L $1 -type f \
-  \( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.cmake" \) \
-  -exec sed -i 's@'"$2"'@'"$3"'@g' {} ';'
+  find -L $1 -type f   \\( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.cmake" \\)   -exec sed -i 's@'"$2"'@'"$3"'@g' {} ';'
 fi
 """,
     )

--- a/tools/build_defs/shell_toolchain/toolchains/impl/linux_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/linux_commands.bzl
@@ -46,10 +46,10 @@ fi
 
 def define_function(name, text):
     lines = []
-    lines += ["function " + name + "() {"]
+    lines.append("function " + name + "() {")
     for line_ in text.splitlines():
-        lines += ["  " + line_]
-    lines += ["}"]
+        lines.append("  " + line_)
+    lines.append("}")
     return "\n".join(lines)
 
 def replace_in_files(dir, from_, to_):

--- a/tools/build_defs/shell_toolchain/toolchains/impl/linux_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/linux_commands.bzl
@@ -1,6 +1,6 @@
 load("@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains:function_and_call.bzl", "FunctionAndCall")
 
-_REPLACE_VALUE = "\${EXT_BUILD_DEPS}"
+_REPLACE_VALUE = "\\${EXT_BUILD_DEPS}"
 
 def os_name():
     return "linux"
@@ -55,9 +55,7 @@ def define_function(name, text):
 def replace_in_files(dir, from_, to_):
     return FunctionAndCall(
         text = """if [ -d "$1" ]; then
-  find -L $1 -type f \
-  \( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.cmake" \) \
-  -exec sed -i 's@'"$2"'@'"$3"'@g' {} ';'
+  find -L $1 -type f   \\( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.cmake" \\)   -exec sed -i 's@'"$2"'@'"$3"'@g' {} ';'
 fi
 """,
     )

--- a/tools/build_defs/shell_toolchain/toolchains/impl/osx_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/osx_commands.bzl
@@ -1,6 +1,6 @@
 load("@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains:function_and_call.bzl", "FunctionAndCall")
 
-_REPLACE_VALUE = "\${EXT_BUILD_DEPS}"
+_REPLACE_VALUE = "\\${EXT_BUILD_DEPS}"
 
 def os_name():
     return "osx"
@@ -55,8 +55,7 @@ def define_function(name, text):
 def replace_in_files(dir, from_, to_):
     return FunctionAndCall(
         text = """if [ -d "$1" ]; then
-    find -L -f $1 \( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.cmake" \) \
-    -exec sed -i -e 's@'"$2"'@'"$3"'@g' {} ';'
+    find -L -f $1 \\( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.cmake" \\)     -exec sed -i -e 's@'"$2"'@'"$3"'@g' {} ';'
 fi
 """,
     )

--- a/tools/build_defs/shell_toolchain/toolchains/impl/osx_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/osx_commands.bzl
@@ -46,10 +46,10 @@ fi
 
 def define_function(name, text):
     lines = []
-    lines += ["function " + name + "() {"]
+    lines.append("function " + name + "() {")
     for line_ in text.splitlines():
-        lines += ["  " + line_]
-    lines += ["}"]
+        lines.append("  " + line_)
+    lines.append("}")
     return "\n".join(lines)
 
 def replace_in_files(dir, from_, to_):

--- a/tools/build_defs/shell_toolchain/toolchains/impl/windows_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/windows_commands.bzl
@@ -46,10 +46,10 @@ fi
 
 def define_function(name, text):
     lines = []
-    lines += ["function " + name + "() {"]
+    lines.append("function " + name + "() {")
     for line_ in text.splitlines():
-        lines += ["  " + line_]
-    lines += ["}"]
+        lines.append("  " + line_)
+    lines.append("}")
     return "\n".join(lines)
 
 def replace_in_files(dir, from_, to_):

--- a/tools/build_defs/shell_toolchain/toolchains/impl/windows_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/windows_commands.bzl
@@ -1,6 +1,6 @@
 load("@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains:function_and_call.bzl", "FunctionAndCall")
 
-_REPLACE_VALUE = "\${EXT_BUILD_DEPS}"
+_REPLACE_VALUE = "\\${EXT_BUILD_DEPS}"
 
 def os_name():
     return "windows"
@@ -55,9 +55,7 @@ def define_function(name, text):
 def replace_in_files(dir, from_, to_):
     return FunctionAndCall(
         text = """if [ -d "$1" ]; then
-  $REAL_FIND -L $1 -type f \
-  \( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.cmake" \) \
-  -exec sed -i 's@'"$2"'@'"$3"'@g' {} ';'
+  $REAL_FIND -L $1 -type f   \\( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.cmake" \\)   -exec sed -i 's@'"$2"'@'"$3"'@g' {} ';'
 fi
 """,
     )

--- a/workspace_definitions.bzl
+++ b/workspace_definitions.bzl
@@ -1,4 +1,3 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//for_workspace:repositories.bzl", "repositories")
 load(
     "//tools/build_defs/shell_toolchain/toolchains:ws_defs.bzl",

--- a/workspace_definitions.bzl
+++ b/workspace_definitions.bzl
@@ -58,8 +58,7 @@ def rules_foreign_cc_dependencies(
         native_tools_toolchains = [],
         register_default_tools = True,
         additonal_shell_toolchain_mappings = [],
-        additonal_shell_toolchain_package = None,
-        ):
+        additonal_shell_toolchain_package = None):
     """ Call this function from the WORKSPACE file to initialize rules_foreign_cc
      dependencies and let neccesary code generation happen
      (Code generation is needed to support different variants of the C++ Starlark API.).
@@ -88,7 +87,7 @@ def rules_foreign_cc_dependencies(
     """
     repositories()
     _read_build_options(name = "foreign_cc_platform_utils")
-    bazel_version(name="rules_foreign_cc_bazel_version")
+    bazel_version(name = "rules_foreign_cc_bazel_version")
 
     shell_toolchain_workspace_initalization(
         additonal_shell_toolchain_mappings,


### PR DESCRIPTION
Change generated by:
* `buildifier -r .` (first commit)
* `buildifier --lint=fix -r .` (second commit)

In particular, this should fix the compatibility with --incompatible_restrict_string_escapes.