### PR TITLE
Enable Buildifier in CI

### DIFF
--- a/.bazelci/config.yaml
+++ b/.bazelci/config.yaml
@@ -124,3 +124,5 @@ tasks:
       - "//cmake_android:app"
     test_targets:
       - "//:tests_no_synthetic"
+
+buildifier: latest

--- a/cc_configure_make/def.bzl
+++ b/cc_configure_make/def.bzl
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# buildifier: disable=module-docstring
 _DEPRECATION_NOTICE = """\
 `cc_configure_make` is deprecated and will soon be removed. Please use \
 configure_make rule defined in `@rules_foreign_cc//tools/build_defs:configure.bzl` \
@@ -77,7 +78,9 @@ _cc_configure_make_rule = rule(
     deprecation = _DEPRECATION_NOTICE,
 )
 
+# buildifier: disable=function-docstring
 def cc_configure_make(name, configure_flags, src, out_lib_path):
+    # buildifier: disable=print
     print("WARNING: " + _DEPRECATION_NOTICE)
     name_cmr = "_{}_cc_configure_make_rule".format(name)
     _cc_configure_make_rule(
@@ -95,6 +98,8 @@ def cc_configure_make(name, configure_flags, src, out_lib_path):
     )
 
     name_libfile_import = "_{}_libfile_import".format(name)
+
+    # buildifier: disable=native-cc
     native.cc_import(
         name = name_libfile_import,
         static_library = name_libfile_fg,
@@ -107,6 +112,7 @@ def cc_configure_make(name, configure_flags, src, out_lib_path):
         output_group = "headers",
     )
 
+    # buildifier: disable=native-cc
     native.cc_library(
         name = name,
         hdrs = [name_headers_fg],

--- a/docs/stardoc_deps.bzl
+++ b/docs/stardoc_deps.bzl
@@ -1,3 +1,7 @@
+"""A wrapper for defining stardoc dependencies to make instantiating
+it in a WORKSPACE file more consistent
+"""
+
 load("@io_bazel_stardoc//:setup.bzl", _stardoc_repositories = "stardoc_repositories")
 
 stardoc_deps = _stardoc_repositories

--- a/docs/stardoc_repository.bzl
+++ b/docs/stardoc_repository.bzl
@@ -1,3 +1,5 @@
+"""A module for defining the stardoc repository"""
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 

--- a/examples/cmake_android/BUILD
+++ b/examples/cmake_android/BUILD
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_android//android:rules.bzl", "android_binary", "android_library")
 load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 

--- a/examples/cmake_with_data/BUILD
+++ b/examples/cmake_with_data/BUILD
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
 load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 
 cmake_external(
@@ -25,7 +26,10 @@ cmake_external(
     lib_source = "//cmake_with_data/lib_a:srcs",
     make_commands = select({
         "@bazel_tools//src/conditions:windows": ["MSBuild.exe INSTALL.vcxproj"],
-        "//conditions:default": ["make", "make install"],
+        "//conditions:default": [
+            "make",
+            "make install",
+        ],
     }),
     static_libraries = select({
         "@bazel_tools//src/conditions:windows": ["lib_a.lib"],

--- a/examples/cmake_with_data/lib_b/BUILD
+++ b/examples/cmake_with_data/lib_b/BUILD
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 cc_library(
     name = "lib_b",
     srcs = ["src/lib_b.cpp"],

--- a/for_workspace/install_ws_dependency.bzl
+++ b/for_workspace/install_ws_dependency.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 def _generate_install_rule_impl(rctx):
     rctx.download_and_extract(
         url = rctx.attr.url,

--- a/test/shell_script_helper_test_rule.bzl
+++ b/test/shell_script_helper_test_rule.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 load(
     "@rules_foreign_cc//tools/build_defs:shell_script_helper.bzl",
     "convert_shell_script",

--- a/test/standard_cxx_flags_test/tests.bzl
+++ b/test/standard_cxx_flags_test/tests.bzl
@@ -1,5 +1,4 @@
-""" TODO """
-
+# buildifier: disable=module-docstring
 load("@rules_foreign_cc//tools/build_defs:cc_toolchain_util.bzl", "get_flags_info")
 
 def _impl(ctx):
@@ -30,6 +29,7 @@ def _impl(ctx):
 
     return [DefaultInfo(files = depset([exe]), executable = exe)]
 
+# buildifier: disable=function-docstring
 def assert_contains_once(arr, value):
     cnt = 0
     for elem in arr:

--- a/test/symlink_contents_to_dir_test_rule.bzl
+++ b/test/symlink_contents_to_dir_test_rule.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 load(
     "@rules_foreign_cc//tools/build_defs:shell_script_helper.bzl",
     "convert_shell_script",

--- a/test/utils_test.bzl
+++ b/test/utils_test.bzl
@@ -10,8 +10,8 @@ def _uniq_list_keep_order_test(ctx):
     filtered = uniq_list_keep_order(list)
     asserts.equals(env, [1, 2, 3, 4, 5, 7], filtered)
 
-    filteredEmpty = uniq_list_keep_order([])
-    asserts.equals(env, [], filteredEmpty)
+    filtered_empty = uniq_list_keep_order([])
+    asserts.equals(env, [], filtered_empty)
 
     return unittest.end(env)
 

--- a/toolchains_examples/additional_toolchains.bzl
+++ b/toolchains_examples/additional_toolchains.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 load("@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains:toolchain_mappings.bzl", "ToolchainMapping")
 
 ADD_TOOLCHAIN_MAPPINGS = [

--- a/toolchains_examples/fancy_platform_commands.bzl
+++ b/toolchains_examples/fancy_platform_commands.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 load("@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains:function_and_call.bzl", "FunctionAndCall")
 
 _REPLACE_VALUE = "BAZEL_GEN_ROOT"
@@ -44,6 +45,7 @@ else
 fi
 """.format(condition = condition, if_text = if_text, else_text = else_text)
 
