### PR TITLE
Add tools_deps_env_vars

### DIFF
--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -105,6 +105,13 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
         cfg = "host",
         default = [],
     ),
+    "tools_deps_env_vars": attr.string_dict(
+        doc = (
+            "Optional environment variables which will point to the absolute path of the file in " +
+            "tools_deps dir with the value's name. " +
+            "e.g. if this is set as {\"PERL\": \"perl6\"} the action will have the env var PERL=/path/to/tools/deps/bin/perl6"
+        ),
+    ),
     "out_include_dir": attr.string(
         doc = "Optional name of the output subdirectory with the header files, defaults to 'include'.",
         mandatory = False,
@@ -303,7 +310,7 @@ def cc_external_rule_impl(ctx, attrs):
         "export BUILD_TMPDIR=##tmpdir##",
         "export EXT_BUILD_DEPS=##tmpdir##",
         "export INSTALLDIR=$$EXT_BUILD_ROOT$$/" + empty.file.dirname + "/" + lib_name,
-    ]
+    ] + ["export " + key + "=${EXT_BUILD_DEPS}/bin/" + value for key, value in ctx.attr.tools_deps_env_vars.items()]
 
     make_commands = []
     for line in attrs.make_commands:


### PR DESCRIPTION
Some external build tools allow overriding which version of a binary will be used by tool-specific environment variables. This is already done for a hard-coded set of tools here: https://github.com/bazelbuild/rules_foreign_cc/blob/9eb30f8c5a214799b73707666ca49e7b7a35978f/tools/build_defs/configure_script.bzl#L170-L175

This PR allows users to specify that additional environment variables should be set for tools in `${EXT_BUILD_DEPS}/bin` - these are already added to the `$PATH` but some build tools require env vars rather than presence on the `$PATH` to do this overriding.