### PR TITLE
Handle case where LDFLAGS is undefined

### DIFF
--- a/tools/build_defs/configure_script.bzl
+++ b/tools/build_defs/configure_script.bzl
@@ -68,7 +68,10 @@ def get_env_vars(
     vars = _get_configure_variables(tools, flags, user_vars)
     deps_flags = _define_deps_flags(deps, inputs)
 
-    vars["LDFLAGS"] = vars["LDFLAGS"] + deps_flags.libs
+    if "LDFLAGS" in vars.keys():
+      vars["LDFLAGS"] = vars["LDFLAGS"] + deps_flags.libs
+    else:
+      vars["LDFLAGS"] = deps_flags.libs
 
     # -I flags should be put into preprocessor flags, CPPFLAGS
     # https://www.gnu.org/software/autoconf/manual/autoconf-2.63/html_node/Preset-Output-Variables.html


### PR DESCRIPTION
I am cross-compiling Envoy and for some reason hitting a case where `LDFLAGS` is not set. I don't quite understand the root cause yet, but clearly this code shouldn't assume that `vars`  has `LDFLAG` key set to something, especially because it's set conditionally in the first place:

https://github.com/bazelbuild/rules_foreign_cc/blob/74b146dc87d37baa1919da1e8f7b8aafbd32acd9/tools/build_defs/configure_script.bzl#L144-L147