### PR TITLE
Use null delimited find for looping

### DIFF
--- a/test/expected/inner_fun_text.txt
+++ b/test/expected/inner_fun_text.txt
@@ -7,10 +7,9 @@ elif [[ -L "$1" ]]; then
 local actual=$(readlink "$1")
 symlink_contents_to_dir $actual $target
 elif [[ -d "$1" ]]; then
-local children=$(find -H "$1" -maxdepth 1 -mindepth 1)
-for child in $children; do
+while IFS= read -r -d '' child; do
 symlink_to_dir $child $target
-done
+done < <(find -H "$1" -maxdepth 1 -mindepth 1 -print0)
 fi
 }
 function symlink_to_dir() {
@@ -21,12 +20,11 @@ ln -s -f -t "$target" "$1"
 elif [[ -L "$1" ]]; then
 cp $1 $2
 elif [[ -d "$1" ]]; then
-local children=$(find -H "$1" -maxdepth 1 -mindepth 1)
 local dirname=$(basename "$1")
 mkdir -p "$target/$dirname"
-for child in $children; do
+while IFS= read -r -d '' child; do
 symlink_to_dir $child $target/$dirname
-done
+done < <(find -H "$1" -maxdepth 1 -mindepth 1 -print0)
 else
 echo "Can not copy $1"
 fi

--- a/test/expected/inner_fun_text_osx.txt
+++ b/test/expected/inner_fun_text_osx.txt
@@ -7,10 +7,9 @@ elif [[ -L "$1" ]]; then
 local actual=$(readlink "$1")
 symlink_contents_to_dir $actual $target
 elif [[ -d "$1" ]]; then
-local children=$(find "$1" -maxdepth 1 -mindepth 1)
-for child in $children; do
+while IFS= read -r -d '' child; do
 symlink_to_dir $child $target
-done
+done < <(find "$1" -maxdepth 1 -mindepth 1 -print0)
 fi
 }
 function symlink_to_dir() {
@@ -21,12 +20,11 @@ ln -s -f "$1" "$target"
 elif [[ -L "$1" ]]; then
 cp $1 $2
 elif [[ -d "$1" ]]; then
-local children=$(find "$1" -maxdepth 1 -mindepth 1)
 local dirname=$(basename "$1")
 mkdir -p "$target/$dirname"
-for child in $children; do
+while IFS= read -r -d '' child; do
 symlink_to_dir $child $target/$dirname
-done
+done < <(find "$1" -maxdepth 1 -mindepth 1 -print0)
 else
 echo "Can not copy $1"
 fi

--- a/tools/build_defs/shell_toolchain/toolchains/impl/osx_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/osx_commands.bzl
@@ -62,10 +62,9 @@ fi
 
 def copy_dir_contents_to_dir(source, target):
     text = """
-local children=$(find "$1" -maxdepth 1 -mindepth 1)
 local target="$2"
 mkdir -p "${target}"
-for child in $children; do
+while IFS= read -r -d '' child; do
   if [[ -f "$child" ]]; then
     cp "$child" "$target"
   elif [[ -L "$child" ]]; then
@@ -82,7 +81,7 @@ for child in $children; do
     mkdir -p "$target/$dirn"
     ##copy_dir_contents_to_dir## "$child" "$target/$dirn"
   fi
-done
+done < <(find "$1" -maxdepth 1 -mindepth 1 -print0)
 """
     return FunctionAndCall(text = text)
 
@@ -95,10 +94,9 @@ elif [[ -L "$1" ]]; then
   local actual=$(readlink "$1")
   ##symlink_contents_to_dir## "$actual" "$target"
 elif [[ -d "$1" ]]; then
-  local children=$(find "$1" -maxdepth 1 -mindepth 1)
-  for child in $children; do
+  while IFS= read -r -d '' child; do
     ##symlink_to_dir## "$child" "$target"
-  done
+  done < <(find "$1" -maxdepth 1 -mindepth 1 -print0)
 fi
 """
     return FunctionAndCall(text = text)
@@ -111,12 +109,11 @@ if [[ -f "$1" ]]; then
 elif [[ -L "$1" ]]; then
   cp $1 $2
 elif [[ -d "$1" ]]; then
-  local children=$(find "$1" -maxdepth 1 -mindepth 1)
   local dirname=$(basename "$1")
   mkdir -p "$target/$dirname"
-  for child in $children; do
+  while IFS= read -r -d '' child; do
     ##symlink_to_dir## "$child" "$target/$dirname"
-  done
+  done < <(find "$1" -maxdepth 1 -mindepth 1 -print0)
 else
   echo "Can not copy $1"
 fi
@@ -128,12 +125,11 @@ def script_prelude():
 
 def increment_pkg_config_path(source):
     text = """
-local children=$(find $1 -mindepth 1 -name '*.pc')
-# assume there is only one directory with pkg config
-for child in $children; do
+while IFS= read -r -d '' child; do
+  # assume there is only one directory with pkg config
   export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(dirname $child)"
   return
-done
+done < <(find $1 -mindepth 1 -name '*.pc' -print0)
 """
     return FunctionAndCall(text = text)
 
@@ -159,13 +155,11 @@ def cleanup_function(on_success, on_failure):
 
 def children_to_path(dir_):
     text = """if [ -d {dir_} ]; then
-  local tools=$(find $EXT_BUILD_DEPS/bin -maxdepth 1 -mindepth 1)
-  for tool in $tools;
-  do
+  while IFS= read -r -d '' tool; do
     if  [[ -d \"$tool\" ]] || [[ -L \"$tool\" ]]; then
       export PATH=$PATH:$tool
     fi
-  done
+  done < <(find $EXT_BUILD_DEPS/bin -maxdepth 1 -mindepth 1 -print0)
 fi""".format(dir_ = dir_)
     return FunctionAndCall(text = text)
 


### PR DESCRIPTION
Looping over the results of find does not work if the filenames contain spaces.