### PR TITLE
Set LD_LIBRARY_PATH in configure scripts.

### DIFF
--- a/examples/deps/repositories.bzl
+++ b/examples/deps/repositories.bzl
@@ -285,3 +285,35 @@ def repositories():
         ],
         sha256 = "f83c604cde80a49af91345a1ff3f4558958202989fb768e6508963e24ea2524c",
     )
+
+    http_archive(
+        name = "postgres",
+        urls = ["https://ftp.postgresql.org/pub/source/v12.5/postgresql-12.5.tar.bz2"],
+        build_file_content = all_content,
+        sha256 = "bd0d25341d9578b5473c9506300022de26370879581f5fddd243a886ce79ff95",
+        strip_prefix = "postgresql-12.5",
+    )
+
+    http_archive(
+        name = "readline",
+        urls = ["https://ftp.gnu.org/gnu/readline/readline-8.0.tar.gz"],
+        build_file_content = all_content,
+        strip_prefix = "readline-8.0",
+        sha256 = "e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461",
+    )
+
+    http_archive(
+        name = "ncurses",
+        urls = ["https://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.2.tar.gz"],
+        build_file_content = all_content,
+        strip_prefix = "ncurses-6.2",
+        sha256 = "30306e0c76e0f9f1f0de987cf1c82a5c21e1ce6568b9227f7da5b71cbea86c9d",
+    )
+
+    http_archive(
+        name = "openssl",
+        urls = ["https://github.com/openssl/openssl/archive/OpenSSL_1_1_1i.tar.gz"],
+        strip_prefix = "openssl-OpenSSL_1_1_1i",
+        build_file_content = all_content,
+        sha256 = "728d537d466a062e94705d44ee8c13c7b82d1b66f59f4e948e0cbf1cd7c461d8",
+    )

--- a/examples/postgres/BUILD
+++ b/examples/postgres/BUILD
@@ -1,0 +1,122 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@rules_foreign_cc//tools/build_defs:configure.bzl", "configure_make")
+load("@rules_foreign_cc//tools/build_defs:framework.bzl", "foreign_runtime")
+
+# This example tests a somewhat complex dependency scheme::
+#
+#     ncurses <- readline <- postgres
+#                 openssl <--/
+
+CONFIGURE_ENV_VARS = select({
+    # See https://github.com/bazelbuild/rules_foreign_cc/issues/338
+    "@bazel_tools//src/conditions:darwin": {"AR": ""},
+    "//conditions:default": {},
+})
+
+sh_library(
+    name = "exec",
+    srcs = ["exec.sh"],
+)
+
+configure_make(
+    name = "ncurses",
+    configure_env_vars = CONFIGURE_ENV_VARS,
+    configure_options = [
+        "--without-manpages",
+        "--without-debug",
+        "--without-ada",
+        "--without-tests",
+        "--without-tack",
+        "--disable-home-terminfo",
+        "--disable-db-install",
+        "--enable-interop",
+    ] + select({
+        "@bazel_tools//src/conditions:darwin": [],
+        "//conditions:default": [
+            # The configure script checks this value and when run under Bazel on
+            # bare-bones Debian 10 it gets a value of "unknown" which triggers
+            # downstream errors.  When run in Debian 10 in a user shell, this is
+            # the result (and it's also a hard coded value in the configure
+            # script).
+            "ARFLAGS=-curvU",
+        ],
+    }),
+    lib_source = "@ncurses//:all",
+    static_libraries = ["libncurses.a"],
+)
+
+configure_make(
+    name = "readline",
+    configure_env_vars = CONFIGURE_ENV_VARS,
+    lib_source = "@readline//:all",
+    static_libraries = [
+        "libreadline.a",
+        "libhistory.a",
+    ],
+    deps = [":ncurses"],
+)
+
+configure_make(
+    name = "openssl",
+    configure_command = "config",
+    configure_env_vars = CONFIGURE_ENV_VARS,
+    lib_source = "@openssl//:all",
+    static_libraries = [
+        "libssl.a",
+        "libcrypto.a",
+    ],
+)
+
+configure_make(
+    name = "postgres",
+    binaries = [
+        "psql",
+        "pg_ctl",
+        "postgres",
+        "initdb",
+    ],
+    configure_env_vars = CONFIGURE_ENV_VARS,
+    configure_options = ["--with-openssl"],
+    lib_source = "@postgres//:all",
+    static_libraries = ["libpq.a"],
+    deps = [
+        ":openssl",
+        ":readline",
+    ],
+)
+
+foreign_runtime(
+    name = "postgres.runtime",
+    srcs = [":postgres"],
+)
+
+runtime_data = select({
+    "@bazel_tools//src/conditions:darwin": [],
+    "//conditions:default": [":postgres.runtime"],
+})
+
+filegroup(
+    name = "psql_binary",
+    srcs = [":postgres"],
+    output_group = "psql",
+)
+
+sh_binary(
+    name = "psql",
+    srcs = [":exec"],
+    args = ["$(location :psql_binary)"],
+    data = [":psql_binary"] + runtime_data,
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)
+
+sh_binary(
+    name = "check_ldd",
+    srcs = [":exec"],
+    args = [
+        "ldd",
+        "$(location :psql_binary)",
+    ],
+    data = [":psql_binary"] + runtime_data,
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)

