### PR TITLE
Support running autogen.sh and autoreconf

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -27,6 +27,8 @@ test_suite(
         "//cmake_synthetic:test_libs",
         "//cmake_with_bazel_transitive:test",
         "//configure_gnuplot:configure_libgd_tests",
+        "//configure_libunwind:configure_libunwind_tests",
+        "//configure_mpc:configure_mpc_tests",
         "//cmake_hello_world_lib/shared:test_libhello",
         "//cmake_hello_world_lib/binary:test_binary",
         "//configure_with_bazel_transitive:test",

--- a/examples/configure_libunwind/BUILD
+++ b/examples/configure_libunwind/BUILD
@@ -1,0 +1,29 @@
+load("@rules_foreign_cc//tools/build_defs:configure.bzl", "configure_make")
+
+configure_make(
+    name = "libunwind",
+    autogen = True,
+    configure_in_place = True,
+    configure_options = [
+        "--disable-coredump",
+        "--disable-ptrace",
+        "--disable-setjmp",
+        "--disable-documentation",
+        "--disable-weak-backtrace",
+    ],
+    lib_source = "@libunwind//:all",
+    shared_libraries = ["libunwind.so"],
+    static_libraries = ["libunwind.a"],
+    visibility = ["//visibility:public"],
+)
+
+cc_test(
+    name = "test_libunwind",
+    srcs = ["libunwind_test.c"],
+    deps = [":libunwind"],
+)
+
+test_suite(
+    name = "configure_libunwind_tests",
+    tests = [":test_libunwind"],
+)

--- a/examples/configure_libunwind/libunwind_test.c
+++ b/examples/configure_libunwind/libunwind_test.c
@@ -1,0 +1,60 @@
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#define UNW_LOCAL_ONLY 1
+#include "libunwind.h"
+
+#ifndef __has_attribute
+#define __has_attribute(x) 0
+#endif
+
+#if defined(__GNUC__) || __has_attribute(noinline)
+#define NOINLINE __attribute__((noinline))
+#elif defined(_MSC_VER)
+#define NOINLINE __declspec(noinline)
+#else
+#define NOINLINE
+#endif
+
+NOINLINE void bar() {
+  unw_context_t context;
+  unw_cursor_t cursor;
+  unw_word_t ip, sp, off;
+  char proc_name[256];
+  if (unw_getcontext(&context)) {
+    return;
+  }
+  if (unw_init_local(&cursor, &context)) {
+    return;
+  }
+  for (;;) {
+    if (unw_step(&cursor) <= 0) {
+      break;
+    }
+    ip = 0;
+    if (unw_get_reg(&cursor, UNW_REG_IP, &ip)) {
+      ip = 0;
+    }
+    sp = 0;
+    if (unw_get_reg(&cursor, UNW_REG_SP, &sp)) {
+      sp = 0;
+    }
+    memset(proc_name, '\0', sizeof(proc_name));
+    if (unw_get_proc_name(&cursor, proc_name, sizeof(proc_name) - 1, &off)) {
+      proc_name[0] = '\0';
+      strcpy(proc_name, "<unknown>");
+    }
+    fprintf(stdout,
+            "proc=%s off=%" PRIdPTR " ip=%" PRIdPTR " sp=%" PRIdPTR "\n",
+            proc_name, (uintptr_t)off, (uintptr_t)ip, (uintptr_t)sp);
+  }
+}
+
+NOINLINE void foo() { bar(); }
+
+int main(int argc, char** argv) {
+  foo();
+  return 0;
+}

--- a/examples/configure_mpc/BUILD
+++ b/examples/configure_mpc/BUILD
@@ -1,0 +1,48 @@
+load("@rules_foreign_cc//tools/build_defs:configure.bzl", "configure_make")
+
+configure_make(
+    name = "gmp",
+    lib_source = "@gmp//:all",
+    shared_libraries = ["libgmp.so"],
+    static_libraries = ["libgmp.a"],
+    visibility = ["//visibility:public"],
+)
+
+configure_make(
+    name = "mpfr",
+    lib_source = "@mpfr//:all",
+    shared_libraries = ["libmpfr.so"],
+    static_libraries = ["libmpfr.a"],
+    visibility = ["//visibility:public"],
+    deps = [":gmp"],
+)
+
+configure_make(
+    name = "mpc",
+    autoreconf = True,
+    autoreconf_options = [
+        "-i",
+        "-f",
+        "-v",
+    ],
+    configure_in_place = True,
+    lib_source = "@mpc//:all",
+    shared_libraries = ["libmpc.so"],
+    static_libraries = ["libmpc.a"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gmp",
+        ":mpfr",
+    ],
+)
+
+cc_test(
+    name = "test_mpc",
+    srcs = ["mpc_test.c"],
+    deps = [":mpc"],
+)
+
+test_suite(
+    name = "configure_mpc_tests",
+    tests = [":test_mpc"],
+)

--- a/examples/configure_mpc/mpc_test.c
+++ b/examples/configure_mpc/mpc_test.c
@@ -1,0 +1,26 @@
+#include "mpc.h"
+
+#include <stdio.h>
+
+int main(int argc, char** argv) {
+  mpc_t x;
+  mpc_t y;
+  mpc_t z;
+  mpc_init2(x, 64);
+  mpc_init2(y, 64);
+  mpc_init2(z, 64);
+  mpc_set_ui_ui(x, 2, 3, MPC_RNDNN);
+  mpc_set_ui_ui(y, 3, 2, MPC_RNDNN);
+  mpc_add(z, x, y, MPC_RNDNN);
+  mpc_out_str(stdout, 10, 0, x, MPC_RNDNN);
+  fprintf(stdout, " + ");
+  mpc_out_str(stdout, 10, 0, y, MPC_RNDNN);
+  fprintf(stdout, " = ");
+  mpc_out_str(stdout, 10, 0, z, MPC_RNDNN);
+  fprintf(stdout, "\n");
+  fflush(stdout);
+  mpc_clear(x);
+  mpc_clear(y);
+  mpc_clear(z);
+  return 0;
+}

--- a/examples/examples_repositories.bzl
+++ b/examples/examples_repositories.bzl
@@ -202,3 +202,47 @@ def include_examples_repositories():
         ],
         sha256 = "d613cf222bbb05b8cff7a1c03c37345ed33744a4ebaf3a8bfd5f56a76e25ca08",
     )
