### PR TITLE
Whs essentials patch

### DIFF
--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -52,8 +52,8 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
     #
     # Optional part of the shell script to be added after the make commands
     "postfix_script": attr.string(mandatory = False),
-    # Optinal make commands, defaults to ["make", "make install"]
-    "make_commands": attr.string_list(mandatory = False, default = ["make", "make install"]),
+    # Optinal make commands, defaults to ["make -j`nproc`", "make install"]
+    "make_commands": attr.string_list(mandatory = False, default = ["make -j`nproc`", "make install"]),
     #
     # Optional dependencies to be copied into the directory structure.
     # Typically those directly required for the external building of the library/binaries.

--- a/tools/build_defs/make.bzl
+++ b/tools/build_defs/make.bzl
@@ -42,7 +42,7 @@ def _create_make_script(configureParameters):
     flags = get_flags_info(ctx)
 
     make_commands = ctx.attr.make_commands or [
-        "{make} {keep_going} -C $$EXT_BUILD_ROOT$$/{root}".format(
+        "{make} -j`nproc` {keep_going} -C $$EXT_BUILD_ROOT$$/{root}".format(
             make=configureParameters.attrs.make_path,
             keep_going="-k" if ctx.attr.keep_going else "",
             root=root),

--- a/tools/build_defs/shell_toolchain/toolchains/impl/default_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/default_commands.bzl
@@ -105,10 +105,8 @@ def script_prelude():
 
 def increment_pkg_config_path(source):
     text = """local children=$(find $1 -mindepth 1 -name '*.pc')
-# assume there is only one directory with pkg config
 for child in $children; do
   export PKG_CONFIG_PATH="$$PKG_CONFIG_PATH$$:$(dirname $child)"
-  return
 done
 """
     return FunctionAndCall(text = text)

--- a/tools/build_defs/shell_toolchain/toolchains/impl/linux_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/linux_commands.bzl
@@ -105,10 +105,8 @@ def script_prelude():
 
 def increment_pkg_config_path(source):
     text = """local children=$(find $1 -mindepth 1 -name '*.pc')
-# assume there is only one directory with pkg config
 for child in $children; do
   export PKG_CONFIG_PATH="$$PKG_CONFIG_PATH$$:$(dirname $child)"
-  return
 done
 """
     return FunctionAndCall(text = text)

--- a/tools/build_defs/shell_toolchain/toolchains/impl/osx_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/osx_commands.bzl
@@ -129,10 +129,8 @@ def script_prelude():
 def increment_pkg_config_path(source):
     text = """
 local children=$(find $1 -mindepth 1 -name '*.pc')
-# assume there is only one directory with pkg config
 for child in $children; do
   export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(dirname $child)"
-  return
 done
 """
     return FunctionAndCall(text = text)

--- a/tools/build_defs/shell_toolchain/toolchains/impl/windows_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/windows_commands.bzl
@@ -113,10 +113,8 @@ export SYSTEMDRIVE="C:"
 
 def increment_pkg_config_path(source):
     text = """local children=$($REAL_FIND $1 -mindepth 1 -name '*.pc')
-# assume there is only one directory with pkg config
 for child in $children; do
   export PKG_CONFIG_PATH="$$PKG_CONFIG_PATH$$:$(dirname $child)"
-  return
 done
 """
     return FunctionAndCall(text = text)

--- a/tools/build_defs/shell_toolchain/toolchains/toolchain_mappings.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/toolchain_mappings.bzl
@@ -11,21 +11,18 @@ TOOLCHAIN_MAPPINGS = [
     ToolchainMapping(
         exec_compatible_with = [
             "@bazel_tools//platforms:linux",
-            "@bazel_tools//platforms:x86_64",
         ],
         file = "@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains/impl:linux_commands.bzl",
     ),
     ToolchainMapping(
         exec_compatible_with = [
             "@bazel_tools//platforms:windows",
-            "@bazel_tools//platforms:x86_64",
         ],
         file = "@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains/impl:windows_commands.bzl",
     ),
     ToolchainMapping(
         exec_compatible_with = [
             "@bazel_tools//platforms:osx",
-            "@bazel_tools//platforms:x86_64",
         ],
         file = "@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains/impl:osx_commands.bzl",
     ),


### PR DESCRIPTION
After using `rules_foreign_cc` for half a year, I can conclude these are the essential patches

* Add parallel make
* Fix PKG_CONFIG_PATH
* Fix pkgconfig
* Remove x86_64 restriction (#456)

# How to use
```starlark
WORKSPACE
---
http_archive(
    name = "rules_foreign_cc",
    strip_prefix = "rules_foreign_cc-d54c78ab86b40770ee19f0949db9d74a831ab9f0",
    url = "https://github.com/bazelbuild/rules_foreign_cc/archive/d54c78ab86b40770ee19f0949db9d74a831ab9f0.zip",
    patch_args = [
        "-p1",
    ],
    patches = [
        "//:0001-Whs-essentials-patch.patch",
    ],
)
```

```patch
0001-Whs-essentials-patch.patch
---
From c31e2a84e5d25ea6ec95fe4a46971576005b62d4 Mon Sep 17 00:00:00 2001
From: whs <hswongac@gmail.com>
Date: Fri, 18 Dec 2020 21:35:37 +0800
Subject: [PATCH] Whs essentials patch

* Add parallel make
* Fix PKG_CONFIG_PATH
* Fix pkgconfig
* Remove x86_64 restriction (#456)
---
 tools/build_defs/configure_script.bzl         | 24 ++++++++++++-------
 tools/build_defs/framework.bzl                |  4 ++--
 tools/build_defs/make.bzl                     |  2 +-
 .../toolchains/impl/default_commands.bzl      |  2 --
 .../toolchains/impl/linux_commands.bzl        |  2 --
 .../toolchains/impl/osx_commands.bzl          |  2 --
 .../toolchains/impl/windows_commands.bzl      |  2 --
 .../toolchains/toolchain_mappings.bzl         |  3 ---
 8 files changed, 19 insertions(+), 22 deletions(-)

diff --git a/tools/build_defs/configure_script.bzl b/tools/build_defs/configure_script.bzl
index 729ac4b..8656b0c 100644
--- a/tools/build_defs/configure_script.bzl
+++ b/tools/build_defs/configure_script.bzl
@@ -1,6 +1,17 @@
 load(":cc_toolchain_util.bzl", "absolutize_path_in_str")
 load(":framework.bzl", "get_foreign_cc_dep")
 
+def _pkgconfig_script(ext_build_dirs):
+    script = []
+    for ext_dir in ext_build_dirs:
+        script.append("##increment_pkg_config_path## $$EXT_BUILD_DEPS$$/" + ext_dir.basename)
+
+    script.append("echo \"PKG_CONFIG_PATH=$$PKG_CONFIG_PATH$$\"")
+
+    script.append("##define_absolute_paths## $$EXT_BUILD_DEPS$$ $$EXT_BUILD_DEPS$$")
+
+    return script
+
 def create_configure_script(
         workspace_name,
         target_os,
@@ -23,11 +34,9 @@ def create_configure_script(
         autogen_env_vars):
     env_vars_string = get_env_vars(workspace_name, tools, flags, user_vars, deps, inputs)
 
-    script = []
-    for ext_dir in inputs.ext_build_dirs:
-        script.append("##increment_pkg_config_path## $$EXT_BUILD_ROOT$$/" + ext_dir.path)
+    ext_build_dirs = inputs.ext_build_dirs
 
-    script.append("echo \"PKG_CONFIG_PATH=$$PKG_CONFIG_PATH$$\"")
+    script = _pkgconfig_script(ext_build_dirs)
 
     root_path = "$$EXT_BUILD_ROOT$$/{}".format(root)
     configure_path = "{}/{}".format(root_path, configure_command)
@@ -71,11 +80,10 @@ def create_make_script(
         make_commands,
         prefix):
     env_vars_string = get_env_vars(workspace_name, tools, flags, user_vars, deps, inputs)
-    script = []
-    for ext_dir in inputs.ext_build_dirs:
-        script.append("##increment_pkg_config_path## $$EXT_BUILD_ROOT$$/" + ext_dir.path)
 
-    script.append("echo \"PKG_CONFIG_PATH=$$PKG_CONFIG_PATH$$\"")
+    ext_build_dirs = inputs.ext_build_dirs
+
+    script = _pkgconfig_script(ext_build_dirs)
 
     script.append("##symlink_contents_to_dir## $$EXT_BUILD_ROOT$$/{} $$BUILD_TMPDIR$$".format(root))
     script.append("" + " && ".join(make_commands))
diff --git a/tools/build_defs/framework.bzl b/tools/build_defs/framework.bzl
index 7277161..7080b2c 100644
--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -52,8 +52,8 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
     #
     # Optional part of the shell script to be added after the make commands
     "postfix_script": attr.string(mandatory = False),
-    # Optinal make commands, defaults to ["make", "make install"]
-    "make_commands": attr.string_list(mandatory = False, default = ["make", "make install"]),
+    # Optinal make commands, defaults to ["make -j`nproc`", "make install"]
+    "make_commands": attr.string_list(mandatory = False, default = ["make -j`nproc`", "make install"]),
     #
     # Optional dependencies to be copied into the directory structure.
     # Typically those directly required for the external building of the library/binaries.
diff --git a/tools/build_defs/make.bzl b/tools/build_defs/make.bzl
index f9f9d30..0928760 100644
--- a/tools/build_defs/make.bzl
+++ b/tools/build_defs/make.bzl
@@ -42,7 +42,7 @@ def _create_make_script(configureParameters):
     flags = get_flags_info(ctx)
 
     make_commands = ctx.attr.make_commands or [
-        "{make} {keep_going} -C $$EXT_BUILD_ROOT$$/{root}".format(
+        "{make} -j`nproc` {keep_going} -C $$EXT_BUILD_ROOT$$/{root}".format(
             make=configureParameters.attrs.make_path,
             keep_going="-k" if ctx.attr.keep_going else "",
             root=root),
diff --git a/tools/build_defs/shell_toolchain/toolchains/impl/default_commands.bzl b/tools/build_defs/shell_toolchain/toolchains/impl/default_commands.bzl
index 0d11cd4..db9bf0a 100644
--- a/tools/build_defs/shell_toolchain/toolchains/impl/default_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/default_commands.bzl
@@ -105,10 +105,8 @@ def script_prelude():
 
 def increment_pkg_config_path(source):
     text = """local children=$(find $1 -mindepth 1 -name '*.pc')
-# assume there is only one directory with pkg config
 for child in $children; do
   export PKG_CONFIG_PATH="$$PKG_CONFIG_PATH$$:$(dirname $child)"
-  return
 done
 """
     return FunctionAndCall(text = text)
diff --git a/tools/build_defs/shell_toolchain/toolchains/impl/linux_commands.bzl b/tools/build_defs/shell_toolchain/toolchains/impl/linux_commands.bzl
index 4fdceb8..d93b1b8 100644
--- a/tools/build_defs/shell_toolchain/toolchains/impl/linux_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/linux_commands.bzl
@@ -105,10 +105,8 @@ def script_prelude():
 
 def increment_pkg_config_path(source):
     text = """local children=$(find $1 -mindepth 1 -name '*.pc')
-# assume there is only one directory with pkg config
 for child in $children; do
   export PKG_CONFIG_PATH="$$PKG_CONFIG_PATH$$:$(dirname $child)"
-  return
 done
 """
     return FunctionAndCall(text = text)
diff --git a/tools/build_defs/shell_toolchain/toolchains/impl/osx_commands.bzl b/tools/build_defs/shell_toolchain/toolchains/impl/osx_commands.bzl
index 6d72c96..274dd7a 100644
--- a/tools/build_defs/shell_toolchain/toolchains/impl/osx_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/osx_commands.bzl
@@ -129,10 +129,8 @@ def script_prelude():
 def increment_pkg_config_path(source):
     text = """
 local children=$(find $1 -mindepth 1 -name '*.pc')
-# assume there is only one directory with pkg config
 for child in $children; do
   export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(dirname $child)"
-  return
 done
 """
     return FunctionAndCall(text = text)
diff --git a/tools/build_defs/shell_toolchain/toolchains/impl/windows_commands.bzl b/tools/build_defs/shell_toolchain/toolchains/impl/windows_commands.bzl
index 5bb63dc..3a7b45d 100644
--- a/tools/build_defs/shell_toolchain/toolchains/impl/windows_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/windows_commands.bzl
@@ -113,10 +113,8 @@ export SYSTEMDRIVE="C:"
 
 def increment_pkg_config_path(source):
     text = """local children=$($REAL_FIND $1 -mindepth 1 -name '*.pc')
-# assume there is only one directory with pkg config
 for child in $children; do
   export PKG_CONFIG_PATH="$$PKG_CONFIG_PATH$$:$(dirname $child)"
-  return
 done
 """
     return FunctionAndCall(text = text)
diff --git a/tools/build_defs/shell_toolchain/toolchains/toolchain_mappings.bzl b/tools/build_defs/shell_toolchain/toolchains/toolchain_mappings.bzl
index 1691dde..a7d6d95 100644
--- a/tools/build_defs/shell_toolchain/toolchains/toolchain_mappings.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/toolchain_mappings.bzl
@@ -11,21 +11,18 @@ TOOLCHAIN_MAPPINGS = [
     ToolchainMapping(
         exec_compatible_with = [
             "@bazel_tools//platforms:linux",
-            "@bazel_tools//platforms:x86_64",
         ],
         file = "@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains/impl:linux_commands.bzl",
     ),
     ToolchainMapping(
         exec_compatible_with = [
             "@bazel_tools//platforms:windows",
-            "@bazel_tools//platforms:x86_64",
         ],
         file = "@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains/impl:windows_commands.bzl",
     ),
     ToolchainMapping(
         exec_compatible_with = [
             "@bazel_tools//platforms:osx",
-            "@bazel_tools//platforms:x86_64",
         ],
         file = "@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains/impl:osx_commands.bzl",
     ),
-- 
2.30.0

```