### PR TITLE
Expand depset to list

### DIFF
--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -587,7 +587,7 @@ def _define_inputs(attrs):
             tools_files += _list(file_list)
 
     for tool in attrs.additional_tools:
-        for file_list in tool.files:
+        for file_list in tool.files.to_list():
             tools_files += _list(file_list)
 
     # These variables are needed for correct C/C++ providers constraction,


### PR DESCRIPTION
Otherwise if I put anything in additional_tools I get an error about
depset not being iterable.

This matches the for loop just above, which does the to_list conversion.