### PR TITLE
Fix failing configure_make builds on macOS

### DIFF
--- a/tools/build_defs/shell_toolchain/toolchains/impl/osx_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/osx_commands.bzl
@@ -74,7 +74,7 @@ for child in "${children[@]}"; do
   if [[ -f "$child" ]]; then
     cp "$child" "$target"
   elif [[ -L "$child" ]]; then
-    local $actual=$(readlink "$child")
+    local actual=$(readlink "$child")
     if [[ -f "$actual" ]]; then
       cp "$actual" "$target"
     else


### PR DESCRIPTION
Hey thanks for this project, it's amazing.

I recently had `configure_make` builds fail on macOS, but the logs showed the compile was successful. I tracked the bug down to the generated shell script, which was throwing an error on copying the results.

There was a slight error with the bash syntax, a local variable was being created *and* expanded at the same time, but this fails as the variable doesn't yet exist.

Removing this variable expansion fixed my builds.

Something like `set -o nounset` or `set -e` would've caught this, but I wasn't confident enough with my bash skills to add that here, out of fear of causing errors elsewhere.