### PR TITLE
configure: add autoconf to configure

### DIFF
--- a/tools/build_defs/configure.bzl
+++ b/tools/build_defs/configure.bzl
@@ -61,6 +61,9 @@ def _create_configure_script(configureParameters):
         deps = ctx.attr.deps,
         inputs = inputs,
         configure_in_place = ctx.attr.configure_in_place,
+        autoconf = ctx.attr.autoconf,
+        autoconf_options = ctx.attr.autoconf_options,
+        autoconf_env_vars = ctx.attr.autoconf_env_vars,
         autoreconf = ctx.attr.autoreconf,
         autoreconf_options = ctx.attr.autoreconf_options,
         autoreconf_env_vars = ctx.attr.autoreconf_env_vars,
@@ -123,6 +126,21 @@ def _attrs():
         "autoreconf_env_vars": attr.string_dict(
             doc = "Environment variables to be set for 'autoreconf' invocation.",
         ),
+        "autoconf": attr.bool(
+            mandatory = False,
+            default = False,
+            doc = (
+              "Set to True if 'autoconf' should be invoked before 'configure', " +
+              "currently requires 'configure_in_place' to be True."
+            ),
+        ),
+        "autoconf_options": attr.string_list(
+            doc = "Any options to be put in the 'autoconf.sh' command line.",
+        ),
+        "autoconf_env_vars": attr.string_dict(
+            doc = "Environment variables to be set for 'autoconf' invocation.",
+        ),
+
         "autogen": attr.bool(
             doc = (
                 "Set to True if 'autogen.sh' should be invoked before 'configure', " +

--- a/tools/build_defs/configure_script.bzl
+++ b/tools/build_defs/configure_script.bzl
@@ -14,6 +14,9 @@ def create_configure_script(
         deps,
         inputs,
         configure_in_place,
+        autoconf,
+        autoconf_options,
+        autoconf_env_vars,
         autoreconf,
         autoreconf_options,
         autoreconf_env_vars,
@@ -45,6 +48,12 @@ def create_configure_script(
             root_path,
             autogen_command,
             " ".join(autogen_options),
+        ).lstrip())
+
+    if autoconf and configure_in_place:
+        script.append("{} autoconf {}".format(
+            " ".join(["{}=\"{}\"".format(key, autoconf_env_vars[key]) for key in autoconf_env_vars]),
+            " ".join(autoconf_options),
         ).lstrip())
 
     if autoreconf and configure_in_place:


### PR DESCRIPTION
We have run into a library that works with autoconf (jemalloc) but not autoreconf.
As such, I've introduced a new rule to use autoconf as the build script.