+# buildifier: disable=function-docstring
 def define_function(name, text):
     lines = []
     lines.append("function " + name + "() {")

--- a/toolchains_examples/test_platform_name_rule.bzl
+++ b/toolchains_examples/test_platform_name_rule.bzl
@@ -1,8 +1,8 @@
+# buildifier: disable=module-docstring
 load("@rules_foreign_cc//tools/build_defs:shell_script_helper.bzl", "os_name")
 
 def _test_platform_name(ctx):
     os_name_ = os_name(ctx)
-    print("OS name: " + os_name_)
     if os_name_ != ctx.attr.expected:
         fail("Expected '{}', but was '{}'".format(ctx.attr.expected, os_name_))
 

--- a/tools/build_defs/cc_toolchain_util.bzl
+++ b/tools/build_defs/cc_toolchain_util.bzl
@@ -179,10 +179,11 @@ def _build_cc_link_params(
     }
 
 def targets_windows(ctx, cc_toolchain):
-    """ Returns true if build is targeting Windows
+    """Returns true if build is targeting Windows
+
     Args:
-        ctx - rule context
-        cc_toolchain - optional - Cc toolchain
+        ctx: rule context
+        cc_toolchain: optional - Cc toolchain
     """
     toolchain = cc_toolchain if cc_toolchain else find_cpp_toolchain(ctx)
     feature_configuration = _configure_features(
@@ -196,11 +197,12 @@ def targets_windows(ctx, cc_toolchain):
     )
 
 def create_linking_info(ctx, user_link_flags, files):
-    """ Creates CcLinkingInfo for the passed user link options and libraries.
+    """Creates CcLinkingInfo for the passed user link options and libraries.
+
     Args:
-        ctx - rule context
-        user_link_flags - (list of strings) link optins, provided by user
-        files - (LibrariesToLink) provider with the library files
+        ctx (ctx): rule context
+        user_link_flags (list of strings): link optins, provided by user
+        files (LibrariesToLink): provider with the library files
     """
 
     return cc_common.create_linking_context(
@@ -213,6 +215,7 @@ def create_linking_info(ctx, user_link_flags, files):
         ]),
     )
 