+
+    http_archive(
+        name = "gmp",
+        build_file_content = all_content,
+        strip_prefix = "gmp-6.2.0",
+        urls = [
+            "https://mirror.bazel.build/gmplib.org/download/gmp/gmp-6.2.0.tar.gz",
+            "https://gmplib.org/download/gmp/gmp-6.2.0.tar.gz",
+        ],
+        sha256 = "cadd49052b740ccc3d8075c24ceaefbe5128d44246d91d0ecc818b2f78b0ec9c",
+    )
+
+    http_archive(
+        name = "mpfr",
+        build_file_content = all_content,
+        strip_prefix = "mpfr-4.0.2",
+        urls = [
+            "https://mirror.bazel.build/www.mpfr.org/mpfr-current/mpfr-4.0.2.tar.gz",
+            "https://www.mpfr.org/mpfr-current/mpfr-4.0.2.tar.gz",
+        ],
+        sha256 = "ae26cace63a498f07047a784cd3b0e4d010b44d2b193bab82af693de57a19a78",
+    )
+
+    http_archive(
+        name = "mpc",
+        build_file_content = all_content,
+        strip_prefix = "mpc-1.1.0",
+        urls = [
+            "https://mirror.bazel.build/ftp.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz",
+            "https://ftp.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz",
+        ],
+        sha256 = "6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e",
+    )
+
+    http_archive(
+        name = "libunwind",
+        build_file_content = all_content,
+        strip_prefix = "libunwind-9165d2a150d707d3037c2045f2cdc0fabd5fee98",
+        urls = [
+            "https://mirror.bazel.build/github.com/libunwind/libunwind/archive/9165d2a150d707d3037c2045f2cdc0fabd5fee98.zip",
+            "https://github.com/libunwind/libunwind/archive/9165d2a150d707d3037c2045f2cdc0fabd5fee98.zip",
+        ],
+        sha256 = "f83c604cde80a49af91345a1ff3f4558958202989fb768e6508963e24ea2524c",
+    )

--- a/tools/build_defs/configure.bzl
+++ b/tools/build_defs/configure.bzl
@@ -54,6 +54,13 @@ def _create_configure_script(configureParameters):
         deps = ctx.attr.deps,
         inputs = inputs,
         configure_in_place = ctx.attr.configure_in_place,
+        autoreconf = ctx.attr.autoreconf,
+        autoreconf_options = ctx.attr.autoreconf_options,
+        autoreconf_env_vars = ctx.attr.autoreconf_env_vars,
+        autogen = ctx.attr.autogen,
+        autogen_command = ctx.attr.autogen_command,
+        autogen_options = ctx.attr.autogen_options,
+        autogen_env_vars = ctx.attr.autogen_env_vars,
     )
     return "\n".join([define_install_prefix, configure])
 
@@ -80,6 +87,24 @@ def _attrs():
         # Set to True if 'configure' should be invoked in place, i.e. from its enclosing
         # directory.
         "configure_in_place": attr.bool(mandatory = False, default = False),
+        # Set to True if 'autoreconf' should be invoked before 'configure.',
+        # currently requires 'configure_in_place' to be True.
+        "autoreconf": attr.bool(mandatory = False, default = False),
+        # Any options to be put in the 'autoreconf.sh' command line.
+        "autoreconf_options": attr.string_list(),
+        # Environment variables to be set for 'autoreconf' invocation.
+        "autoreconf_env_vars": attr.string_dict(),
+        # Set to True if 'autogen.sh' should be invoked before 'configure',
+        # currently requires 'configure_in_place' to be True.
+        "autogen": attr.bool(mandatory = False, default = False),
+        # The name of the autogen script file, default: autogen.sh.
+        # Many projects use autogen.sh however the Autotools FAQ recommends bootstrap
+        # so we provide this option to support that.
+        "autogen_command": attr.string(default = "autogen.sh"),
+        # Any options to be put in the 'autogen.sh' command line.
+        "autogen_options": attr.string_list(),
+        # Environment variables to be set for 'autogen' invocation.
+        "autogen_env_vars": attr.string_dict(),
     })
     return attrs
 

