### PR TITLE
toolchain_mappings: remove unnecessary arch constraints

### DIFF
--- a/tools/build_defs/shell_toolchain/toolchains/toolchain_mappings.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/toolchain_mappings.bzl
@@ -11,21 +11,18 @@ TOOLCHAIN_MAPPINGS = [
     ToolchainMapping(
         exec_compatible_with = [
             "@bazel_tools//platforms:linux",
-            "@bazel_tools//platforms:x86_64",
         ],
         file = "@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains/impl:linux_commands.bzl",
     ),
     ToolchainMapping(
         exec_compatible_with = [
             "@bazel_tools//platforms:windows",
-            "@bazel_tools//platforms:x86_64",
         ],
         file = "@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains/impl:windows_commands.bzl",
     ),
     ToolchainMapping(
         exec_compatible_with = [
             "@bazel_tools//platforms:osx",
-            "@bazel_tools//platforms:x86_64",
         ],
         file = "@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains/impl:osx_commands.bzl",
     ),


### PR DESCRIPTION
This change allows rules_foreign_cc to work on architectures other
than x86_64.

Bug: bazelbuild/bazel#11628
Test: manual. no longer fails with "ln: illegal option -- t" on darwin_arm64