### PR TITLE
Moved documenting comments into `doc` fields

### DIFF
--- a/examples/docs/README.md
+++ b/examples/docs/README.md
@@ -11,7 +11,7 @@ boost_build(<a href="#boost_build-name">name</a>, <a href="#boost_build-addition
             <a href="#boost_build-shared_libraries">shared_libraries</a>, <a href="#boost_build-static_libraries">static_libraries</a>, <a href="#boost_build-tools_deps">tools_deps</a>, <a href="#boost_build-user_options">user_options</a>)
 </pre>
 
-
+Rule for building Boost. Invokes bootstrap.sh and then b2 install.
 
 **ATTRIBUTES**
 
@@ -19,27 +19,27 @@ boost_build(<a href="#boost_build-name">name</a>, <a href="#boost_build-addition
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="boost_build-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| <a id="boost_build-additional_inputs"></a>additional_inputs |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="boost_build-additional_tools"></a>additional_tools |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="boost_build-alwayslink"></a>alwayslink |  -   | Boolean | optional | False |
-| <a id="boost_build-binaries"></a>binaries |  -   | List of strings | optional | [] |
-| <a id="boost_build-bootstrap_options"></a>bootstrap_options |  -   | List of strings | optional | [] |
-| <a id="boost_build-defines"></a>defines |  -   | List of strings | optional | [] |
-| <a id="boost_build-deps"></a>deps |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="boost_build-headers_only"></a>headers_only |  -   | Boolean | optional | False |
-| <a id="boost_build-interface_libraries"></a>interface_libraries |  -   | List of strings | optional | [] |
-| <a id="boost_build-lib_name"></a>lib_name |  -   | String | optional | "" |
-| <a id="boost_build-lib_source"></a>lib_source |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
-| <a id="boost_build-linkopts"></a>linkopts |  -   | List of strings | optional | [] |
-| <a id="boost_build-make_commands"></a>make_commands |  -   | List of strings | optional | ["make", "make install"] |
-| <a id="boost_build-out_bin_dir"></a>out_bin_dir |  -   | String | optional | "bin" |
-| <a id="boost_build-out_include_dir"></a>out_include_dir |  -   | String | optional | "include" |
-| <a id="boost_build-out_lib_dir"></a>out_lib_dir |  -   | String | optional | "lib" |
-| <a id="boost_build-postfix_script"></a>postfix_script |  -   | String | optional | "" |
-| <a id="boost_build-shared_libraries"></a>shared_libraries |  -   | List of strings | optional | [] |
-| <a id="boost_build-static_libraries"></a>static_libraries |  -   | List of strings | optional | [] |
-| <a id="boost_build-tools_deps"></a>tools_deps |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="boost_build-user_options"></a>user_options |  -   | List of strings | optional | [] |
+| <a id="boost_build-additional_inputs"></a>additional_inputs |  Optional additional inputs to be declared as needed for the shell script action.Not used by the shell script part in cc_external_rule_impl.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="boost_build-additional_tools"></a>additional_tools |  Optional additional tools needed for the building. Not used by the shell script part in cc_external_rule_impl.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="boost_build-alwayslink"></a>alwayslink |  Optional. if true, link all the object files from the static library, even if they are not used.   | Boolean | optional | False |
+| <a id="boost_build-binaries"></a>binaries |  Optional names of the resulting binaries.   | List of strings | optional | [] |
+| <a id="boost_build-bootstrap_options"></a>bootstrap_options |  any additional flags to pass to bootstrap.sh   | List of strings | optional | [] |
+| <a id="boost_build-defines"></a>defines |  Optional compilation definitions to be passed to the dependencies of this library. They are NOT passed to the compiler, you should duplicate them in the configuration options.   | List of strings | optional | [] |
+| <a id="boost_build-deps"></a>deps |  Optional dependencies to be copied into the directory structure. Typically those directly required for the external building of the library/binaries. (i.e. those that the external buidl system will be looking for and paths to which are provided by the calling rule)   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="boost_build-headers_only"></a>headers_only |  Flag variable to indicate that the library produces only headers   | Boolean | optional | False |
+| <a id="boost_build-interface_libraries"></a>interface_libraries |  Optional names of the resulting interface libraries.   | List of strings | optional | [] |
+| <a id="boost_build-lib_name"></a>lib_name |  Library name. Defines the name of the install directory and the name of the static library, if no output files parameters are defined (any of static_libraries, shared_libraries, interface_libraries, binaries_names) Optional. If not defined, defaults to the target's name.   | String | optional | "" |
+| <a id="boost_build-lib_source"></a>lib_source |  Label with source code to build. Typically a filegroup for the source of remote repository. Mandatory.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| <a id="boost_build-linkopts"></a>linkopts |  Optional link options to be passed up to the dependencies of this library   | List of strings | optional | [] |
+| <a id="boost_build-make_commands"></a>make_commands |  Optinal make commands, defaults to ["make", "make install"]   | List of strings | optional | ["make", "make install"] |
+| <a id="boost_build-out_bin_dir"></a>out_bin_dir |  Optional name of the output subdirectory with the binary files, defaults to 'bin'.   | String | optional | "bin" |
+| <a id="boost_build-out_include_dir"></a>out_include_dir |  Optional name of the output subdirectory with the header files, defaults to 'include'.   | String | optional | "include" |
+| <a id="boost_build-out_lib_dir"></a>out_lib_dir |  Optional name of the output subdirectory with the library files, defaults to 'lib'.   | String | optional | "lib" |
+| <a id="boost_build-postfix_script"></a>postfix_script |  Optional part of the shell script to be added after the make commands   | String | optional | "" |
+| <a id="boost_build-shared_libraries"></a>shared_libraries |  Optional names of the resulting shared libraries.   | List of strings | optional | [] |
+| <a id="boost_build-static_libraries"></a>static_libraries |  Optional names of the resulting static libraries.   | List of strings | optional | [] |
+| <a id="boost_build-tools_deps"></a>tools_deps |  Optional tools to be copied into the directory structure. Similar to deps, those directly required for the external building of the library/binaries.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="boost_build-user_options"></a>user_options |  any additional flags to pass to b2   | List of strings | optional | [] |
 
 
 <a id="#cmake_external"></a>
@@ -54,7 +54,7 @@ cmake_external(<a href="#cmake_external-name">name</a>, <a href="#cmake_external
                <a href="#cmake_external-static_libraries">static_libraries</a>, <a href="#cmake_external-tools_deps">tools_deps</a>, <a href="#cmake_external-working_directory">working_directory</a>)
 </pre>
 
-
+Rule for building external library with CMake.
 
 **ATTRIBUTES**
 
@@ -62,31 +62,31 @@ cmake_external(<a href="#cmake_external-name">name</a>, <a href="#cmake_external
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="cmake_external-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| <a id="cmake_external-additional_inputs"></a>additional_inputs |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="cmake_external-additional_tools"></a>additional_tools |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="cmake_external-alwayslink"></a>alwayslink |  -   | Boolean | optional | False |
-| <a id="cmake_external-binaries"></a>binaries |  -   | List of strings | optional | [] |
-| <a id="cmake_external-cache_entries"></a>cache_entries |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
-| <a id="cmake_external-cmake_options"></a>cmake_options |  -   | List of strings | optional | [] |
-| <a id="cmake_external-defines"></a>defines |  -   | List of strings | optional | [] |
-| <a id="cmake_external-deps"></a>deps |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="cmake_external-env_vars"></a>env_vars |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
-| <a id="cmake_external-generate_crosstool_file"></a>generate_crosstool_file |  -   | Boolean | optional | False |
-| <a id="cmake_external-headers_only"></a>headers_only |  -   | Boolean | optional | False |
-| <a id="cmake_external-install_prefix"></a>install_prefix |  -   | String | optional | "" |
-| <a id="cmake_external-interface_libraries"></a>interface_libraries |  -   | List of strings | optional | [] |
-| <a id="cmake_external-lib_name"></a>lib_name |  -   | String | optional | "" |
-| <a id="cmake_external-lib_source"></a>lib_source |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
-| <a id="cmake_external-linkopts"></a>linkopts |  -   | List of strings | optional | [] |
-| <a id="cmake_external-make_commands"></a>make_commands |  -   | List of strings | optional | ["make", "make install"] |
-| <a id="cmake_external-out_bin_dir"></a>out_bin_dir |  -   | String | optional | "bin" |
-| <a id="cmake_external-out_include_dir"></a>out_include_dir |  -   | String | optional | "include" |
-| <a id="cmake_external-out_lib_dir"></a>out_lib_dir |  -   | String | optional | "lib" |
-| <a id="cmake_external-postfix_script"></a>postfix_script |  -   | String | optional | "" |
-| <a id="cmake_external-shared_libraries"></a>shared_libraries |  -   | List of strings | optional | [] |
-| <a id="cmake_external-static_libraries"></a>static_libraries |  -   | List of strings | optional | [] |
-| <a id="cmake_external-tools_deps"></a>tools_deps |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="cmake_external-working_directory"></a>working_directory |  -   | String | optional | "" |
+| <a id="cmake_external-additional_inputs"></a>additional_inputs |  Optional additional inputs to be declared as needed for the shell script action.Not used by the shell script part in cc_external_rule_impl.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="cmake_external-additional_tools"></a>additional_tools |  Optional additional tools needed for the building. Not used by the shell script part in cc_external_rule_impl.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="cmake_external-alwayslink"></a>alwayslink |  Optional. if true, link all the object files from the static library, even if they are not used.   | Boolean | optional | False |
+| <a id="cmake_external-binaries"></a>binaries |  Optional names of the resulting binaries.   | List of strings | optional | [] |
+| <a id="cmake_external-cache_entries"></a>cache_entries |  CMake cache entries to initialize (they will be passed with -Dkey=value) Values, defined by the toolchain, will be joined with the values, passed here. (Toolchain values come first)   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
+| <a id="cmake_external-cmake_options"></a>cmake_options |  Other CMake options   | List of strings | optional | [] |
+| <a id="cmake_external-defines"></a>defines |  Optional compilation definitions to be passed to the dependencies of this library. They are NOT passed to the compiler, you should duplicate them in the configuration options.   | List of strings | optional | [] |
+| <a id="cmake_external-deps"></a>deps |  Optional dependencies to be copied into the directory structure. Typically those directly required for the external building of the library/binaries. (i.e. those that the external buidl system will be looking for and paths to which are provided by the calling rule)   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="cmake_external-env_vars"></a>env_vars |  CMake environment variable values to join with toolchain-defined. For example, additional CXXFLAGS.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
+| <a id="cmake_external-generate_crosstool_file"></a>generate_crosstool_file |  When True, CMake crosstool file will be generated from the toolchain values, provided cache-entries and env_vars (some values will still be passed as -Dkey=value and environment variables). If CMAKE_TOOLCHAIN_FILE cache entry is passed, specified crosstool file will be used When using this option, it makes sense to specify CMAKE_SYSTEM_NAME in the cache_entries - the rule makes only a poor guess about the target system, it is better to specify it manually.   | Boolean | optional | False |
+| <a id="cmake_external-headers_only"></a>headers_only |  Flag variable to indicate that the library produces only headers   | Boolean | optional | False |
+| <a id="cmake_external-install_prefix"></a>install_prefix |  Relative install prefix to be passed to CMake in -DCMAKE_INSTALL_PREFIX   | String | optional | "" |
+| <a id="cmake_external-interface_libraries"></a>interface_libraries |  Optional names of the resulting interface libraries.   | List of strings | optional | [] |
+| <a id="cmake_external-lib_name"></a>lib_name |  Library name. Defines the name of the install directory and the name of the static library, if no output files parameters are defined (any of static_libraries, shared_libraries, interface_libraries, binaries_names) Optional. If not defined, defaults to the target's name.   | String | optional | "" |
+| <a id="cmake_external-lib_source"></a>lib_source |  Label with source code to build. Typically a filegroup for the source of remote repository. Mandatory.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| <a id="cmake_external-linkopts"></a>linkopts |  Optional link options to be passed up to the dependencies of this library   | List of strings | optional | [] |
+| <a id="cmake_external-make_commands"></a>make_commands |  Optinal make commands, defaults to ["make", "make install"]   | List of strings | optional | ["make", "make install"] |
+| <a id="cmake_external-out_bin_dir"></a>out_bin_dir |  Optional name of the output subdirectory with the binary files, defaults to 'bin'.   | String | optional | "bin" |
+| <a id="cmake_external-out_include_dir"></a>out_include_dir |  Optional name of the output subdirectory with the header files, defaults to 'include'.   | String | optional | "include" |
+| <a id="cmake_external-out_lib_dir"></a>out_lib_dir |  Optional name of the output subdirectory with the library files, defaults to 'lib'.   | String | optional | "lib" |
+| <a id="cmake_external-postfix_script"></a>postfix_script |  Optional part of the shell script to be added after the make commands   | String | optional | "" |
+| <a id="cmake_external-shared_libraries"></a>shared_libraries |  Optional names of the resulting shared libraries.   | List of strings | optional | [] |
+| <a id="cmake_external-static_libraries"></a>static_libraries |  Optional names of the resulting static libraries.   | List of strings | optional | [] |
+| <a id="cmake_external-tools_deps"></a>tools_deps |  Optional tools to be copied into the directory structure. Similar to deps, those directly required for the external building of the library/binaries.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="cmake_external-working_directory"></a>working_directory |  Working directory, with the main CMakeLists.txt (otherwise, the top directory of the lib_source label files is used.)   | String | optional | "" |
 
 
 <a id="#configure_make"></a>
@@ -102,7 +102,7 @@ configure_make(<a href="#configure_make-name">name</a>, <a href="#configure_make
                <a href="#configure_make-shared_libraries">shared_libraries</a>, <a href="#configure_make-static_libraries">static_libraries</a>, <a href="#configure_make-tools_deps">tools_deps</a>)
 </pre>
 
-
+Rule for building external libraries with configure-make pattern. Some 'configure' script is invoked with --prefix=install (by default), and other parameters for compilation and linking, taken from Bazel C/C++ toolchain and passed dependencies. After configuration, GNU Make is called.
 
 **ATTRIBUTES**
 
@@ -110,37 +110,37 @@ configure_make(<a href="#configure_make-name">name</a>, <a href="#configure_make
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="configure_make-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| <a id="configure_make-additional_inputs"></a>additional_inputs |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="configure_make-additional_tools"></a>additional_tools |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="configure_make-alwayslink"></a>alwayslink |  -   | Boolean | optional | False |
-| <a id="configure_make-autogen"></a>autogen |  -   | Boolean | optional | False |
-| <a id="configure_make-autogen_command"></a>autogen_command |  -   | String | optional | "autogen.sh" |
-| <a id="configure_make-autogen_env_vars"></a>autogen_env_vars |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
-| <a id="configure_make-autogen_options"></a>autogen_options |  -   | List of strings | optional | [] |
-| <a id="configure_make-autoreconf"></a>autoreconf |  -   | Boolean | optional | False |
-| <a id="configure_make-autoreconf_env_vars"></a>autoreconf_env_vars |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
-| <a id="configure_make-autoreconf_options"></a>autoreconf_options |  -   | List of strings | optional | [] |
-| <a id="configure_make-binaries"></a>binaries |  -   | List of strings | optional | [] |
-| <a id="configure_make-configure_command"></a>configure_command |  -   | String | optional | "configure" |
-| <a id="configure_make-configure_env_vars"></a>configure_env_vars |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
-| <a id="configure_make-configure_in_place"></a>configure_in_place |  -   | Boolean | optional | False |
-| <a id="configure_make-configure_options"></a>configure_options |  -   | List of strings | optional | [] |
-| <a id="configure_make-defines"></a>defines |  -   | List of strings | optional | [] |
-| <a id="configure_make-deps"></a>deps |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="configure_make-headers_only"></a>headers_only |  -   | Boolean | optional | False |
-| <a id="configure_make-install_prefix"></a>install_prefix |  -   | String | optional | "" |
-| <a id="configure_make-interface_libraries"></a>interface_libraries |  -   | List of strings | optional | [] |
-| <a id="configure_make-lib_name"></a>lib_name |  -   | String | optional | "" |
-| <a id="configure_make-lib_source"></a>lib_source |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
-| <a id="configure_make-linkopts"></a>linkopts |  -   | List of strings | optional | [] |
-| <a id="configure_make-make_commands"></a>make_commands |  -   | List of strings | optional | ["make", "make install"] |
-| <a id="configure_make-out_bin_dir"></a>out_bin_dir |  -   | String | optional | "bin" |
-| <a id="configure_make-out_include_dir"></a>out_include_dir |  -   | String | optional | "include" |
-| <a id="configure_make-out_lib_dir"></a>out_lib_dir |  -   | String | optional | "lib" |
-| <a id="configure_make-postfix_script"></a>postfix_script |  -   | String | optional | "" |
-| <a id="configure_make-shared_libraries"></a>shared_libraries |  -   | List of strings | optional | [] |
-| <a id="configure_make-static_libraries"></a>static_libraries |  -   | List of strings | optional | [] |
-| <a id="configure_make-tools_deps"></a>tools_deps |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="configure_make-additional_inputs"></a>additional_inputs |  Optional additional inputs to be declared as needed for the shell script action.Not used by the shell script part in cc_external_rule_impl.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="configure_make-additional_tools"></a>additional_tools |  Optional additional tools needed for the building. Not used by the shell script part in cc_external_rule_impl.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="configure_make-alwayslink"></a>alwayslink |  Optional. if true, link all the object files from the static library, even if they are not used.   | Boolean | optional | False |
+| <a id="configure_make-autogen"></a>autogen |  Set to True if 'autogen.sh' should be invoked before 'configure', currently requires 'configure_in_place' to be True.   | Boolean | optional | False |
+| <a id="configure_make-autogen_command"></a>autogen_command |  The name of the autogen script file, default: autogen.sh. Many projects use autogen.sh however the Autotools FAQ recommends bootstrap so we provide this option to support that.   | String | optional | "autogen.sh" |
+| <a id="configure_make-autogen_env_vars"></a>autogen_env_vars |  Environment variables to be set for 'autogen' invocation.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
+| <a id="configure_make-autogen_options"></a>autogen_options |  Any options to be put in the 'autogen.sh' command line.   | List of strings | optional | [] |
+| <a id="configure_make-autoreconf"></a>autoreconf |  Set to True if 'autoreconf' should be invoked before 'configure.', currently requires 'configure_in_place' to be True.   | Boolean | optional | False |
+| <a id="configure_make-autoreconf_env_vars"></a>autoreconf_env_vars |  Environment variables to be set for 'autoreconf' invocation.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
+| <a id="configure_make-autoreconf_options"></a>autoreconf_options |  Any options to be put in the 'autoreconf.sh' command line.   | List of strings | optional | [] |
+| <a id="configure_make-binaries"></a>binaries |  Optional names of the resulting binaries.   | List of strings | optional | [] |
+| <a id="configure_make-configure_command"></a>configure_command |  The name of the configuration script file, default: configure. The file must be in the root of the source directory.   | String | optional | "configure" |
+| <a id="configure_make-configure_env_vars"></a>configure_env_vars |  Environment variables to be set for the 'configure' invocation.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
+| <a id="configure_make-configure_in_place"></a>configure_in_place |  Set to True if 'configure' should be invoked in place, i.e. from its enclosing directory.   | Boolean | optional | False |
+| <a id="configure_make-configure_options"></a>configure_options |  Any options to be put on the 'configure' command line.   | List of strings | optional | [] |
+| <a id="configure_make-defines"></a>defines |  Optional compilation definitions to be passed to the dependencies of this library. They are NOT passed to the compiler, you should duplicate them in the configuration options.   | List of strings | optional | [] |
+| <a id="configure_make-deps"></a>deps |  Optional dependencies to be copied into the directory structure. Typically those directly required for the external building of the library/binaries. (i.e. those that the external buidl system will be looking for and paths to which are provided by the calling rule)   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="configure_make-headers_only"></a>headers_only |  Flag variable to indicate that the library produces only headers   | Boolean | optional | False |
+| <a id="configure_make-install_prefix"></a>install_prefix |  Install prefix, i.e. relative path to where to install the result of the build. Passed to the 'configure' script with --prefix flag.   | String | optional | "" |
+| <a id="configure_make-interface_libraries"></a>interface_libraries |  Optional names of the resulting interface libraries.   | List of strings | optional | [] |
+| <a id="configure_make-lib_name"></a>lib_name |  Library name. Defines the name of the install directory and the name of the static library, if no output files parameters are defined (any of static_libraries, shared_libraries, interface_libraries, binaries_names) Optional. If not defined, defaults to the target's name.   | String | optional | "" |
+| <a id="configure_make-lib_source"></a>lib_source |  Label with source code to build. Typically a filegroup for the source of remote repository. Mandatory.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| <a id="configure_make-linkopts"></a>linkopts |  Optional link options to be passed up to the dependencies of this library   | List of strings | optional | [] |
+| <a id="configure_make-make_commands"></a>make_commands |  Optinal make commands, defaults to ["make", "make install"]   | List of strings | optional | ["make", "make install"] |
+| <a id="configure_make-out_bin_dir"></a>out_bin_dir |  Optional name of the output subdirectory with the binary files, defaults to 'bin'.   | String | optional | "bin" |
+| <a id="configure_make-out_include_dir"></a>out_include_dir |  Optional name of the output subdirectory with the header files, defaults to 'include'.   | String | optional | "include" |
+| <a id="configure_make-out_lib_dir"></a>out_lib_dir |  Optional name of the output subdirectory with the library files, defaults to 'lib'.   | String | optional | "lib" |
+| <a id="configure_make-postfix_script"></a>postfix_script |  Optional part of the shell script to be added after the make commands   | String | optional | "" |
+| <a id="configure_make-shared_libraries"></a>shared_libraries |  Optional names of the resulting shared libraries.   | List of strings | optional | [] |
+| <a id="configure_make-static_libraries"></a>static_libraries |  Optional names of the resulting static libraries.   | List of strings | optional | [] |
+| <a id="configure_make-tools_deps"></a>tools_deps |  Optional tools to be copied into the directory structure. Similar to deps, those directly required for the external building of the library/binaries.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 
 
 <a id="#make"></a>
@@ -154,7 +154,7 @@ make(<a href="#make-name">name</a>, <a href="#make-additional_inputs">additional
      <a href="#make-static_libraries">static_libraries</a>, <a href="#make-tools_deps">tools_deps</a>)
 </pre>
 
-
+Rule for building external libraries with GNU Make. GNU Make commands (make and make install by default) are invoked with prefix="install" (by default), and other environment variables for compilation and linking, taken from Bazel C/C++ toolchain and passed dependencies.
 
 **ATTRIBUTES**
 
@@ -162,28 +162,28 @@ make(<a href="#make-name">name</a>, <a href="#make-additional_inputs">additional
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="make-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| <a id="make-additional_inputs"></a>additional_inputs |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="make-additional_tools"></a>additional_tools |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="make-alwayslink"></a>alwayslink |  -   | Boolean | optional | False |
-| <a id="make-binaries"></a>binaries |  -   | List of strings | optional | [] |
-| <a id="make-defines"></a>defines |  -   | List of strings | optional | [] |
-| <a id="make-deps"></a>deps |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="make-headers_only"></a>headers_only |  -   | Boolean | optional | False |
-| <a id="make-interface_libraries"></a>interface_libraries |  -   | List of strings | optional | [] |
-| <a id="make-keep_going"></a>keep_going |  -   | Boolean | optional | True |
-| <a id="make-lib_name"></a>lib_name |  -   | String | optional | "" |
-| <a id="make-lib_source"></a>lib_source |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
-| <a id="make-linkopts"></a>linkopts |  -   | List of strings | optional | [] |
-| <a id="make-make_commands"></a>make_commands |  -   | List of strings | optional | [] |
-| <a id="make-make_env_vars"></a>make_env_vars |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
-| <a id="make-out_bin_dir"></a>out_bin_dir |  -   | String | optional | "bin" |
-| <a id="make-out_include_dir"></a>out_include_dir |  -   | String | optional | "include" |
-| <a id="make-out_lib_dir"></a>out_lib_dir |  -   | String | optional | "lib" |
-| <a id="make-postfix_script"></a>postfix_script |  -   | String | optional | "" |
-| <a id="make-prefix"></a>prefix |  -   | String | optional | "" |
-| <a id="make-shared_libraries"></a>shared_libraries |  -   | List of strings | optional | [] |
-| <a id="make-static_libraries"></a>static_libraries |  -   | List of strings | optional | [] |
-| <a id="make-tools_deps"></a>tools_deps |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="make-additional_inputs"></a>additional_inputs |  Optional additional inputs to be declared as needed for the shell script action.Not used by the shell script part in cc_external_rule_impl.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="make-additional_tools"></a>additional_tools |  Optional additional tools needed for the building. Not used by the shell script part in cc_external_rule_impl.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="make-alwayslink"></a>alwayslink |  Optional. if true, link all the object files from the static library, even if they are not used.   | Boolean | optional | False |
+| <a id="make-binaries"></a>binaries |  Optional names of the resulting binaries.   | List of strings | optional | [] |
+| <a id="make-defines"></a>defines |  Optional compilation definitions to be passed to the dependencies of this library. They are NOT passed to the compiler, you should duplicate them in the configuration options.   | List of strings | optional | [] |
+| <a id="make-deps"></a>deps |  Optional dependencies to be copied into the directory structure. Typically those directly required for the external building of the library/binaries. (i.e. those that the external buidl system will be looking for and paths to which are provided by the calling rule)   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="make-headers_only"></a>headers_only |  Flag variable to indicate that the library produces only headers   | Boolean | optional | False |
+| <a id="make-interface_libraries"></a>interface_libraries |  Optional names of the resulting interface libraries.   | List of strings | optional | [] |
+| <a id="make-keep_going"></a>keep_going |  Keep going when some targets can not be made, -k flag is passed to make (applies only if make_commands attribute is not set). Please have a look at _create_make_script for default make_commands.   | Boolean | optional | True |
+| <a id="make-lib_name"></a>lib_name |  Library name. Defines the name of the install directory and the name of the static library, if no output files parameters are defined (any of static_libraries, shared_libraries, interface_libraries, binaries_names) Optional. If not defined, defaults to the target's name.   | String | optional | "" |
+| <a id="make-lib_source"></a>lib_source |  Label with source code to build. Typically a filegroup for the source of remote repository. Mandatory.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| <a id="make-linkopts"></a>linkopts |  Optional link options to be passed up to the dependencies of this library   | List of strings | optional | [] |
+| <a id="make-make_commands"></a>make_commands |  Overriding make_commands default value to be empty, then we can provide better default value programmatically   | List of strings | optional | [] |
+| <a id="make-make_env_vars"></a>make_env_vars |  Environment variables to be set for the 'configure' invocation.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
+| <a id="make-out_bin_dir"></a>out_bin_dir |  Optional name of the output subdirectory with the binary files, defaults to 'bin'.   | String | optional | "bin" |
+| <a id="make-out_include_dir"></a>out_include_dir |  Optional name of the output subdirectory with the header files, defaults to 'include'.   | String | optional | "include" |
+| <a id="make-out_lib_dir"></a>out_lib_dir |  Optional name of the output subdirectory with the library files, defaults to 'lib'.   | String | optional | "lib" |
+| <a id="make-postfix_script"></a>postfix_script |  Optional part of the shell script to be added after the make commands   | String | optional | "" |
+| <a id="make-prefix"></a>prefix |  Install prefix, an absolute path. Passed to the GNU make via "make install PREFIX=&lt;value&gt;". By default, the install directory created under sandboxed execution root is used. Build results are copied to the Bazel's output directory, so the prefix is only important if it is recorded into any text files by Makefile script. In that case, it is important to note that rules_foreign_cc is overriding the paths under execution root with "BAZEL_GEN_ROOT" value.   | String | optional | "" |
+| <a id="make-shared_libraries"></a>shared_libraries |  Optional names of the resulting shared libraries.   | List of strings | optional | [] |
+| <a id="make-static_libraries"></a>static_libraries |  Optional names of the resulting static libraries.   | List of strings | optional | [] |
+| <a id="make-tools_deps"></a>tools_deps |  Optional tools to be copied into the directory structure. Similar to deps, those directly required for the external building of the library/binaries.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 
 
 <a id="#ConfigureParameters"></a>

--- a/tools/build_defs/boost_build.bzl
+++ b/tools/build_defs/boost_build.bzl
@@ -30,18 +30,19 @@ def _create_configure_script(configureParameters):
 def _attrs():
     attrs = dict(CC_EXTERNAL_RULE_ATTRIBUTES)
     attrs.update({
-        # any additional flags to pass to bootstrap.sh
-        "bootstrap_options": attr.string_list(mandatory = False),
-        # any additional flags to pass to b2
-        "user_options": attr.string_list(mandatory = False),
+        "bootstrap_options": attr.string_list(
+            doc = "any additional flags to pass to bootstrap.sh",
+            mandatory = False,
+        ),
+        "user_options": attr.string_list(
+            doc = "any additional flags to pass to b2",
+            mandatory = False,
+        ),
     })
     return attrs
 
-""" Rule for building Boost. Invokes bootstrap.sh and then b2 install.
-  Attributes:
-    boost_srcs - target with the boost sources
-"""
 boost_build = rule(
+    doc = "Rule for building Boost. Invokes bootstrap.sh and then b2 install.",
     attrs = _attrs(),
     fragments = ["cpp"],
     output_to_genfiles = True,

--- a/tools/build_defs/cmake.bzl
+++ b/tools/build_defs/cmake.bzl
@@ -103,37 +103,58 @@ def _get_install_prefix(ctx):
 def _attrs():
     attrs = dict(CC_EXTERNAL_RULE_ATTRIBUTES)
     attrs.update({
-        # Relative install prefix to be passed to CMake in -DCMAKE_INSTALL_PREFIX
-        "install_prefix": attr.string(mandatory = False),
-        # CMake cache entries to initialize (they will be passed with -Dkey=value)
-        # Values, defined by the toolchain, will be joined with the values, passed here.
-        # (Toolchain values come first)
-        "cache_entries": attr.string_dict(mandatory = False, default = {}),
-        # CMake environment variable values to join with toolchain-defined.
-        # For example, additional CXXFLAGS.
-        "env_vars": attr.string_dict(mandatory = False, default = {}),
-        # Other CMake options
-        "cmake_options": attr.string_list(mandatory = False, default = []),
-        # When True, CMake crosstool file will be generated from the toolchain values,
-        # provided cache-entries and env_vars (some values will still be passed as -Dkey=value
-        # and environment variables).
-        # If CMAKE_TOOLCHAIN_FILE cache entry is passed, specified crosstool file will be used
-        # When using this option, it makes sense to specify CMAKE_SYSTEM_NAME in the
-        # cache_entries - the rule makes only a poor guess about the target system,
-        # it is better to specify it manually.
-        "generate_crosstool_file": attr.bool(mandatory = False, default = False),
-        # Working directory, with the main CMakeLists.txt
-        # (otherwise, the top directory of the lib_source label files is used.)
-        "working_directory": attr.string(mandatory = False, default = ""),
+        "install_prefix": attr.string(
+            doc = "Relative install prefix to be passed to CMake in -DCMAKE_INSTALL_PREFIX",
+            mandatory = False,
+        ),
+        "cache_entries": attr.string_dict(
+            doc = (
+                "CMake cache entries to initialize (they will be passed with -Dkey=value) " +
+                "Values, defined by the toolchain, will be joined with the values, passed here. " +
+                "(Toolchain values come first)"
+            ),
+            mandatory = False,
+            default = {},
+        ),
+        "env_vars": attr.string_dict(
+            doc = (
+                "CMake environment variable values to join with toolchain-defined. " +
+                "For example, additional CXXFLAGS."
+            ),
+            mandatory = False,
+            default = {},
+        ),
+        "cmake_options": attr.string_list(
+            doc = "Other CMake options",
+            mandatory = False,
+            default = [],
+        ),
+        "generate_crosstool_file": attr.bool(
+            doc = (
+                "When True, CMake crosstool file will be generated from the toolchain values, " +
+                "provided cache-entries and env_vars (some values will still be passed as -Dkey=value " +
+                "and environment variables). " +
+                "If CMAKE_TOOLCHAIN_FILE cache entry is passed, specified crosstool file will be used " +
+                "When using this option, it makes sense to specify CMAKE_SYSTEM_NAME in the " +
+                "cache_entries - the rule makes only a poor guess about the target system, " +
+                "it is better to specify it manually."
+            ),
+            mandatory = False,
+            default = False,
+        ),
+        "working_directory": attr.string(
+            doc = (
+                "Working directory, with the main CMakeLists.txt " +
+                "(otherwise, the top directory of the lib_source label files is used.)"
+            ),
+            mandatory = False,
+            default = "",
+        ),
     })
     return attrs
 
-""" Rule for building external library with CMake.
- Attributes:
-   See line comments in _attrs() method.
- Other attributes are documented in framework.bzl:CC_EXTERNAL_RULE_ATTRIBUTES
-"""
 cmake_external = rule(
+    doc = "Rule for building external library with CMake.",
     attrs = _attrs(),
     fragments = ["cpp"],
     output_to_genfiles = True,

--- a/tools/build_defs/configure.bzl
+++ b/tools/build_defs/configure.bzl
@@ -81,51 +81,81 @@ def _get_install_prefix(ctx):
 def _attrs():
     attrs = dict(CC_EXTERNAL_RULE_ATTRIBUTES)
     attrs.update({
-        # The name of the configuration script file, default: configure.
-        # The file must be in the root of the source directory.
-        "configure_command": attr.string(default = "configure"),
-        # Any options to be put on the 'configure' command line.
-        "configure_options": attr.string_list(),
-        # Environment variables to be set for the 'configure' invocation.
-        "configure_env_vars": attr.string_dict(),
-        # Install prefix, i.e. relative path to where to install the result of the build.
-        # Passed to the 'configure' script with --prefix flag.
-        "install_prefix": attr.string(mandatory = False),
-        # Set to True if 'configure' should be invoked in place, i.e. from its enclosing
-        # directory.
-        "configure_in_place": attr.bool(mandatory = False, default = False),
-        # Set to True if 'autoreconf' should be invoked before 'configure.',
-        # currently requires 'configure_in_place' to be True.
-        "autoreconf": attr.bool(mandatory = False, default = False),
-        # Any options to be put in the 'autoreconf.sh' command line.
-        "autoreconf_options": attr.string_list(),
-        # Environment variables to be set for 'autoreconf' invocation.
-        "autoreconf_env_vars": attr.string_dict(),
-        # Set to True if 'autogen.sh' should be invoked before 'configure',
-        # currently requires 'configure_in_place' to be True.
-        "autogen": attr.bool(mandatory = False, default = False),
-        # The name of the autogen script file, default: autogen.sh.
-        # Many projects use autogen.sh however the Autotools FAQ recommends bootstrap
-        # so we provide this option to support that.
-        "autogen_command": attr.string(default = "autogen.sh"),
-        # Any options to be put in the 'autogen.sh' command line.
-        "autogen_options": attr.string_list(),
-        # Environment variables to be set for 'autogen' invocation.
-        "autogen_env_vars": attr.string_dict(),
+        "configure_command": attr.string(
+            doc = (
+                "The name of the configuration script file, default: configure. " +
+                "The file must be in the root of the source directory."
+            ),
+            default = "configure",
+        ),
+        "configure_options": attr.string_list(
+            doc = "Any options to be put on the 'configure' command line.",
+        ),
+        "configure_env_vars": attr.string_dict(
+            doc = "Environment variables to be set for the 'configure' invocation.",
+        ),
+        "install_prefix": attr.string(
+            doc = (
+                "Install prefix, i.e. relative path to where to install the result of the build. " +
+                "Passed to the 'configure' script with --prefix flag."
+            ),
+            mandatory = False,
+        ),
+        "configure_in_place": attr.bool(
+            doc = (
+                "Set to True if 'configure' should be invoked in place, i.e. from its enclosing " +
+                "directory."
+            ),
+            mandatory = False,
+            default = False,
+        ),
+        "autoreconf": attr.bool(
+            doc = (
+                "Set to True if 'autoreconf' should be invoked before 'configure.', " +
+                "currently requires 'configure_in_place' to be True."
+            ),
+            mandatory = False,
+            default = False,
+        ),
+        "autoreconf_options": attr.string_list(
+            doc = "Any options to be put in the 'autoreconf.sh' command line.",
+        ),
+        "autoreconf_env_vars": attr.string_dict(
+            doc = "Environment variables to be set for 'autoreconf' invocation.",
+        ),
+        "autogen": attr.bool(
+            doc = (
+                "Set to True if 'autogen.sh' should be invoked before 'configure', " +
+                "currently requires 'configure_in_place' to be True."
+            ),
+            mandatory = False,
+            default = False,
+        ),
+        "autogen_command": attr.string(
+            doc = (
+                "The name of the autogen script file, default: autogen.sh. " +
+                "Many projects use autogen.sh however the Autotools FAQ recommends bootstrap " +
+                "so we provide this option to support that."
+            ),
+            default = "autogen.sh",
+        ),
+        "autogen_options": attr.string_list(
+            doc = "Any options to be put in the 'autogen.sh' command line.",
+        ),
+        "autogen_env_vars": attr.string_dict(
+            doc = "Environment variables to be set for 'autogen' invocation.",
+        ),
     })
     return attrs
 
-""" Rule for building external libraries with configure-make pattern.
- Some 'configure' script is invoked with --prefix=install (by default),
- and other parameters for compilation and linking, taken from Bazel C/C++
- toolchain and passed dependencies.
- After configuration, GNU Make is called.
-
- Attributes:
-   See line comments in _attrs() method.
- Other attributes are documented in framework.bzl:CC_EXTERNAL_RULE_ATTRIBUTES
-"""
 configure_make = rule(
+    doc = (
+        "Rule for building external libraries with configure-make pattern. " +
+        "Some 'configure' script is invoked with --prefix=install (by default), " +
+        "and other parameters for compilation and linking, taken from Bazel C/C++ " +
+        "toolchain and passed dependencies. " +
+        "After configuration, GNU Make is called."
+    ),
     attrs = _attrs(),
     fragments = ["cpp"],
     output_to_genfiles = True,

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -31,72 +31,140 @@ load(
  description dict. See cmake.bzl as an example.
 """
 CC_EXTERNAL_RULE_ATTRIBUTES = {
-    # Library name. Defines the name of the install directory and the name of the static library,
-    # if no output files parameters are defined (any of static_libraries, shared_libraries,
-    # interface_libraries, binaries_names)
-    # Optional. If not defined, defaults to the target's name.
-    "lib_name": attr.string(mandatory = False),
-    # Label with source code to build. Typically a filegroup for the source of remote repository.
-    # Mandatory.
-    "lib_source": attr.label(mandatory = True, allow_files = True),
-    # Optional compilation definitions to be passed to the dependencies of this library.
-    # They are NOT passed to the compiler, you should duplicate them in the configuration options.
-    "defines": attr.string_list(mandatory = False, default = []),
-    #
-    # Optional additional inputs to be declared as needed for the shell script action.
-    # Not used by the shell script part in cc_external_rule_impl.
-    "additional_inputs": attr.label_list(mandatory = False, allow_files = True, default = []),
-    # Optional additional tools needed for the building.
-    # Not used by the shell script part in cc_external_rule_impl.
-    "additional_tools": attr.label_list(mandatory = False, allow_files = True, default = []),
-    #
-    # Optional part of the shell script to be added after the make commands
-    "postfix_script": attr.string(mandatory = False),
-    # Optinal make commands, defaults to ["make", "make install"]
-    "make_commands": attr.string_list(mandatory = False, default = ["make", "make install"]),
-    #
-    # Optional dependencies to be copied into the directory structure.
-    # Typically those directly required for the external building of the library/binaries.
-    # (i.e. those that the external buidl system will be looking for and paths to which are
-    # provided by the calling rule)
-    "deps": attr.label_list(mandatory = False, allow_files = True, default = []),
-    # Optional tools to be copied into the directory structure.
-    # Similar to deps, those directly required for the external building of the library/binaries.
-    "tools_deps": attr.label_list(mandatory = False, allow_files = True, cfg = "host", default = []),
-    #
-    # Optional name of the output subdirectory with the header files, defaults to 'include'.
-    "out_include_dir": attr.string(mandatory = False, default = "include"),
-    # Optional name of the output subdirectory with the library files, defaults to 'lib'.
-    "out_lib_dir": attr.string(mandatory = False, default = "lib"),
-    # Optional name of the output subdirectory with the binary files, defaults to 'bin'.
-    "out_bin_dir": attr.string(mandatory = False, default = "bin"),
-    #
-    # Optional. if true, link all the object files from the static library,
-    # even if they are not used.
-    "alwayslink": attr.bool(mandatory = False, default = False),
-    # Optional link options to be passed up to the dependencies of this library
-    "linkopts": attr.string_list(mandatory = False, default = []),
+    "lib_name": attr.string(
+        doc = (
+            "Library name. Defines the name of the install directory and the name of the static library, " +
+            "if no output files parameters are defined (any of static_libraries, shared_libraries, " +
+            "interface_libraries, binaries_names) " +
+            "Optional. If not defined, defaults to the target's name."
+        ),
+        mandatory = False,
+    ),
+    "lib_source": attr.label(
+        doc = (
+            "Label with source code to build. Typically a filegroup for the source of remote repository. " +
+            "Mandatory."
+        ),
+        mandatory = True,
+        allow_files = True,
+    ),
+    "defines": attr.string_list(
+        doc = (
+            "Optional compilation definitions to be passed to the dependencies of this library. " +
+            "They are NOT passed to the compiler, you should duplicate them in the configuration options."
+        ),
+        mandatory = False,
+        default = [],
+    ),
+    "additional_inputs": attr.label_list(
+        doc = (
+            "Optional additional inputs to be declared as needed for the shell script action." +
+            "Not used by the shell script part in cc_external_rule_impl."
+        ),
+        mandatory = False,
+        allow_files = True,
+        default = [],
+    ),
+    "additional_tools": attr.label_list(
+        doc = (
+            "Optional additional tools needed for the building. " +
+            "Not used by the shell script part in cc_external_rule_impl."
+        ),
+        mandatory = False,
+        allow_files = True,
+        default = [],
+    ),
+    "postfix_script": attr.string(
+        doc = "Optional part of the shell script to be added after the make commands",
+        mandatory = False,
+    ),
+    "make_commands": attr.string_list(
+        doc = "Optinal make commands, defaults to [\"make\", \"make install\"]",
+        mandatory = False,
+        default = ["make", "make install"],
+    ),
+    "deps": attr.label_list(
+        doc = (
+            "Optional dependencies to be copied into the directory structure. " +
+            "Typically those directly required for the external building of the library/binaries. " +
+            "(i.e. those that the external buidl system will be looking for and paths to which are " +
+            "provided by the calling rule)"
+        ),
+        mandatory = False,
+        allow_files = True,
+        default = [],
+    ),
+    "tools_deps": attr.label_list(
+        doc = (
+            "Optional tools to be copied into the directory structure. " +
+            "Similar to deps, those directly required for the external building of the library/binaries."
+        ),
+        mandatory = False,
+        allow_files = True,
+        cfg = "host",
+        default = [],
+    ),
+    "out_include_dir": attr.string(
+        doc = "Optional name of the output subdirectory with the header files, defaults to 'include'.",
+        mandatory = False,
+        default = "include",
+    ),
+    "out_lib_dir": attr.string(
+        doc = "Optional name of the output subdirectory with the library files, defaults to 'lib'.",
+        mandatory = False,
+        default = "lib",
+    ),
+    "out_bin_dir": attr.string(
+        doc = "Optional name of the output subdirectory with the binary files, defaults to 'bin'.",
+        mandatory = False,
+        default = "bin",
+    ),
+    "alwayslink": attr.bool(
+        doc = (
+            "Optional. if true, link all the object files from the static library, " +
+            "even if they are not used."
+        ),
+        mandatory = False,
+        default = False,
+    ),
+    "linkopts": attr.string_list(
+        doc = "Optional link options to be passed up to the dependencies of this library",
+        mandatory = False,
+        default = [],
+    ),
     #
     # Output files names parameters. If any of them is defined, only these files are passed to
     # Bazel providers.
     # if no of them is defined, default lib_name.a/lib_name.lib static library is assumed.
     #
-    # Optional names of the resulting static libraries.
-    "static_libraries": attr.string_list(mandatory = False),
-    # Optional names of the resulting shared libraries.
-    "shared_libraries": attr.string_list(mandatory = False),
-    # Optional names of the resulting interface libraries.
-    "interface_libraries": attr.string_list(mandatory = False),
-    # Optional names of the resulting binaries.
-    "binaries": attr.string_list(mandatory = False),
-    # Flag variable to indicate that the library produces only headers
-    "headers_only": attr.bool(mandatory = False, default = False),
-    #
+    "static_libraries": attr.string_list(
+        doc = "Optional names of the resulting static libraries.",
+        mandatory = False,
+    ),
+    "shared_libraries": attr.string_list(
+        doc = "Optional names of the resulting shared libraries.",
+        mandatory = False,
+    ),
+    "interface_libraries": attr.string_list(
+        doc = "Optional names of the resulting interface libraries.",
+        mandatory = False,
+    ),
+    "binaries": attr.string_list(
+        doc = "Optional names of the resulting binaries.",
+        mandatory = False,
+    ),
+    "headers_only": attr.bool(
+        doc = "Flag variable to indicate that the library produces only headers",
+        mandatory = False,
+        default = False,
+    ),
     "_is_debug": attr.label(
         default = "@foreign_cc_platform_utils//:compilation_mode",
     ),
     # we need to declare this attribute to access cc_toolchain
-    "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
+    "_cc_toolchain": attr.label(
+        default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+    ),
 }
 
 def create_attrs(attr_struct, configure_name, create_configure_script, **kwargs):

--- a/tools/build_defs/make.bzl
+++ b/tools/build_defs/make.bzl
@@ -74,36 +74,48 @@ def _get_install_prefix(ctx):
 def _attrs():
     attrs = dict(CC_EXTERNAL_RULE_ATTRIBUTES)
     attrs.update({
-        # Environment variables to be set for the 'configure' invocation.
-        "make_env_vars": attr.string_dict(),
-        # Install prefix, an absolute path.
-        # Passed to the GNU make via "make install PREFIX=<value>".
-        # By default, the install directory created under sandboxed execution root is used.
-        # Build results are copied to the Bazel's output directory, so the prefix is only important
-        # if it is recorded into any text files by Makefile script.
-        # In that case, it is important to note that rules_foreign_cc is overriding the paths under
-        # execution root with "BAZEL_GEN_ROOT" value.
-        "prefix": attr.string(mandatory = False),
-        # Overriding make_commands default value to be empty,
-        # then we can provide better default value programmatically
-        "make_commands": attr.string_list(mandatory = False, default = []),
-        # Keep going when some targets can not be made, -k flag is passed to make
-        # (applies only if make_commands attribute is not set).
-        # Please have a look at _create_make_script for default make_commands.
-        "keep_going": attr.bool(mandatory = False, default = True),
+        "make_env_vars": attr.string_dict(
+            doc = "Environment variables to be set for the 'configure' invocation.",
+        ),
+        "prefix": attr.string(
+            doc = (
+                "Install prefix, an absolute path. " +
+                "Passed to the GNU make via \"make install PREFIX=<value>\". " +
+                "By default, the install directory created under sandboxed execution root is used. " +
+                "Build results are copied to the Bazel's output directory, so the prefix is only important " +
+                "if it is recorded into any text files by Makefile script. " +
+                "In that case, it is important to note that rules_foreign_cc is overriding the paths under " +
+                "execution root with \"BAZEL_GEN_ROOT\" value."
+            ),
+            mandatory = False,
+        ),
+        "make_commands": attr.string_list(
+            doc = (
+                "Overriding make_commands default value to be empty, " +
+                "then we can provide better default value programmatically "
+            ),
+            mandatory = False,
+            default = [],
+        ),
+        "keep_going": attr.bool(
+            doc = (
+                "Keep going when some targets can not be made, -k flag is passed to make " +
+                "(applies only if make_commands attribute is not set). " +
+                "Please have a look at _create_make_script for default make_commands."
+            ),
+            mandatory = False,
+            default = True,
+        ),
     })
     return attrs
 
-"""Rule for building external libraries with GNU Make.
- GNU Make commands (make and make install by default) are invoked with prefix="install"
- (by default), and other environment variables for compilation and linking, taken from Bazel C/C++
- toolchain and passed dependencies.
-
- Attributes:
-   See line comments in _attrs() method.
- Other attributes are documented in framework.bzl:CC_EXTERNAL_RULE_ATTRIBUTES
-"""
 make = rule(
+    doc = (
+        "Rule for building external libraries with GNU Make. " +
+        "GNU Make commands (make and make install by default) are invoked with prefix=\"install\" " +
+        "(by default), and other environment variables for compilation and linking, taken from Bazel C/C++ " +
+        "toolchain and passed dependencies."
+    ),
     attrs = _attrs(),
     fragments = ["cpp"],
     output_to_genfiles = True,


### PR DESCRIPTION
This makes it possible for stardoc to render information about the rules in this project.
<img width="1091" alt="Screen Shot 2021-01-22 at 6 27 54 AM" src="https://user-images.githubusercontent.com/26427366/105503053-f7e9eb00-5c7a-11eb-9347-00cf51d80429.png">
