### PR TITLE
Replace target attribute with targets

### DIFF
--- a/examples/with_prebuilt_ninja_artefact/BUILD
+++ b/examples/with_prebuilt_ninja_artefact/BUILD
@@ -9,7 +9,7 @@ native_tool_toolchain(
     # In the path, we also start with the name of the directory,
     # in this case the external repository.
     path = "ninja_artefact/ninja",
-    target = "@ninja_artefact//:all",
+    targets = ["@ninja_artefact//:all"],
     visibility = ["//visibility:public"],
 )
 

--- a/tools/build_defs/native_tools/BUILD
+++ b/tools/build_defs/native_tools/BUILD
@@ -19,7 +19,7 @@ make_tool(
 native_tool_toolchain(
     name = "built_make",
     path = "make/bin/make",
-    target = ":make_tool",
+    targets = [":make_tool"],
     visibility = ["//visibility:public"],
 )
 
@@ -38,7 +38,7 @@ cmake_tool(
 native_tool_toolchain(
     name = "built_cmake",
     path = "cmake/bin/cmake",
-    target = ":cmake_tool",
+    targets = [":cmake_tool"],
     visibility = ["//visibility:public"],
 )
 
@@ -57,7 +57,7 @@ ninja_tool(
 native_tool_toolchain(
     name = "built_ninja",
     path = "ninja/ninja",
-    target = ":ninja_tool",
+    targets = [":ninja_tool"],
     visibility = ["//visibility:public"],
 )
 

--- a/tools/build_defs/native_tools/tool_access.bzl
+++ b/tools/build_defs/native_tools/tool_access.bzl
@@ -12,9 +12,9 @@ def get_make_data(ctx):
 
 def _access_and_expect_label_copied(toolchain_type_, ctx, tool_name):
     tool_data = access_tool(toolchain_type_, ctx, tool_name)
-    if tool_data.target:
+    if tool_data.targets:
         return struct(
-            deps = [tool_data.target],
+            deps = tool_data.targets,
             # as the tool will be copied into tools directory
             path = "$EXT_BUILD_DEPS/bin/{}".format(tool_data.path),
         )


### PR DESCRIPTION
This is so that multiple labels could be provided to a toolchain as sources. An example is `emcmake`, which needs both `emscripten` and `binaryen` to run.

Another reason for this is to pass in config files that might be needed for the toolchain. The config files can be passed in as a label and will be available in `${EXT_BUILD_DEPS}/bin`, just like any other directory.