### PR TITLE
Migrate to modern linking input API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is **not an officially supported Google product**
 
 ## Bazel versions compatibility
 
-Works with Bazel after 0.23 without any flags.
+Works with Bazel after 3.0.0 without any flags.
 
 ## News
 **March 2019:**

--- a/tools/build_defs/cc_toolchain_util.bzl
+++ b/tools/build_defs/cc_toolchain_util.bzl
@@ -102,7 +102,7 @@ def _create_libraries_to_link(ctx, files):
             alwayslink = ctx.attr.alwayslink,
         ))
 
-    return libs
+    return depset(direct = libs)
 
 def _is_position_independent(file):
     return file.basename.endswith(".pic.a")
@@ -214,8 +214,13 @@ def create_linking_info(ctx, user_link_flags, files):
     """
 
     return cc_common.create_linking_context(
-        user_link_flags = user_link_flags,
-        libraries_to_link = _create_libraries_to_link(ctx, files),
+        linker_inputs = depset(direct = [
+            cc_common.create_linker_input(
+                owner = ctx.label,
+                libraries = _create_libraries_to_link(ctx, files),
+                user_link_flags = depset(direct = user_link_flags),
+            ),
+        ]),
     )
 
 def get_env_vars(ctx):

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -676,12 +676,9 @@ def _extract_libraries(library_to_link):
 
 def _collect_libs(cc_linking):
     libs = []
-    libraries_to_link = cc_linking.libraries_to_link
-    if type(libraries_to_link) == "depset":
-        libraries_to_link = libraries_to_link.to_list()
-
-    for library_to_link in libraries_to_link:
-        for library in _extract_libraries(library_to_link):
-            if library:
-                libs.append(library)
+    for li in cc_linking.linker_inputs.to_list():
+        for library_to_link in li.libraries:
+            for library in _extract_libraries(library_to_link):
+                if library:
+                    libs.append(library)
     return collections.uniq(libs)


### PR DESCRIPTION
See https://github.com/bazelbuild/bazel/issues/10860.