### PR TITLE
Add prefix script attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,9 @@ attrs: {
     # Not used by the shell script part in cc_external_rule_impl.
     "additional_tools": attr.label_list(mandatory = False, allow_files = True, default = []),
     #
+    # Optional part of the shell script to be added before the configure command
+    "prefix_script": attr.string(mandatory = False),
+    #
     # Optional part of the shell script to be added after the make commands
     "postfix_script": attr.string(mandatory = False),
     # Optinal make commands, defaults to ["make", "make install"]

--- a/examples/build_ffmpeg_with_prefix_script/BUILD.ffmpeg
+++ b/examples/build_ffmpeg_with_prefix_script/BUILD.ffmpeg
@@ -1,0 +1,31 @@
+load("@rules_foreign_cc//tools/build_defs:configure.bzl", "configure_make")
+
+filegroup(
+    name = "all",
+    srcs = glob(["**"]),
+)
+
+configure_make(
+    name = "library",
+    lib_source = ":all",
+    configure_options = [
+        "--disable-static",
+        "--enable-shared",
+        "--enable-libx264",
+        "--enable-gpl",
+    ],
+    deps = [
+        "@x264//:library",
+    ],
+    shared_libraries = [
+        "libavcodec.so",
+        "libavdevice.so",
+        "libavfilter.so",
+        "libavformat.so",
+        "libavutil.so",
+        "libpostproc.so",
+        "libswresample.so",
+        "libswscale.so",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/examples/build_ffmpeg_with_prefix_script/BUILD.x264
+++ b/examples/build_ffmpeg_with_prefix_script/BUILD.x264
@@ -1,0 +1,38 @@
+load("@rules_foreign_cc//tools/build_defs:configure.bzl", "configure_make")
+
+filegroup(
+    name = "all",
+    srcs = glob(["**"], exclude = ["configure"]) + [
+        "//:configure.modified",
+    ],
+)
+
+genrule(
+    name = "modified_configure",
+    srcs = [
+        "configure",
+    ],
+    outs = ["configure.modified"],
+    cmd = "\n".join([
+        "cp $< $@",
+        "sed -i 's|ASFLAGS=\"$$ASFLAGS -DARCH_X86_64|ASFLAGS=\"$$NASMFLAGS -DARCH_X86_64|g' $@",
+    ]),
+)
+
+x264_prefix_script = """
+find -L $$EXT_BUILD_ROOT$$ -type f -name "*.modified" -exec sh -c "cp {} $$EXT_BUILD_ROOT$$/external/x264/\$(basename {} .modified)" \;
+"""
+
+configure_make(
+    name = "library",
+    lib_source = ":all",
+    configure_options = [
+        "--enable-shared",
+        "--extra-cflags='-Dredacted=\"\\\"redacted\\\"\"'",
+    ],
+    prefix_script = x264_prefix_script,
+    shared_libraries = [
+        "libx264.so",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/examples/build_ffmpeg_with_prefix_script/README.md
+++ b/examples/build_ffmpeg_with_prefix_script/README.md
@@ -1,0 +1,4 @@
+```sh
+bazel build @ffmpeg//:library
+LD_LIBRARY_PATH=$(find -L bazel-out -type d -path "**/copy_*/*/lib" | sed -e ':a;N;$!ba;s|\n|:|g') firefox
+```

--- a/examples/build_ffmpeg_with_prefix_script/WORKSPACE
+++ b/examples/build_ffmpeg_with_prefix_script/WORKSPACE
@@ -1,0 +1,26 @@
+workspace(name = "build_ffmpeg_with_prefix_script")
+
+local_repository(
+    name = "rules_foreign_cc",
+    path = "../..",
+)
+
+load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
+
+rules_foreign_cc_dependencies()
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+
+new_git_repository(
+    name = "x264",
+    branch = "master",
+    build_file = "@//:BUILD.x264",
+    remote = "https://code.videolan.org/videolan/x264.git",
+)
+
+new_git_repository(
+    name = "ffmpeg",
+    branch = "master",
+    build_file = "@//:BUILD.ffmpeg",
+    remote = "https://git.ffmpeg.org/ffmpeg.git",
+)

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -50,6 +50,9 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
     # Not used by the shell script part in cc_external_rule_impl.
     "additional_tools": attr.label_list(mandatory = False, allow_files = True, default = []),
     #
+    # Optional part of the shell script to be added before the configure command
+    "prefix_script": attr.string(mandatory = False),
+    #
     # Optional part of the shell script to be added after the make commands
     "postfix_script": attr.string(mandatory = False),
     # Optinal make commands, defaults to ["make", "make install"]
@@ -185,10 +188,11 @@ def cc_external_rule_impl(ctx, attrs):
         will be installed
 
         These variables should be used by the calling rule to refer to the created directory structure.
-     4) calls 'attrs.create_configure_script'
-     5) calls 'attrs.make_commands'
-     6) calls 'attrs.postfix_script'
-     7) replaces absolute paths in possibly created scripts with a placeholder value
+     4) calls 'attrs.prefix_script'
+     5) calls 'attrs.create_configure_script'
+     6) calls 'attrs.make_commands'
+     7) calls 'attrs.postfix_script'
+     8) replaces absolute paths in possibly created scripts with a placeholder value
 
      Please see cmake.bzl for example usage.
 
@@ -254,6 +258,7 @@ def cc_external_rule_impl(ctx, attrs):
         _print_env(),
         "\n".join(_copy_deps_and_tools(inputs)),
         "cd $$BUILD_TMPDIR$$",
+        attrs.prefix_script or "",
         attrs.create_configure_script(ConfigureParameters(ctx = ctx, attrs = attrs, inputs = inputs)),
         "\n".join(make_commands),
         attrs.postfix_script or "",


### PR DESCRIPTION
This pr add `prefix_script` to attribute, unlike `postfix_script`, `prefix_script` will run before the configure command, which open up new opposites, like making changes to the makefiles or accepting a license.

This new attribute will works for `configure_make`, `cmake_external`, etc.

I also provided an example of building ffmpeg.