--- a/examples/postgres/exec.sh
+++ b/examples/postgres/exec.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# See https://github.com/bazelbuild/bazel/blob/master/tools/bash/runfiles/runfiles.bash
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+set -euo pipefail
+
+runfiles_export_envvars
+
+if [ "$( uname )" == "Linux" ]; then
+  export LD_LIBRARY_PATH=
+  for manifest in $( cut -f2 -d' ' "${RUNFILES_MANIFEST_FILE}" | grep -E '.LD_LIBRARY_PATH$' ); do
+    for rel in $( cat "$manifest" ); do
+      LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$PWD/$rel"
+    done
+  done
+fi
+
+exec $@


### PR DESCRIPTION
In attempting to write some rules for PostgreSQL that would build on a
both MacOS and a bare Debian 10 installation with only Bazel and
build-essential installed, I ran into [2] on Linux.  This attempts to
generalize approach taken in [1] to address [2]

This change also adds a foreign_runtime rule which replaces the
filegroup(..., output_group = "gen_dir").  It bundles all transitive
ForeignCcArtifact dependencies and produces a manifest file suitable
to build an LD_LIBRARY_PATH environment variable at runtime.  An
"exec.sh" wrapper then uses the shell runfiles support in @bazel_tools
to build the right environment variable.

Notably, all this was unnecessary on MaxOS.

[1] https://github.com/bazelbuild/rules_foreign_cc/pull/247
[2] https://github.com/bazelbuild/rules_foreign_cc/issues/241

Tested:

Confirm that binaries find the right library dependencies at runtime
on Linux.

    $ bazel run postgres:check_ldd
    ...
    INFO: Build completed successfully, 4 total actions
    	linux-vdso.so.1 (0x00007ffe4a991000)
    	libpq.so.5 => /home/vagrant/.cache/bazel/_bazel_vagrant/1e1e282f2d2054fbbe63d9fcfcb08d64/execroot/rules_foreign_cc_tests/bazel-out/k8-fastbuild/bin/postgres/check_ldd.runfiles/rules_foreign_cc_tests/postgres/copy_postgres/postgres/lib/libpq.so.5 (0x00007f1d67f30000)
    	libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f1d67da7000)
    	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f1d67c24000)
    	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f1d67c03000)
    	libreadline.so.8 => /home/vagrant/.cache/bazel/_bazel_vagrant/1e1e282f2d2054fbbe63d9fcfcb08d64/execroot/rules_foreign_cc_tests/bazel-out/k8-fastbuild/bin/postgres/check_ldd.runfiles/rules_foreign_cc_tests/postgres/copy_readline/readline/lib/libreadline.so.8 (0x00007f1d67ba5000)
    	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f1d67b9b000)
    	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f1d679da000)
    	libssl.so.1.1 => /home/vagrant/.cache/bazel/_bazel_vagrant/1e1e282f2d2054fbbe63d9fcfcb08d64/execroot/rules_foreign_cc_tests/bazel-out/k8-fastbuild/bin/postgres/check_ldd.runfiles/rules_foreign_cc_tests/postgres/copy_openssl/openssl/lib/libssl.so.1.1 (0x00007f1d67927000)
    	libcrypto.so.1.1 => /home/vagrant/.cache/bazel/_bazel_vagrant/1e1e282f2d2054fbbe63d9fcfcb08d64/execroot/rules_foreign_cc_tests/bazel-out/k8-fastbuild/bin/postgres/check_ldd.runfiles/rules_foreign_cc_tests/postgres/copy_openssl/openssl/lib/libcrypto.so.1.1 (0x00007f1d675df000)
    	/lib64/ld-linux-x86-64.so.2 (0x00007f1d68062000)
    	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f1d675c3000)
    	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f1d675be000)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bazelbuild/rules_foreign_cc/417)
<!-- Reviewable:end -->