+# buildifier: disable=function-docstring
 def get_env_vars(ctx):
     cc_toolchain = find_cpp_toolchain(ctx)
     feature_configuration = _configure_features(
@@ -241,9 +244,10 @@ def is_debug_mode(ctx):
     return ctx.var.get("COMPILATION_MODE", "fastbuild") == "dbg"
 
 def get_tools_info(ctx):
-    """ Takes information about tools paths from cc_toolchain, returns CxxToolsInfo
+    """Takes information about tools paths from cc_toolchain, returns CxxToolsInfo
+
     Args:
-        ctx - rule context
+        ctx: rule context
     """
     cc_toolchain = find_cpp_toolchain(ctx)
     feature_configuration = _configure_features(
@@ -271,11 +275,15 @@ def get_tools_info(ctx):
     )
 
 def get_flags_info(ctx, link_output_file = None):
-    """ Takes information about flags from cc_toolchain, returns CxxFlagsInfo
+    """Takes information about flags from cc_toolchain, returns CxxFlagsInfo
+
     Args:
-        ctx - rule context
-        link_output_file - output file to be specified in the link command line
-        flags
+        ctx: rule context
+        link_output_file: output file to be specified in the link command line
+            flags
+
+    Returns:
+        CxxFlagsInfo: A provider containing Cxx flags
     """
     cc_toolchain_ = find_cpp_toolchain(ctx)
     feature_configuration = _configure_features(
@@ -366,17 +374,20 @@ def _add_if_needed(arr, add_arr):
     return arr + filtered
 
 def absolutize_path_in_str(workspace_name, root_str, text, force = False):
-    """ Replaces relative paths in [the middle of] 'text', prepending them with 'root_str'.
-    If there is nothing to replace, returns the 'text'.
+    """Replaces relative paths in [the middle of] 'text', prepending them with 'root_str'. If there is nothing to replace, returns the 'text'.
 
     We only will replace relative paths starting with either 'external/' or '<top-package-name>/',
     because we only want to point with absolute paths to external repositories or inside our
     current workspace. (And also to limit the possibility of error with such not exact replacing.)
 
     Args:
-        workspace_name - workspace name
-        text - the text to do replacement in
-        root_str - the text to prepend to the found relative path
+        workspace_name: workspace name
+        text: the text to do replacement in
+        root_str: the text to prepend to the found relative path
+        force: If true, the `root_str` will always be prepended
+
+    Returns:
+        string: A formatted string
     """
     new_text = _prefix(text, "external/", root_str)
     if new_text == text:

--- a/tools/build_defs/cmake_script.bzl
+++ b/tools/build_defs/cmake_script.bzl
@@ -36,7 +36,7 @@ def create_cmake_script(
 
     Returns:
         string: A formatted string of the generated build command
-    """        
+    """
 
     merged_prefix_path = _merge_prefix_path(user_cache, include_dirs)
 
@@ -299,6 +299,7 @@ def _find_flag_value(list, flag_name_no_dashes):
             return _tail.lstrip(" =")
         if _tail != None:
             check_for_value = True
+    return None
 
 def _tail_if_starts_with(str, start):
     if (str.startswith(start)):

--- a/tools/build_defs/configure.bzl
+++ b/tools/build_defs/configure.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 load(
     "//tools/build_defs:framework.bzl",
     "CC_EXTERNAL_RULE_ATTRIBUTES",
@@ -130,8 +131,8 @@ def _attrs():
             mandatory = False,
             default = False,
             doc = (
-              "Set to True if 'autoconf' should be invoked before 'configure', " +
-              "currently requires 'configure_in_place' to be True."
+                "Set to True if 'autoconf' should be invoked before 'configure', " +
+                "currently requires 'configure_in_place' to be True."
             ),
         ),
         "autoconf_options": attr.string_list(
@@ -140,7 +141,6 @@ def _attrs():
         "autoconf_env_vars": attr.string_dict(
             doc = "Environment variables to be set for 'autoconf' invocation.",
         ),
-
         "autogen": attr.bool(
             doc = (
                 "Set to True if 'autogen.sh' should be invoked before 'configure', " +

--- a/tools/build_defs/configure_script.bzl
+++ b/tools/build_defs/configure_script.bzl
@@ -1,6 +1,8 @@
+# buildifier: disable=module-docstring
 load(":cc_toolchain_util.bzl", "absolutize_path_in_str")
 load(":framework.bzl", "get_foreign_cc_dep")
 
+# buildifier: disable=function-docstring
 def create_configure_script(
         workspace_name,
         target_os,
@@ -69,6 +71,7 @@ def create_configure_script(
     ))
     return "\n".join(script)
 
+# buildifier: disable=function-docstring
 def create_make_script(
         workspace_name,
         tools,
@@ -90,6 +93,7 @@ def create_make_script(
     script.append("" + " && ".join(make_commands))
     return "\n".join(script)
 
+# buildifier: disable=function-docstring
 def get_env_vars(
         workspace_name,
         tools,

--- a/tools/build_defs/detect_root.bzl
+++ b/tools/build_defs/detect_root.bzl
@@ -1,7 +1,11 @@
+# buildifier: disable=module-docstring
+# buildifier: disable=function-docstring-header
+# buildifier: disable=function-docstring-args
+# buildifier: disable=function-docstring-return
 def detect_root(source):
     """Detects the path to the topmost directory of the 'source' outputs.
     To be used with external build systems to point to the source code/tools directories.
-"""
+    """
 
     root = ""
     sources = source.files.to_list()
@@ -40,13 +44,16 @@ def _get_level(path):
 
     return normalized.count("/")
 
-"""When the directories are also passed in the filegroup with the sources,
-we get into a situation when we have containing in the sources list,
-which is not allowed by Bazel (execroot creation code fails).
-The parent directories will be created for us in the execroot anyway,
-so we filter them out."""
-
+# buildifier: disable=function-docstring-header
+# buildifier: disable=function-docstring-args
+# buildifier: disable=function-docstring-return
 def filter_containing_dirs_from_inputs(input_files_list):
+    """When the directories are also passed in the filegroup with the sources,
+    we get into a situation when we have containing in the sources list,
+    which is not allowed by Bazel (execroot creation code fails).
+    The parent directories will be created for us in the execroot anyway,
+    so we filter them out."""
+
     # This puts directories in front of their children in list
     sorted_list = sorted(input_files_list)
     contains_map = {}

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -25,12 +25,12 @@ load(
 )
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 
-""" Dict with definitions of the context attributes, that customize cc_external_rule_impl function.
- Many of the attributes have default values.
-
- Typically, the concrete external library rule will use this structure to create the attributes
- description dict. See cmake.bzl as an example.
-"""
+# Dict with definitions of the context attributes, that customize cc_external_rule_impl function.
+# Many of the attributes have default values.
+#
+# Typically, the concrete external library rule will use this structure to create the attributes
+# description dict. See cmake.bzl as an example.
+#
 CC_EXTERNAL_RULE_ATTRIBUTES = {
     "lib_name": attr.string(
         doc = (
@@ -171,8 +171,11 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
     ),
 }
 
+# buildifier: disable=function-docstring-header
+# buildifier: disable=function-docstring-args
+# buildifier: disable=function-docstring-return
 def create_attrs(attr_struct, configure_name, create_configure_script, **kwargs):
-    """ Function for adding/modifying context attributes struct (originally from ctx.attr),
+    """Function for adding/modifying context attributes struct (originally from ctx.attr),
      provided by user, to be passed to the cc_external_rule_impl function as a struct.
 
      Copies a struct 'attr_struct' values (with attributes from CC_EXTERNAL_RULE_ATTRIBUTES)
@@ -191,11 +194,13 @@ def create_attrs(attr_struct, configure_name, create_configure_script, **kwargs)
         attrs[arg] = kwargs[arg]
     return struct(**attrs)
 
+# buildifier: disable=name-conventions
 ForeignCcDeps = provider(
     doc = """Provider to pass transitive information about external libraries.""",
     fields = {"artifacts": "Depset of ForeignCcArtifact"},
 )
 
+# buildifier: disable=name-conventions
 ForeignCcArtifact = provider(
     doc = """Groups information about the external library install directory,
 and relative bin, include and lib directories.
@@ -212,6 +217,7 @@ Instances of ForeignCcArtifact are incapsulated in a depset ForeignCcDeps#artifa
     },
 )
 
+# buildifier: disable=name-conventions
 ConfigureParameters = provider(
     doc = """Parameters of create_configure_script callback function, called by
 cc_external_rule_impl function. create_configure_script creates the configuration part
@@ -226,28 +232,28 @@ dependencies.""",
 )
 
 def cc_external_rule_impl(ctx, attrs):
-    """ Framework function for performing external C/C++ building.
+    """Framework function for performing external C/C++ building.
 
-     To be used to build external libraries or/and binaries with CMake, configure/make, autotools etc.,
-     and use results in Bazel.
-     It is possible to use it to build a group of external libraries, that depend on each other or on
-     Bazel library, and pass nessesary tools.
+    To be used to build external libraries or/and binaries with CMake, configure/make, autotools etc.,
+    and use results in Bazel.
+    It is possible to use it to build a group of external libraries, that depend on each other or on
+    Bazel library, and pass nessesary tools.
 
-     Accepts the actual commands for build configuration/execution in attrs.
+    Accepts the actual commands for build configuration/execution in attrs.
 
-     Creates and runs a shell script, which:
+    Creates and runs a shell script, which:
 
-     1) prepares directory structure with sources, dependencies, and tools symlinked into subdirectories
-      of the execroot directory. Adds tools into PATH.
-     2) defines the correct absolute paths in tools with the script paths, see 7
-     3) defines the following environment variables:
+    1. prepares directory structure with sources, dependencies, and tools symlinked into subdirectories
+        of the execroot directory. Adds tools into PATH.
+    2. defines the correct absolute paths in tools with the script paths, see 7
+    3. defines the following environment variables:
         EXT_BUILD_ROOT: execroot directory
         EXT_BUILD_DEPS: subdirectory of execroot, which contains the following subdirectories:
 
-          For cmake_external built dependencies:
+        For cmake_external built dependencies:
             symlinked install directories of the dependencies
 
-          for Bazel built/imported dependencies:
+            for Bazel built/imported dependencies:
 
             include - here the include directories are symlinked
             lib - here the library files are symlinked
@@ -257,22 +263,25 @@ def cc_external_rule_impl(ctx, attrs):
         will be installed
 
         These variables should be used by the calling rule to refer to the created directory structure.
-     4) calls 'attrs.create_configure_script'
-     5) calls 'attrs.make_commands'
-     6) calls 'attrs.postfix_script'
-     7) replaces absolute paths in possibly created scripts with a placeholder value
+    4. calls 'attrs.create_configure_script'
+    5. calls 'attrs.make_commands'
+    6. calls 'attrs.postfix_script'
+    7. replaces absolute paths in possibly created scripts with a placeholder value
 
-     Please see cmake.bzl for example usage.
+    Please see cmake.bzl for example usage.
 
-     Args:
-       ctx: calling rule context
-       attrs: attributes struct, created by create_attrs function above.
-         Contains fields from CC_EXTERNAL_RULE_ATTRIBUTES (see descriptions there),
-         two mandatory fields:
-         -  configure_name: name of the configuration tool, to be used in action mnemonic,
-         -  create_configure_script(ConfigureParameters): function that creates configuration
-            script, accepts ConfigureParameters
-         and some other fields provided by the rule, which have been passed to create_attrs.
+    Args:
+        ctx: calling rule context
+        attrs: attributes struct, created by create_attrs function above.
+            Contains fields from CC_EXTERNAL_RULE_ATTRIBUTES (see descriptions there),
+            two mandatory fields:
+                - configure_name: name of the configuration tool, to be used in action mnemonic,
+                - create_configure_script(ConfigureParameters): function that creates configuration
+                    script, accepts ConfigureParameters
+            and some other fields provided by the rule, which have been passed to create_attrs.
+
+    Returns:
+        A list of providers
     """
     lib_name = attrs.lib_name or ctx.attr.name
 
@@ -402,6 +411,7 @@ def cc_external_rule_impl(ctx, attrs):
         ),
     ]
 
+# buildifier: disable=name-conventions
 WrappedOutputs = provider(
     doc = "Structure for passing the log and scripts file information, and wrapper script text.",
     fields = {
@@ -412,6 +422,7 @@ WrappedOutputs = provider(
     },
 )
 
+# buildifier: disable=function-docstring
 def wrap_outputs(ctx, lib_name, configure_name, script_text):
     build_script_file = ctx.actions.declare_file("{}/logs/{}_script.sh".format(lib_name, configure_name))
     ctx.actions.write(
@@ -564,6 +575,7 @@ def _check_file_name(var):
         if letter in _FORBIDDEN_FOR_FILENAME:
             fail("Symbol '%s' is forbidden in library name '%s'." % (letter, var))
 
+# buildifier: disable=name-conventions
 _Outputs = provider(
     doc = "Provider to keep different kinds of the external build output files and directories",
     fields = dict(
@@ -612,19 +624,27 @@ def _declare_out(ctx, lib_name, dir_, files):
         return [ctx.actions.declare_file("/".join([lib_name, dir_, file])) for file in files]
     return []
 
+# buildifier: disable=name-conventions
 InputFiles = provider(
-    doc = """Provider to keep different kinds of input files, directories,
-and C/C++ compilation and linking info from dependencies""",
+    doc = (
+        "Provider to keep different kinds of input files, directories, " +
+        "and C/C++ compilation and linking info from dependencies"
+    ),
     fields = dict(
-        headers = """Include files built by Bazel. Will be copied into $EXT_BUILD_DEPS/include.""",
-        include_dirs = """Include directories built by Bazel.
-Will be copied into $EXT_BUILD_DEPS/include.""",
-        libs = """Library files built by Bazel.
-Will be copied into $EXT_BUILD_DEPS/lib.""",
-        tools_files = """Files and directories with tools needed for configuration/building
-to be copied into the bin folder, which is added to the PATH""",
-        ext_build_dirs = """Directories with libraries, built by framework function.
-This directories should be copied into $EXT_BUILD_DEPS/lib-name as is, with all contents.""",
+        headers = "Include files built by Bazel. Will be copied into $EXT_BUILD_DEPS/include.",
+        include_dirs = (
+            "Include directories built by Bazel. Will be copied " +
+            "into $EXT_BUILD_DEPS/include."
+        ),
+        libs = "Library files built by Bazel. Will be copied into $EXT_BUILD_DEPS/lib.",
+        tools_files = (
+            "Files and directories with tools needed for configuration/building " +
+            "to be copied into the bin folder, which is added to the PATH"
+        ),
+        ext_build_dirs = (
+            "Directories with libraries, built by framework function. " +
+            "This directories should be copied into $EXT_BUILD_DEPS/lib-name as is, with all contents."
+        ),
         deps_compilation_info = "Merged CcCompilationInfo from deps attribute",
         deps_linking_info = "Merged CcLinkingInfo from deps attribute",
         declared_inputs = "All files and directories that must be declared as action inputs",
@@ -696,6 +716,7 @@ def _define_inputs(attrs):
                           ext_build_dirs,
     )
 
+# buildifier: disable=function-docstring
 def uniq_list_keep_order(list):
     result = []
     contains_map = {}

--- a/tools/build_defs/make.bzl
+++ b/tools/build_defs/make.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 load(
     "//tools/build_defs:framework.bzl",
     "CC_EXTERNAL_RULE_ATTRIBUTES",

--- a/tools/build_defs/native_tools/native_tools_toolchain.bzl
+++ b/tools/build_defs/native_tools/native_tools_toolchain.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 ToolInfo = provider(
     doc = "Information about the native tool",
     fields = {

--- a/tools/build_defs/native_tools/tool_access.bzl
+++ b/tools/build_defs/native_tools/tool_access.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 load(":native_tools_toolchain.bzl", "access_tool")
 
 def get_cmake_data(ctx):

--- a/tools/build_defs/run_shell_file_utils.bzl
+++ b/tools/build_defs/run_shell_file_utils.bzl
@@ -1,3 +1,5 @@
+# buildifier: disable=module-docstring
+# buildifier: disable=name-conventions
 CreatedByScript = provider(
     doc = "Structure to keep declared file or directory and creating script.",
     fields = dict(
@@ -6,14 +8,16 @@ CreatedByScript = provider(
     ),
 )
 
-""" Creates a fictive file under the build root.
-This gives the possibility to address the build root in script and construct paths under it.
-  Attributes:
-    actions - actions factory (ctx.actions)
-    target_name - name of the current target (ctx.label.name)
-"""
-
 def fictive_file_in_genroot(actions, target_name):
+    """Creates a fictive file under the build root.
+
+    This gives the possibility to address the build root in script and construct paths under it.
+
+    Args:
+        actions (ctx.actions): actions factory
+        target_name (ctx.label.name): name of the current target
+    """
+
     # we need this fictive file in the genroot to get the path of the root in the script
     empty = actions.declare_file("empty_{}.txt".format(target_name))
     return CreatedByScript(
@@ -21,15 +25,16 @@ def fictive_file_in_genroot(actions, target_name):
         script = "##touch## $$EXT_BUILD_ROOT$$/" + empty.path,
     )
 
-""" Copies directory by $EXT_BUILD_ROOT/orig_path into to $EXT_BUILD_ROOT/copy_path.
-I.e. a copy of the directory is created under $EXT_BUILD_ROOT/copy_path.
-  Attributes:
-    actions - actions factory (ctx.actions)
-    orig_path - path to the original directory, relative to the build root
-    copy_path - target directory, relative to the build root
-"""
-
 def copy_directory(actions, orig_path, copy_path):
+    """Copies directory by $EXT_BUILD_ROOT/orig_path into to $EXT_BUILD_ROOT/copy_path.
+
+    I.e. a copy of the directory is created under $EXT_BUILD_ROOT/copy_path.
+
+    Args:
+        actions: actions factory (ctx.actions)
+        orig_path: path to the original directory, relative to the build root
+        copy_path: target directory, relative to the build root
+    """
     dir_copy = actions.declare_directory(copy_path)
     return CreatedByScript(
         file = dir_copy,

--- a/tools/build_defs/shell_script_helper.bzl
+++ b/tools/build_defs/shell_script_helper.bzl
@@ -1,34 +1,34 @@
-""" Contains functions for conversion from intermediate multiplatform notation for defining
- the shell script into the actual shell script for the concrete platform.
+"""Contains functions for conversion from intermediate multiplatform notation for defining
+the shell script into the actual shell script for the concrete platform.
 
- Notation:
+Notation:
 
- 1) export <varname>=<value>
- Define the environment variable with the name <varname> and value <value>.
- If the <value> contains the toolchain command call (see 3), the call is replaced with needed value.
+1. `export <varname>=<value>`
+Define the environment variable with the name <varname> and value <value>.
+If the <value> contains the toolchain command call (see 3), the call is replaced with needed value.
 
- 2) $$<varname>$$
- Refer the environment variable with the name <varname>,
- i.e. this will become $<varname> on Linux/MacOS, and %<varname>% on Windows.
+2. `$$<varname>$$`
+Refer the environment variable with the name <varname>,
+i.e. this will become $<varname> on Linux/MacOS, and %<varname>% on Windows.
 
- 3) ##<funname>## <arg1> ... <argn>
- Find the shell toolchain command Starlark method with the name <funname> for that command
- in a toolchain, and call it, passing <arg1> .. <argn>.
- (see ./shell_toolchain/commands.bzl, ./shell_toolchain/impl/linux_commands.bzl etc.)
- The arguments are space-separated; if the argument is quoted, the spaces inside the quites are
- ignored.
- ! Escaping of the quotes inside the quoted argument is not supported, as it was not needed for now.
- (quoted arguments are used for paths and never for any arbitrary string.)
+3. `##<funname>## <arg1> ... <argn>`
+Find the shell toolchain command Starlark method with the name <funname> for that command
+in a toolchain, and call it, passing <arg1> .. <argn>.
+(see ./shell_toolchain/commands.bzl, ./shell_toolchain/impl/linux_commands.bzl etc.)
+The arguments are space-separated; if the argument is quoted, the spaces inside the quites are
+ignored.
+! Escaping of the quotes inside the quoted argument is not supported, as it was not needed for now.
+(quoted arguments are used for paths and never for any arbitrary string.)
 
- The call of a shell toolchain Starlark method is performed through
- //tools/build_defs/shell_toolchain/toolchains:access.bzl; please refer there for the details.
+The call of a shell toolchain Starlark method is performed through
+//tools/build_defs/shell_toolchain/toolchains:access.bzl; please refer there for the details.
 
- Here what is important is that the Starlark method can also add some text (function definitions)
- into a "prelude" part of the shell_context.
- The resulting script is constructed from the prelude part with function definitions and
- the actual translated script part.
- Since function definitions can call other functions, we perform the fictive translation
- of the function bodies to populate the "prelude" part of the script.
+Here what is important is that the Starlark method can also add some text (function definitions)
+into a "prelude" part of the shell_context.
+The resulting script is constructed from the prelude part with function definitions and
+the actual translated script part.
+Since function definitions can call other functions, we perform the fictive translation
+of the function bodies to populate the "prelude" part of the script.
 """
 
 load("//tools/build_defs/shell_toolchain/toolchains:access.bzl", "call_shell", "create_context")
@@ -42,16 +42,19 @@ def create_function(ctx, name, text):
 
 def convert_shell_script(ctx, script):
     """ Converts shell script from the intermediate notation to actual schell script.
+
     Please see the file header for the notation description.
 
-    Arguments:
-      ctx - rule context
-      script - the array of script strings, each string can be of multiple lines
+    Args:
+        ctx: rule context
+        script: the array of script strings, each string can be of multiple lines
 
-    Output: the string with the shell script for the current execution platform
+    Returns:
+        the string with the shell script for the current execution platform
     """
     return convert_shell_script_by_context(create_context(ctx), script)
 
+# buildifier: disable=function-docstring
 def convert_shell_script_by_context(shell_context, script):
     # 0. Split in lines merged fragments.
     new_script = []
@@ -96,6 +99,7 @@ def convert_shell_script_by_context(shell_context, script):
     result = "\n".join(script)
     return result
 
+# buildifier: disable=function-docstring
 def replace_var_ref(text, shell_context):
     parts = []
     current = text
@@ -112,6 +116,7 @@ def replace_var_ref(text, shell_context):
 
     return "".join(parts)
 
+# buildifier: disable=function-docstring
 def replace_exports(text, shell_context):
     text = text.strip(" ")
     (varname, separator, value) = text.partition("=")
@@ -125,6 +130,7 @@ def replace_exports(text, shell_context):
 
     return call_shell(shell_context, "export_var", varname, value)
 
+# buildifier: disable=function-docstring
 def get_function_name(text):
     (funname, separator, after) = text.partition(" ")
 
@@ -140,6 +146,7 @@ def get_function_name(text):
 
     return (None, None)
 
+# buildifier: disable=function-docstring
 def extract_wrapped(text, prefix, postfix = None):
     postfix = postfix or prefix
     (before, separator, after) = text.partition(prefix)
@@ -150,6 +157,7 @@ def extract_wrapped(text, prefix, postfix = None):
         fail("Variable or function name is not marked correctly in fragment: {}".format(text))
     return (before, varname, after2)
 
+# buildifier: disable=function-docstring
 def do_function_call(text, shell_context):
     (funname, after) = get_function_name(text.strip(" "))
     if not funname:
@@ -161,6 +169,7 @@ def do_function_call(text, shell_context):
     arguments = split_arguments(after.strip(" ")) if after else []
     return call_shell(shell_context, funname, *arguments)
 
+# buildifier: disable=function-docstring
 def split_arguments(text):
     parts = []
     current = text.strip(" ")

--- a/tools/build_defs/shell_toolchain/polymorphism/generate_overloads.bzl
+++ b/tools/build_defs/shell_toolchain/polymorphism/generate_overloads.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 def _provider_text(symbols):
     return """
 WRAPPER = provider(

--- a/tools/build_defs/shell_toolchain/toolchains/access.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/access.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 load("//tools/build_defs/shell_toolchain/toolchains:commands.bzl", "PLATFORM_COMMANDS")
 load(":function_and_call.bzl", "FunctionAndCall")
 
@@ -9,13 +10,16 @@ def create_context(ctx):
         prelude = {},
     )
 
+# buildifier: disable=function-docstring-header
+# buildifier: disable=function-docstring-args
+# buildifier: disable=function-docstring-return
 def call_shell(shell_context, method_, *args):
-    """ Calls the 'method_' shell command from the toolchain.
- Checks the number and types of passed arguments.
- If the command returns the resulting text wrapped into FunctionAndCall provider,
- puts the text of the function into the 'prelude' dictionary in the 'shell_context',
- and returns only the call of that function.
-"""
+    """Calls the 'method_' shell command from the toolchain.
+    Checks the number and types of passed arguments.
+    If the command returns the resulting text wrapped into FunctionAndCall provider,
+    puts the text of the function into the 'prelude' dictionary in the 'shell_context',
+    and returns only the call of that function.
+    """
     check_argument_types(method_, args)
 
     func_ = getattr(shell_context.shell, method_)
@@ -37,6 +41,7 @@ def call_shell(shell_context, method_, *args):
 def _wrap_if_needed(arg):
     return "\"" + arg + "\"" if arg.find(" ") >= 0 else arg
 
+# buildifier: disable=function-docstring
 def check_argument_types(method_, args_list):
     descriptor = PLATFORM_COMMANDS[method_]
     args_info = descriptor.arguments

--- a/tools/build_defs/shell_toolchain/toolchains/commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/commands.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 CommandInfo = provider(
     doc = "To pass information about the Starlark function, defining the shell fragment.",
     fields = {
@@ -113,9 +114,10 @@ PLATFORM_COMMANDS = {
             ),
             ArgumentInfo(name = "target", type_ = type(""), doc = "Target directory"),
         ],
-        doc = """
-Symlink contents of the directory to target directory (create the target directory if needed).
-If file is passed, symlink it into the target directory.""",
+        doc = (
+            "Symlink contents of the directory to target directory (create the target directory if needed). " +
+            "If file is passed, symlink it into the target directory."
+        ),
     ),
     "symlink_to_dir": CommandInfo(
         arguments = [
@@ -126,9 +128,10 @@ If file is passed, symlink it into the target directory.""",
             ),
             ArgumentInfo(name = "target", type_ = type(""), doc = "Target directory"),
         ],
-        doc = """
-Symlink all files from source directory to target directory (create the target directory if needed).
-NB symlinks from the source directory are copied.""",
+        doc = (
+            "Symlink all files from source directory to target directory (create the target directory if needed). " +
+            "NB symlinks from the source directory are copied."
+        ),
     ),
     "script_prelude": CommandInfo(
         arguments = [],
@@ -142,8 +145,10 @@ NB symlinks from the source directory are copied.""",
                 doc = "Source directory",
             ),
         ],
-        doc = """Find subdirectory inside a passed directory with *.pc files and add it
-    to the PKG_CONFIG_PATH""",
+        doc = (
+            "Find subdirectory inside a passed directory with *.pc files and add it " +
+            "to the PKG_CONFIG_PATH"
+        ),
     ),
     "assert_script_errors": CommandInfo(
         arguments = [],

--- a/tools/build_defs/shell_toolchain/toolchains/defs.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/defs.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 load(
     "//tools/build_defs/shell_toolchain/polymorphism:generate_overloads.bzl",
     "get_file_name",
@@ -15,9 +16,11 @@ toolchain_data = rule(
     },
 )
 
+# buildifier: disable=unnamed-macro
 def build_part(toolchain_type_):
     register_mappings(toolchain_type_, TOOLCHAIN_MAPPINGS)
 
+# buildifier: disable=unnamed-macro
 def register_mappings(toolchain_type_, mappings):
     for item in mappings:
         file_name = get_file_name(item.file)

--- a/tools/build_defs/shell_toolchain/toolchains/function_and_call.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/function_and_call.bzl
@@ -1,3 +1,5 @@
+# buildifier: disable=module-docstring
+# buildifier: disable=name-conventions
 FunctionAndCall = provider(
     doc = "Wrapper to pass function definition and (if custom) function call",
     fields = {

--- a/tools/build_defs/shell_toolchain/toolchains/impl/default_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/default_commands.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 load("@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains:function_and_call.bzl", "FunctionAndCall")
 
 _REPLACE_VALUE = "\\${EXT_BUILD_DEPS}"
@@ -44,6 +45,7 @@ else
 fi
 """.format(condition = condition, if_text = if_text, else_text = else_text)
 
+# buildifier: disable=function-docstring
 def define_function(name, text):
     lines = []
     lines.append("function " + name + "() {")

--- a/tools/build_defs/shell_toolchain/toolchains/impl/linux_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/linux_commands.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 load("@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains:function_and_call.bzl", "FunctionAndCall")
 
 _REPLACE_VALUE = "\\${EXT_BUILD_DEPS}"
@@ -44,6 +45,7 @@ else
 fi
 """.format(condition = condition, if_text = if_text, else_text = else_text)
 
+# buildifier: disable=function-docstring
 def define_function(name, text):
     lines = []
     lines.append("function " + name + "() {")

--- a/tools/build_defs/shell_toolchain/toolchains/impl/osx_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/osx_commands.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 load("@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains:function_and_call.bzl", "FunctionAndCall")
 
 _REPLACE_VALUE = "\\${EXT_BUILD_DEPS}"
@@ -44,6 +45,7 @@ else
 fi
 """.format(condition = condition, if_text = if_text, else_text = else_text)
 
+# buildifier: disable=function-docstring
 def define_function(name, text):
     lines = []
     lines.append("function " + name + "() {")

--- a/tools/build_defs/shell_toolchain/toolchains/impl/windows_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/windows_commands.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 load("@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains:function_and_call.bzl", "FunctionAndCall")
 
 _REPLACE_VALUE = "\\${EXT_BUILD_DEPS}"
@@ -44,6 +45,7 @@ else
 fi
 """.format(condition = condition, if_text = if_text, else_text = else_text)
 
+# buildifier: disable=function-docstring
 def define_function(name, text):
     lines = []
     lines.append("function " + name + "() {")

--- a/tools/build_defs/shell_toolchain/toolchains/toolchain_mappings.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/toolchain_mappings.bzl
@@ -1,3 +1,5 @@
+# buildifier: disable=module-docstring
+# buildifier: disable=name-conventions
 ToolchainMapping = provider(
     doc = "Mapping of toolchain definition files to platform constraints",
     fields = {

--- a/tools/build_defs/shell_toolchain/toolchains/ws_defs.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/ws_defs.bzl
@@ -1,3 +1,4 @@
+# buildifier: disable=module-docstring
 load(
     "//tools/build_defs/shell_toolchain/polymorphism:generate_overloads.bzl",
     "generate_overloads",
@@ -6,6 +7,8 @@ load(
 load("//tools/build_defs/shell_toolchain/toolchains:commands.bzl", "PLATFORM_COMMANDS")
 load(":toolchain_mappings.bzl", "TOOLCHAIN_MAPPINGS")
 
+# buildifier: disable=unnamed-macro
+# buildifier: disable=function-docstring
 def workspace_part(
         additional_toolchain_mappings = [],
         additonal_shell_toolchain_package = None):

--- a/tools/build_defs/version.bzl
+++ b/tools/build_defs/version.bzl
@@ -1,1 +1,3 @@
+"""A module defining the version number of rules_foreign_cc"""
+
 VERSION = "0.0.8"  # supports transitive dependencies bazel -> cmake -> bazel


### PR DESCRIPTION
The purpose of this PR is to enable Buildifier in CI. This is done by mostly ignoring existing defects but still allows for future changes to benefit from this check.

New changes should not "disable" any defects.