--- a/tools/build_defs/configure_script.bzl
+++ b/tools/build_defs/configure_script.bzl
@@ -13,7 +13,14 @@ def create_configure_script(
         configure_command,
         deps,
         inputs,
-        configure_in_place):
+        configure_in_place,
+        autoreconf,
+        autoreconf_options,
+        autoreconf_env_vars,
+        autogen,
+        autogen_command,
+        autogen_options,
+        autogen_env_vars):
     env_vars_string = get_env_vars(workspace_name, tools, flags, user_vars, deps, inputs)
 
     script = []
@@ -22,13 +29,29 @@ def create_configure_script(
 
     script.append("echo \"PKG_CONFIG_PATH=$$PKG_CONFIG_PATH$$\"")
 
-    configure_path = "$$EXT_BUILD_ROOT$$/{root}/{configure}".format(
-        root = root,
-        configure = configure_command,
-    )
-    if (configure_in_place):
+    root_path = "$$EXT_BUILD_ROOT$$/{}".format(root)
+    configure_path = "{}/{}".format(root_path, configure_command)
+    if configure_in_place:
         script.append("##symlink_contents_to_dir## $$EXT_BUILD_ROOT$$/{} $$BUILD_TMPDIR$$".format(root))
-        configure_path = "$$BUILD_TMPDIR$$/{}".format(configure_command)
+        root_path = "$$BUILD_TMPDIR$$"
+        configure_path = "{}/{}".format(root_path, configure_command)
+
+    if autogen and configure_in_place:
+        # NOCONFIGURE is pseudo standard and tells the script to not invoke configure.
+        # We explicitly invoke configure later.
+        autogen_env_vars = _get_autogen_env_vars(autogen_env_vars)
+        script.append("{} \"{}/{}\" {}".format(
+            " ".join(["{}=\"{}\"".format(key, autogen_env_vars[key]) for key in autogen_env_vars]),
+            root_path,
+            autogen_command,
+            " ".join(autogen_options),
+        ).lstrip())
+
+    if autoreconf and configure_in_place:
+        script.append("{} autoreconf {}".format(
+            " ".join(["{}=\"{}\"".format(key, autoreconf_env_vars[key]) for key in autoreconf_env_vars]),
+            " ".join(autoreconf_options),
+        ).lstrip())
 
     script.append("{env_vars} \"{configure}\" --prefix=$$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$ {user_options}".format(
         env_vars = env_vars_string,
@@ -76,6 +99,16 @@ def get_env_vars(
 
     return " ".join(["{}=\"{}\""
         .format(key, _join_flags_list(workspace_name, vars[key])) for key in vars])
+
+def _get_autogen_env_vars(autogen_env_vars):
+    # Make a copy if necessary so we can set NOCONFIGURE.
+    if autogen_env_vars.get("NOCONFIGURE"):
+        return autogen_env_vars
+    vars = {}
+    for key in autogen_env_vars:
+        vars[key] = autogen_env_vars.get(key)
+    vars["NOCONFIGURE"] = "1"
+    return vars
 
 def _define_deps_flags(deps, inputs):
     # It is very important to keep the order for the linker => put them into list


### PR DESCRIPTION
Some libraries distributed as tarballs use older versions of autotools to generate some of the scripts such as libtool. Some of these versions apparently do not handle certain things well, such as putting EXT_BUILD_DEPS in .la and .pc files. I was able to get them working by adding support to run autoreconf before running configure. I also added support for executing autogen.sh if it is present.

Example to reproduce the issues. It occurs when building MPC using the most recent version of each library as available today.

```
load("@rules_foreign_cc//tools/build_defs:configure.bzl", "configure_make")

configure_make(
    name = "gmp",
    lib_source = "@gmp//:all",
    shared_libraries = ["libgmp.so"],
    static_libraries = ["libgmp.a"],
)

configure_make(
    name = "mpfr",
    lib_source = "@mpfr//:all",
    shared_libraries = ["libmpfr.so"],
    static_libraries = ["libmpfr.a"],
    deps = [":gmp"],
)

configure_make(
    name = "mpc",
    # Fixed by this pull request and un-commenting the below lines.
    # autoreconf = True,
    # autoreconf_options = [
    #    "-i",
    #    "-f",
    #    "-v",
    # ],
    # configure_in_place = True,
    lib_source = "@mpc//:all",
    shared_libraries = ["libmpc.so"],
    static_libraries = ["libmpc.a"],
    deps = [
        ":gmp",
        ":mpfr",
    ],
)
```