### PR TITLE
Fix extension-stripping logic

### DIFF
--- a/tools/build_defs/cc_toolchain_util.bzl
+++ b/tools/build_defs/cc_toolchain_util.bzl
@@ -401,5 +401,5 @@ def _prefix(text, from_str, prefix):
     return before + prefix + middle + after
 
 def _file_name_no_ext(basename):
-    (before, separator, after) = basename.partition(".")
+    (before, separator, after) = basename.rpartition(".")
     return before


### PR DESCRIPTION
Trivial manual test case:
   
    libpython3.8.a vs libpython3.8m.a

Existing logic erroneously reports collision on "libpython3" token.

Note: string.rpartition is available and semantically unchanged since at least [Bazel 0.23](https://docs.bazel.build/versions/0.21.0/skylark/lib/string.html#rpartition).

Please advise if there's any good places for me to add a unit test for this private function.