### PR TITLE
Add waf support

### DIFF
--- a/for_workspace/repositories.bzl
+++ b/for_workspace/repositories.bzl
@@ -1,6 +1,6 @@
 """ Remote repositories, used by this project itself """
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 
 def repositories():
     _all_content = """filegroup(name = "all", srcs = glob(["**"]), visibility = ["//visibility:public"])"""
@@ -42,4 +42,12 @@ def repositories():
         urls = [
             "https://github.com/Kitware/CMake/releases/download/v3.18.2/cmake-3.18.2.tar.gz",
         ],
+    )
+
+    http_file(
+        name = "waf",
+        downloaded_file_path = "waf",
+        executable = True,
+        urls = ["https://waf.io/waf-2.0.21"],
+        sha256 = "7cebf2c5efe53cbb9a4b5bdc4b49ae90ecd64a8fce7a3222d58e591b58215306",
     )

--- a/tools/build_defs/BUILD
+++ b/tools/build_defs/BUILD
@@ -13,6 +13,11 @@ toolchain_type(
     visibility = ["//visibility:public"],
 )
 
+toolchain_type(
+    name = "waf_toolchain",
+    visibility = ["//visibility:public"],
+)
+
 # Preinstalled cmake will always be the default, if toolchain with more exact constraints
 # is not defined before; registered from workspace_definitions.bzl#rules_foreign_cc_dependencies
 toolchain(
@@ -35,4 +40,10 @@ toolchain(
     name = "preinstalled_make_toolchain",
     toolchain = "@rules_foreign_cc//tools/build_defs/native_tools:preinstalled_make",
     toolchain_type = "@rules_foreign_cc//tools/build_defs:make_toolchain",
+)
+
+toolchain(
+    name = "downloaded_waf_toolchain",
+    toolchain = "@rules_foreign_cc//tools/build_defs/native_tools:downloaded_waf",
+    toolchain_type = "@rules_foreign_cc//tools/build_defs:waf_toolchain",
 )

--- a/tools/build_defs/configure.bzl
+++ b/tools/build_defs/configure.bzl
@@ -58,6 +58,7 @@ def _create_configure_script(configureParameters):
         user_vars = dict(ctx.attr.configure_env_vars),
         is_debug = is_debug_mode(ctx),
         configure_command = ctx.attr.configure_command,
+        configure_script = ctx.attr.configure_script,
         deps = ctx.attr.deps,
         inputs = inputs,
         configure_in_place = ctx.attr.configure_in_place,
@@ -81,9 +82,10 @@ def _get_install_prefix(ctx):
 def _attrs():
     attrs = dict(CC_EXTERNAL_RULE_ATTRIBUTES)
     attrs.update({
+        "configure_command": attr.string(),
         # The name of the configuration script file, default: configure.
         # The file must be in the root of the source directory.
-        "configure_command": attr.string(default = "configure"),
+        "configure_script": attr.string(default = "configure"),
         # Any options to be put on the 'configure' command line.
         "configure_options": attr.string_list(),
         # Environment variables to be set for the 'configure' invocation.

--- a/tools/build_defs/configure.bzl
+++ b/tools/build_defs/configure.bzl
@@ -82,6 +82,8 @@ def _get_install_prefix(ctx):
 def _attrs():
     attrs = dict(CC_EXTERNAL_RULE_ATTRIBUTES)
     attrs.update({
+        # The configure command, prioritise 'configure_script'
+        # Set either 'configure_command' or 'configure_script'
         "configure_command": attr.string(),
         # The name of the configuration script file, default: configure.
         # The file must be in the root of the source directory.

--- a/tools/build_defs/configure.bzl
+++ b/tools/build_defs/configure.bzl
@@ -57,8 +57,8 @@ def _create_configure_script(configureParameters):
         user_options = ctx.attr.configure_options,
         user_vars = dict(ctx.attr.configure_env_vars),
         is_debug = is_debug_mode(ctx),
-        configure_command = ctx.attr.configure_command,
-        configure_script = ctx.attr.configure_script,
+        configure_command = "",
+        configure_script = ctx.attr.configure_command,
         deps = ctx.attr.deps,
         inputs = inputs,
         configure_in_place = ctx.attr.configure_in_place,
@@ -82,12 +82,9 @@ def _get_install_prefix(ctx):
 def _attrs():
     attrs = dict(CC_EXTERNAL_RULE_ATTRIBUTES)
     attrs.update({
-        # The configure command, prioritise 'configure_script'
-        # Set either 'configure_command' or 'configure_script'
-        "configure_command": attr.string(),
         # The name of the configuration script file, default: configure.
         # The file must be in the root of the source directory.
-        "configure_script": attr.string(default = "configure"),
+        "configure_command": attr.string(default = "configure"),
         # Any options to be put on the 'configure' command line.
         "configure_options": attr.string_list(),
         # Environment variables to be set for the 'configure' invocation.

--- a/tools/build_defs/configure_script.bzl
+++ b/tools/build_defs/configure_script.bzl
@@ -11,6 +11,7 @@ def create_configure_script(
         user_vars,
         is_debug,
         configure_command,
+        configure_script,
         deps,
         inputs,
         configure_in_place,
@@ -30,11 +31,11 @@ def create_configure_script(
     script.append("echo \"PKG_CONFIG_PATH=$$PKG_CONFIG_PATH$$\"")
 
     root_path = "$$EXT_BUILD_ROOT$$/{}".format(root)
-    configure_path = "{}/{}".format(root_path, configure_command)
+    configure_path = "{}/{}".format(root_path, configure_script)
     if configure_in_place:
         script.append("##symlink_contents_to_dir## $$EXT_BUILD_ROOT$$/{} $$BUILD_TMPDIR$$".format(root))
         root_path = "$$BUILD_TMPDIR$$"
-        configure_path = "{}/{}".format(root_path, configure_command)
+        configure_path = "{}/{}".format(root_path, configure_script)
 
     if autogen and configure_in_place:
         # NOCONFIGURE is pseudo standard and tells the script to not invoke configure.

--- a/tools/build_defs/configure_script.bzl
+++ b/tools/build_defs/configure_script.bzl
@@ -54,9 +54,9 @@ def create_configure_script(
             " ".join(autoreconf_options),
         ).lstrip())
 
-    script.append("{env_vars} \"{configure}\" --prefix=$$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$ {user_options}".format(
+    script.append("{env_vars} {configure} --prefix=$$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$ {user_options}".format(
         env_vars = env_vars_string,
-        configure = configure_path,
+        configure = configure_command or "\"{}\"".format(configure_path),
         user_options = " ".join(user_options),
     ))
     return "\n".join(script)

--- a/tools/build_defs/configure_script.bzl
+++ b/tools/build_defs/configure_script.bzl
@@ -15,13 +15,13 @@ def create_configure_script(
         deps,
         inputs,
         configure_in_place,
-        autoreconf,
-        autoreconf_options,
-        autoreconf_env_vars,
-        autogen,
-        autogen_command,
-        autogen_options,
-        autogen_env_vars):
+        autoreconf = False,
+        autoreconf_options = [],
+        autoreconf_env_vars = {},
+        autogen = False,
+        autogen_command = "",
+        autogen_options = [],
+        autogen_env_vars = {}):
     env_vars_string = get_env_vars(workspace_name, tools, flags, user_vars, deps, inputs)
 
     script = []

--- a/tools/build_defs/native_tools/BUILD
+++ b/tools/build_defs/native_tools/BUILD
@@ -56,3 +56,10 @@ native_tool_toolchain(
     target = ":ninja_tool",
     visibility = ["//visibility:public"],
 )
+
+native_tool_toolchain(
+    name = "downloaded_waf",
+    path = "waf",
+    target = "@waf//file",
+    visibility = ["//visibility:public"],
+)

--- a/tools/build_defs/native_tools/tool_access.bzl
+++ b/tools/build_defs/native_tools/tool_access.bzl
@@ -9,6 +9,9 @@ def get_ninja_data(ctx):
 def get_make_data(ctx):
     return _access_and_expect_label_copied("@rules_foreign_cc//tools/build_defs:make_toolchain", ctx, "make")
 
+def get_waf_data(ctx):
+    return _access_and_expect_label_copied("@rules_foreign_cc//tools/build_defs:waf_toolchain", ctx, "waf")
+
 def _access_and_expect_label_copied(toolchain_type_, ctx, tool_name):
     tool_data = access_tool(toolchain_type_, ctx, tool_name)
     if tool_data.target:

--- a/tools/build_defs/waf.bzl
+++ b/tools/build_defs/waf.bzl
@@ -1,0 +1,86 @@
+load(
+    "//tools/build_defs:framework.bzl",
+    "CC_EXTERNAL_RULE_ATTRIBUTES",
+    "cc_external_rule_impl",
+    "create_attrs",
+)
+load(
+    "//tools/build_defs:detect_root.bzl",
+    "detect_root",
+)
+load(
+    "//tools/build_defs:cc_toolchain_util.bzl",
+    "get_flags_info",
+    "get_tools_info",
+    "is_debug_mode",
+)
+load(":configure_script.bzl", "create_configure_script")
+load("//tools/build_defs/native_tools:tool_access.bzl", "get_waf_data")
+load("@rules_foreign_cc//tools/build_defs:shell_script_helper.bzl", "os_name")
+
+def _waf(ctx, **kwargs):
+    waf_data = get_waf_data(ctx)
+
+    tools_deps = ctx.attr.tools_deps + waf_data.deps
+
+    copy_results = "##copy_dir_contents_to_dir## $$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$ $$INSTALLDIR$$\n"
+
+    attrs = create_attrs(
+        ctx.attr,
+        configure_name = "Configure",
+        create_configure_script = _create_waf_configure_script,
+        postfix_script = copy_results + "\n" + ctx.attr.postfix_script,
+        tools_deps = tools_deps,
+        make_path = waf_data.path,
+        **kwargs
+    )
+    return cc_external_rule_impl(ctx, attrs)
+
+def _create_waf_configure_script(configureParameters):
+    attrs = configureParameters.attrs
+    ctx = configureParameters.ctx
+    inputs = configureParameters.inputs
+
+    root = detect_root(ctx.attr.lib_source)
+
+    tools = get_tools_info(ctx)
+    flags = get_flags_info(ctx)
+
+    return create_configure_script(
+        workspace_name = ctx.workspace_name,
+        # as default, pass execution OS as target OS
+        target_os = os_name(ctx),
+        tools = tools,
+        flags = flags,
+        root = root,
+        user_options = ctx.attr.configure_options,
+        user_vars = dict(ctx.attr.configure_env_vars),
+        is_debug = is_debug_mode(ctx),
+        configure_command = ctx.attr.configure_command,
+        configure_script = "",
+        deps = ctx.attr.deps,
+        inputs = inputs,
+        configure_in_place = True,
+    )
+
+def _attrs():
+    attrs = dict(CC_EXTERNAL_RULE_ATTRIBUTES)
+    attrs.update({
+        "configure_command": attr.string(default = "waf configure"),
+        "configure_options": attr.string_list(),
+        "configure_env_vars": attr.string_dict(),
+        "make_commands": attr.string_list(mandatory = False, default = ["waf -j`nproc`", "waf install"]),
+    })
+    return attrs
+
+waf = rule(
+    attrs = _attrs(),
+    fragments = ["cpp"],
+    output_to_genfiles = True,
+    implementation = _waf,
+    toolchains = [
+        "@rules_foreign_cc//tools/build_defs:waf_toolchain",
+        "@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains:shell_commands",
+        "@bazel_tools//tools/cpp:toolchain_type",
+    ],
+)

--- a/workspace_definitions.bzl
+++ b/workspace_definitions.bzl
@@ -99,4 +99,5 @@ def rules_foreign_cc_dependencies(
             "@rules_foreign_cc//tools/build_defs:preinstalled_cmake_toolchain",
             "@rules_foreign_cc//tools/build_defs:preinstalled_ninja_toolchain",
             "@rules_foreign_cc//tools/build_defs:preinstalled_make_toolchain",
+            "@rules_foreign_cc//tools/build_defs:downloaded_waf_toolchain",
         )


### PR DESCRIPTION
Hi, this pr add waf support

# Example usage
```starlark
BUILD.mpv
---
load("@rules_foreign_cc//tools/build_defs:waf.bzl", "waf")

filegroup(
    name = "all",
    srcs = glob(["**"]),
)

waf(
    name = "binary",
    lib_source = ":all",
    binaries = [
        "mpv",
    ],
    deps = [
        "@ffmpeg//:mpv_library",
        "@lua52//:library",
    ],
    visibility = ["//visibility:public"],
)
```

```starlark
WORKSPACE
---
http_archive(
    name = "rules_foreign_cc",
    strip_prefix = "whs_rules_foreign_cc-add-waf-upstream2",
    url = "https://github.com/whs-dot-hk/whs_rules_foreign_cc/archive/add-waf-upstream2.zip",
    patch_args = [
        "-p1",
    ],
    patches = [
        "//:0001-Whs-essentials-patch.patch",
    ],
)
```

```patch
0001-Whs-essentials-patch.patch
---
From ef738f47d0778af0fca7f50762314861c4b426e4 Mon Sep 17 00:00:00 2001
From: whs <hswongac@gmail.com>
Date: Fri, 18 Dec 2020 21:35:37 +0800
Subject: [PATCH] Whs essentials patch

---
 tools/build_defs/configure_script.bzl | 24 ++++++++++++++++--------
 tools/build_defs/framework.bzl        |  4 ++--
 tools/build_defs/make.bzl             |  2 +-
 3 files changed, 19 insertions(+), 11 deletions(-)

diff --git a/tools/build_defs/configure_script.bzl b/tools/build_defs/configure_script.bzl
index 659d627..9618074 100644
--- a/tools/build_defs/configure_script.bzl
+++ b/tools/build_defs/configure_script.bzl
@@ -1,6 +1,17 @@
 load(":cc_toolchain_util.bzl", "absolutize_path_in_str")
 load(":framework.bzl", "get_foreign_cc_dep")
 
+def _pkgconfig_script(ext_build_dirs):
+    script = []
+    for ext_dir in ext_build_dirs:
+        script.append("##increment_pkg_config_path## $$EXT_BUILD_DEPS$$/" + ext_dir.basename)
+
+    script.append("echo \"PKG_CONFIG_PATH=$$PKG_CONFIG_PATH$$\"")
+
+    script.append("##define_absolute_paths## $$EXT_BUILD_DEPS$$ $$EXT_BUILD_DEPS$$")
+
+    return script
+
 def create_configure_script(
         workspace_name,
         target_os,
@@ -24,11 +35,9 @@ def create_configure_script(
         autogen_env_vars = {}):
     env_vars_string = get_env_vars(workspace_name, tools, flags, user_vars, deps, inputs)
 
-    script = []
-    for ext_dir in inputs.ext_build_dirs:
-        script.append("##increment_pkg_config_path## $$EXT_BUILD_ROOT$$/" + ext_dir.path)
+    ext_build_dirs = inputs.ext_build_dirs
 
-    script.append("echo \"PKG_CONFIG_PATH=$$PKG_CONFIG_PATH$$\"")
+    script = _pkgconfig_script(ext_build_dirs)
 
     root_path = "$$EXT_BUILD_ROOT$$/{}".format(root)
     configure_path = "{}/{}".format(root_path, configure_script)
@@ -72,11 +81,10 @@ def create_make_script(
         make_commands,
         prefix):
     env_vars_string = get_env_vars(workspace_name, tools, flags, user_vars, deps, inputs)
-    script = []
-    for ext_dir in inputs.ext_build_dirs:
-        script.append("##increment_pkg_config_path## $$EXT_BUILD_ROOT$$/" + ext_dir.path)
 
-    script.append("echo \"PKG_CONFIG_PATH=$$PKG_CONFIG_PATH$$\"")
+    ext_build_dirs = inputs.ext_build_dirs
+
+    script = _pkgconfig_script(ext_build_dirs)
 
     script.append("##symlink_contents_to_dir## $$EXT_BUILD_ROOT$$/{} $$BUILD_TMPDIR$$".format(root))
     script.append("" + " && ".join(make_commands))
diff --git a/tools/build_defs/framework.bzl b/tools/build_defs/framework.bzl
index 7277161..7080b2c 100644
--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -52,8 +52,8 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
     #
     # Optional part of the shell script to be added after the make commands
     "postfix_script": attr.string(mandatory = False),
-    # Optinal make commands, defaults to ["make", "make install"]
-    "make_commands": attr.string_list(mandatory = False, default = ["make", "make install"]),
+    # Optinal make commands, defaults to ["make -j`nproc`", "make install"]
+    "make_commands": attr.string_list(mandatory = False, default = ["make -j`nproc`", "make install"]),
     #
     # Optional dependencies to be copied into the directory structure.
     # Typically those directly required for the external building of the library/binaries.
diff --git a/tools/build_defs/make.bzl b/tools/build_defs/make.bzl
index f9f9d30..0928760 100644
--- a/tools/build_defs/make.bzl
+++ b/tools/build_defs/make.bzl
@@ -42,7 +42,7 @@ def _create_make_script(configureParameters):
     flags = get_flags_info(ctx)
 
     make_commands = ctx.attr.make_commands or [
-        "{make} {keep_going} -C $$EXT_BUILD_ROOT$$/{root}".format(
+        "{make} -j`nproc` {keep_going} -C $$EXT_BUILD_ROOT$$/{root}".format(
             make=configureParameters.attrs.make_path,
             keep_going="-k" if ctx.attr.keep_going else "",
             root=root),
-- 
2.30.0

```
See https://github.com/whs-dot-hk/clear-linux-notes/blob/df9924a0a76fbd4d654c164b6349319ddd20eaa0/BUILD.mpv