### PR TITLE
Replace references to @bazel_tools//platforms with @platforms//

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -89,8 +89,8 @@ sh_test(
 toolchain(
     name = "built_ninja_toolchain_osx",
     exec_compatible_with = [
-        "@bazel_tools//platforms:osx",
-        "@bazel_tools//platforms:x86_64",
+        "@platforms//os:osx",
+        "@platforms//cpu:x86_64",
     ],
     toolchain = "@rules_foreign_cc//tools/build_defs/native_tools:built_ninja",
     toolchain_type = "@rules_foreign_cc//tools/build_defs:ninja_toolchain",
@@ -99,8 +99,8 @@ toolchain(
 toolchain(
     name = "built_ninja_toolchain_linux",
     exec_compatible_with = [
-        "@bazel_tools//platforms:linux",
-        "@bazel_tools//platforms:x86_64",
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
     ],
     toolchain = "@rules_foreign_cc//tools/build_defs/native_tools:built_ninja",
     toolchain_type = "@rules_foreign_cc//tools/build_defs:ninja_toolchain",

--- a/toolchains_examples/BUILD
+++ b/toolchains_examples/BUILD
@@ -20,8 +20,8 @@ constraint_value(
 platform(
     name = "fancy_platform",
     constraint_values = [
-        "@bazel_tools//platforms:linux",
-        "@bazel_tools//platforms:x86_64",
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
         ":fancy_constraint_value",
     ],
 )

--- a/tools/build_defs/shell_toolchain/toolchains/toolchain_mappings.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/toolchain_mappings.bzl
@@ -10,19 +10,19 @@ ToolchainMapping = provider(
 TOOLCHAIN_MAPPINGS = [
     ToolchainMapping(
         exec_compatible_with = [
-            "@bazel_tools//platforms:linux",
+            "@platforms//os:linux",
         ],
         file = "@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains/impl:linux_commands.bzl",
     ),
     ToolchainMapping(
         exec_compatible_with = [
-            "@bazel_tools//platforms:windows",
+            "@platforms//os:windows",
         ],
         file = "@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains/impl:windows_commands.bzl",
     ),
     ToolchainMapping(
         exec_compatible_with = [
-            "@bazel_tools//platforms:osx",
+            "@platforms//os:osx",
         ],
         file = "@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains/impl:osx_commands.bzl",
     ),


### PR DESCRIPTION
The former has been deprecated and will break by `--incompatible_use_platforms_repo_for_constraints`, as announced in
https://github.com/bazelbuild/bazel/issues/8622.

Fixes #354.