### PR TITLE
Added `data` attr to common framework

### DIFF
--- a/.bazelci/config.yaml
+++ b/.bazelci/config.yaml
@@ -6,7 +6,7 @@ tasks:
     build_targets:
       - "//cmake_android:app"
     test_targets:
-    - "//:tests"
+      - "//:tests"
   ubuntu1604:
     platform: ubuntu1604
     working_directory: examples
@@ -24,6 +24,8 @@ tasks:
   windows:
     platform: windows
     working_directory: examples
+    test_flags:
+      - "--enable_runfiles"
     test_targets:
       - "//:win_tests"
   ubuntu1804_flags:

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@
 
 <pre>
 boost_build(<a href="#boost_build-name">name</a>, <a href="#boost_build-additional_inputs">additional_inputs</a>, <a href="#boost_build-additional_tools">additional_tools</a>, <a href="#boost_build-alwayslink">alwayslink</a>, <a href="#boost_build-binaries">binaries</a>, <a href="#boost_build-bootstrap_options">bootstrap_options</a>,
-            <a href="#boost_build-defines">defines</a>, <a href="#boost_build-deps">deps</a>, <a href="#boost_build-headers_only">headers_only</a>, <a href="#boost_build-interface_libraries">interface_libraries</a>, <a href="#boost_build-lib_name">lib_name</a>, <a href="#boost_build-lib_source">lib_source</a>, <a href="#boost_build-linkopts">linkopts</a>,
+            <a href="#boost_build-data">data</a>, <a href="#boost_build-defines">defines</a>, <a href="#boost_build-deps">deps</a>, <a href="#boost_build-headers_only">headers_only</a>, <a href="#boost_build-interface_libraries">interface_libraries</a>, <a href="#boost_build-lib_name">lib_name</a>, <a href="#boost_build-lib_source">lib_source</a>, <a href="#boost_build-linkopts">linkopts</a>,
             <a href="#boost_build-make_commands">make_commands</a>, <a href="#boost_build-out_bin_dir">out_bin_dir</a>, <a href="#boost_build-out_include_dir">out_include_dir</a>, <a href="#boost_build-out_lib_dir">out_lib_dir</a>, <a href="#boost_build-postfix_script">postfix_script</a>,
             <a href="#boost_build-shared_libraries">shared_libraries</a>, <a href="#boost_build-static_libraries">static_libraries</a>, <a href="#boost_build-tools_deps">tools_deps</a>, <a href="#boost_build-user_options">user_options</a>)
 </pre>
@@ -40,6 +40,7 @@ Rule for building Boost. Invokes bootstrap.sh and then b2 install.
 | <a id="boost_build-alwayslink"></a>alwayslink |  Optional. if true, link all the object files from the static library, even if they are not used.   | Boolean | optional | False |
 | <a id="boost_build-binaries"></a>binaries |  Optional names of the resulting binaries.   | List of strings | optional | [] |
 | <a id="boost_build-bootstrap_options"></a>bootstrap_options |  any additional flags to pass to bootstrap.sh   | List of strings | optional | [] |
+| <a id="boost_build-data"></a>data |  Files needed by this rule at runtime. May list file or rule targets. Generally allows any target.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="boost_build-defines"></a>defines |  Optional compilation definitions to be passed to the dependencies of this library. They are NOT passed to the compiler, you should duplicate them in the configuration options.   | List of strings | optional | [] |
 | <a id="boost_build-deps"></a>deps |  Optional dependencies to be copied into the directory structure. Typically those directly required for the external building of the library/binaries. (i.e. those that the external buidl system will be looking for and paths to which are provided by the calling rule)   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="boost_build-headers_only"></a>headers_only |  Flag variable to indicate that the library produces only headers   | Boolean | optional | False |
@@ -64,7 +65,7 @@ Rule for building Boost. Invokes bootstrap.sh and then b2 install.
 
 <pre>
 cmake_external(<a href="#cmake_external-name">name</a>, <a href="#cmake_external-additional_inputs">additional_inputs</a>, <a href="#cmake_external-additional_tools">additional_tools</a>, <a href="#cmake_external-alwayslink">alwayslink</a>, <a href="#cmake_external-binaries">binaries</a>, <a href="#cmake_external-cache_entries">cache_entries</a>,
-               <a href="#cmake_external-cmake_options">cmake_options</a>, <a href="#cmake_external-defines">defines</a>, <a href="#cmake_external-deps">deps</a>, <a href="#cmake_external-env_vars">env_vars</a>, <a href="#cmake_external-generate_crosstool_file">generate_crosstool_file</a>, <a href="#cmake_external-headers_only">headers_only</a>,
+               <a href="#cmake_external-cmake_options">cmake_options</a>, <a href="#cmake_external-data">data</a>, <a href="#cmake_external-defines">defines</a>, <a href="#cmake_external-deps">deps</a>, <a href="#cmake_external-env_vars">env_vars</a>, <a href="#cmake_external-generate_crosstool_file">generate_crosstool_file</a>, <a href="#cmake_external-headers_only">headers_only</a>,
                <a href="#cmake_external-install_prefix">install_prefix</a>, <a href="#cmake_external-interface_libraries">interface_libraries</a>, <a href="#cmake_external-lib_name">lib_name</a>, <a href="#cmake_external-lib_source">lib_source</a>, <a href="#cmake_external-linkopts">linkopts</a>, <a href="#cmake_external-make_commands">make_commands</a>,
                <a href="#cmake_external-out_bin_dir">out_bin_dir</a>, <a href="#cmake_external-out_include_dir">out_include_dir</a>, <a href="#cmake_external-out_lib_dir">out_lib_dir</a>, <a href="#cmake_external-postfix_script">postfix_script</a>, <a href="#cmake_external-shared_libraries">shared_libraries</a>,
                <a href="#cmake_external-static_libraries">static_libraries</a>, <a href="#cmake_external-tools_deps">tools_deps</a>, <a href="#cmake_external-working_directory">working_directory</a>)
@@ -84,6 +85,7 @@ Rule for building external library with CMake.
 | <a id="cmake_external-binaries"></a>binaries |  Optional names of the resulting binaries.   | List of strings | optional | [] |
 | <a id="cmake_external-cache_entries"></a>cache_entries |  CMake cache entries to initialize (they will be passed with -Dkey=value) Values, defined by the toolchain, will be joined with the values, passed here. (Toolchain values come first)   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="cmake_external-cmake_options"></a>cmake_options |  Other CMake options   | List of strings | optional | [] |
+| <a id="cmake_external-data"></a>data |  Files needed by this rule at runtime. May list file or rule targets. Generally allows any target.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="cmake_external-defines"></a>defines |  Optional compilation definitions to be passed to the dependencies of this library. They are NOT passed to the compiler, you should duplicate them in the configuration options.   | List of strings | optional | [] |
 | <a id="cmake_external-deps"></a>deps |  Optional dependencies to be copied into the directory structure. Typically those directly required for the external building of the library/binaries. (i.e. those that the external buidl system will be looking for and paths to which are provided by the calling rule)   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="cmake_external-env_vars"></a>env_vars |  CMake environment variable values to join with toolchain-defined. For example, additional CXXFLAGS.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
@@ -132,9 +134,9 @@ Rule for building CMake. Invokes bootstrap script and make install.
 configure_make(<a href="#configure_make-name">name</a>, <a href="#configure_make-additional_inputs">additional_inputs</a>, <a href="#configure_make-additional_tools">additional_tools</a>, <a href="#configure_make-alwayslink">alwayslink</a>, <a href="#configure_make-autogen">autogen</a>, <a href="#configure_make-autogen_command">autogen_command</a>,
                <a href="#configure_make-autogen_env_vars">autogen_env_vars</a>, <a href="#configure_make-autogen_options">autogen_options</a>, <a href="#configure_make-autoreconf">autoreconf</a>, <a href="#configure_make-autoreconf_env_vars">autoreconf_env_vars</a>, <a href="#configure_make-autoreconf_options">autoreconf_options</a>,
                <a href="#configure_make-binaries">binaries</a>, <a href="#configure_make-configure_command">configure_command</a>, <a href="#configure_make-configure_env_vars">configure_env_vars</a>, <a href="#configure_make-configure_in_place">configure_in_place</a>, <a href="#configure_make-configure_options">configure_options</a>,
-               <a href="#configure_make-defines">defines</a>, <a href="#configure_make-deps">deps</a>, <a href="#configure_make-headers_only">headers_only</a>, <a href="#configure_make-install_prefix">install_prefix</a>, <a href="#configure_make-interface_libraries">interface_libraries</a>, <a href="#configure_make-lib_name">lib_name</a>, <a href="#configure_make-lib_source">lib_source</a>,
-               <a href="#configure_make-linkopts">linkopts</a>, <a href="#configure_make-make_commands">make_commands</a>, <a href="#configure_make-out_bin_dir">out_bin_dir</a>, <a href="#configure_make-out_include_dir">out_include_dir</a>, <a href="#configure_make-out_lib_dir">out_lib_dir</a>, <a href="#configure_make-postfix_script">postfix_script</a>,
-               <a href="#configure_make-shared_libraries">shared_libraries</a>, <a href="#configure_make-static_libraries">static_libraries</a>, <a href="#configure_make-tools_deps">tools_deps</a>)
+               <a href="#configure_make-data">data</a>, <a href="#configure_make-defines">defines</a>, <a href="#configure_make-deps">deps</a>, <a href="#configure_make-headers_only">headers_only</a>, <a href="#configure_make-install_prefix">install_prefix</a>, <a href="#configure_make-interface_libraries">interface_libraries</a>, <a href="#configure_make-lib_name">lib_name</a>,
+               <a href="#configure_make-lib_source">lib_source</a>, <a href="#configure_make-linkopts">linkopts</a>, <a href="#configure_make-make_commands">make_commands</a>, <a href="#configure_make-out_bin_dir">out_bin_dir</a>, <a href="#configure_make-out_include_dir">out_include_dir</a>, <a href="#configure_make-out_lib_dir">out_lib_dir</a>,
+               <a href="#configure_make-postfix_script">postfix_script</a>, <a href="#configure_make-shared_libraries">shared_libraries</a>, <a href="#configure_make-static_libraries">static_libraries</a>, <a href="#configure_make-tools_deps">tools_deps</a>)
 </pre>
 
 Rule for building external libraries with configure-make pattern. Some 'configure' script is invoked with --prefix=install (by default), and other parameters for compilation and linking, taken from Bazel C/C++ toolchain and passed dependencies. After configuration, GNU Make is called.
@@ -160,6 +162,7 @@ Rule for building external libraries with configure-make pattern. Some 'configur
 | <a id="configure_make-configure_env_vars"></a>configure_env_vars |  Environment variables to be set for the 'configure' invocation.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="configure_make-configure_in_place"></a>configure_in_place |  Set to True if 'configure' should be invoked in place, i.e. from its enclosing directory.   | Boolean | optional | False |
 | <a id="configure_make-configure_options"></a>configure_options |  Any options to be put on the 'configure' command line.   | List of strings | optional | [] |
+| <a id="configure_make-data"></a>data |  Files needed by this rule at runtime. May list file or rule targets. Generally allows any target.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="configure_make-defines"></a>defines |  Optional compilation definitions to be passed to the dependencies of this library. They are NOT passed to the compiler, you should duplicate them in the configuration options.   | List of strings | optional | [] |
 | <a id="configure_make-deps"></a>deps |  Optional dependencies to be copied into the directory structure. Typically those directly required for the external building of the library/binaries. (i.e. those that the external buidl system will be looking for and paths to which are provided by the calling rule)   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="configure_make-headers_only"></a>headers_only |  Flag variable to indicate that the library produces only headers   | Boolean | optional | False |
@@ -183,10 +186,10 @@ Rule for building external libraries with configure-make pattern. Some 'configur
 ## make
 
 <pre>
-make(<a href="#make-name">name</a>, <a href="#make-additional_inputs">additional_inputs</a>, <a href="#make-additional_tools">additional_tools</a>, <a href="#make-alwayslink">alwayslink</a>, <a href="#make-binaries">binaries</a>, <a href="#make-defines">defines</a>, <a href="#make-deps">deps</a>, <a href="#make-headers_only">headers_only</a>,
-     <a href="#make-interface_libraries">interface_libraries</a>, <a href="#make-keep_going">keep_going</a>, <a href="#make-lib_name">lib_name</a>, <a href="#make-lib_source">lib_source</a>, <a href="#make-linkopts">linkopts</a>, <a href="#make-make_commands">make_commands</a>, <a href="#make-make_env_vars">make_env_vars</a>,
-     <a href="#make-out_bin_dir">out_bin_dir</a>, <a href="#make-out_include_dir">out_include_dir</a>, <a href="#make-out_lib_dir">out_lib_dir</a>, <a href="#make-postfix_script">postfix_script</a>, <a href="#make-prefix">prefix</a>, <a href="#make-shared_libraries">shared_libraries</a>,
-     <a href="#make-static_libraries">static_libraries</a>, <a href="#make-tools_deps">tools_deps</a>)
+make(<a href="#make-name">name</a>, <a href="#make-additional_inputs">additional_inputs</a>, <a href="#make-additional_tools">additional_tools</a>, <a href="#make-alwayslink">alwayslink</a>, <a href="#make-binaries">binaries</a>, <a href="#make-data">data</a>, <a href="#make-defines">defines</a>, <a href="#make-deps">deps</a>,
+     <a href="#make-headers_only">headers_only</a>, <a href="#make-interface_libraries">interface_libraries</a>, <a href="#make-keep_going">keep_going</a>, <a href="#make-lib_name">lib_name</a>, <a href="#make-lib_source">lib_source</a>, <a href="#make-linkopts">linkopts</a>, <a href="#make-make_commands">make_commands</a>,
+     <a href="#make-make_env_vars">make_env_vars</a>, <a href="#make-out_bin_dir">out_bin_dir</a>, <a href="#make-out_include_dir">out_include_dir</a>, <a href="#make-out_lib_dir">out_lib_dir</a>, <a href="#make-postfix_script">postfix_script</a>, <a href="#make-prefix">prefix</a>,
+     <a href="#make-shared_libraries">shared_libraries</a>, <a href="#make-static_libraries">static_libraries</a>, <a href="#make-tools_deps">tools_deps</a>)
 </pre>
 
 Rule for building external libraries with GNU Make. GNU Make commands (make and make install by default) are invoked with prefix="install" (by default), and other environment variables for compilation and linking, taken from Bazel C/C++ toolchain and passed dependencies.
@@ -201,6 +204,7 @@ Rule for building external libraries with GNU Make. GNU Make commands (make and 
 | <a id="make-additional_tools"></a>additional_tools |  Optional additional tools needed for the building. Not used by the shell script part in cc_external_rule_impl.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="make-alwayslink"></a>alwayslink |  Optional. if true, link all the object files from the static library, even if they are not used.   | Boolean | optional | False |
 | <a id="make-binaries"></a>binaries |  Optional names of the resulting binaries.   | List of strings | optional | [] |
+| <a id="make-data"></a>data |  Files needed by this rule at runtime. May list file or rule targets. Generally allows any target.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="make-defines"></a>defines |  Optional compilation definitions to be passed to the dependencies of this library. They are NOT passed to the compiler, you should duplicate them in the configuration options.   | List of strings | optional | [] |
 | <a id="make-deps"></a>deps |  Optional dependencies to be copied into the directory structure. Typically those directly required for the external building of the library/binaries. (i.e. those that the external buidl system will be looking for and paths to which are provided by the calling rule)   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="make-headers_only"></a>headers_only |  Flag variable to indicate that the library produces only headers   | Boolean | optional | False |
@@ -237,7 +241,7 @@ Rule for building Make. Invokes configure script and make install.
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="make_tool-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| <a id="make_tool-make_srcs"></a>make_srcs |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| <a id="make_tool-make_srcs"></a>make_srcs |  target with the Make sources   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 
 
 <a id="#native_tool_toolchain"></a>

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -19,6 +19,7 @@ tests = [
     "@rules_foreign_cc//test:shell_script_inner_fun_test",
     "@rules_foreign_cc//test:shell_method_symlink_contents_to_dir_test",
     "//cc_configure_make:libevent_echosrv1",
+    "//cmake_with_data:data_attr_tests",
 ]
 
 test_suite(

--- a/examples/cmake_with_data/BUILD
+++ b/examples/cmake_with_data/BUILD
@@ -1,0 +1,64 @@
+load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+
+cmake_external(
+    name = "cmake_with_data",
+    cache_entries = select({
+        "@bazel_tools//src/conditions:windows": {
+            "CMAKE_BUILD_TYPE": "Release",
+            "CMAKE_CXX_FLAGS": "$CMAKE_CXX_FLAGS /MD",
+            "CMAKE_CXX_FLAGS_DEBUG": "$CMAKE_CXX_FLAGS_DEBUG /MD",
+        },
+        "//conditions:default": {},
+    }),
+    cmake_options = select({
+        "@bazel_tools//src/conditions:windows": ["-G \"Visual Studio 15 2017\" -A x64"],
+        "//conditions:default": [],
+    }),
+    data = [
+        "cmake_with_data.txt",
+        "//cmake_with_data/lib_b",
+    ],
+    generate_crosstool_file = select({
+        "@bazel_tools//src/conditions:windows": True,
+        "//conditions:default": False,
+    }),
+    lib_source = "//cmake_with_data/lib_a:srcs",
+    make_commands = select({
+        "@bazel_tools//src/conditions:windows": ["MSBuild.exe INSTALL.vcxproj"],
+        "//conditions:default": ["make", "make install"],
+    }),
+    static_libraries = select({
+        "@bazel_tools//src/conditions:windows": ["lib_a.lib"],
+        "//conditions:default": ["lib_a.a"],
+    }),
+)
+
+# Demonstrates that files can be made available at runtime
+cc_test(
+    name = "test_with_data",
+    srcs = [
+        "tests/test_cmake_with_data.cpp",
+    ],
+    deps = [
+        ":cmake_with_data",
+    ],
+)
+
+# Demonstrates that target outputs can be made available at runtime
+cc_test(
+    name = "test_with_shared_lib",
+    srcs = [
+        "tests/test_cmake_with_shared_lib.cpp",
+    ],
+    deps = [
+        ":cmake_with_data",
+    ],
+)
+
+test_suite(
+    name = "data_attr_tests",
+    tests = [
+        ":test_with_data",
+        ":test_with_shared_lib",
+    ],
+)

--- a/examples/cmake_with_data/cmake_with_data.txt
+++ b/examples/cmake_with_data/cmake_with_data.txt
@@ -1,0 +1,1 @@
+Hallo welt!

--- a/examples/cmake_with_data/lib_a/BUILD
+++ b/examples/cmake_with_data/lib_a/BUILD
@@ -1,0 +1,5 @@
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)

--- a/examples/cmake_with_data/lib_a/CMakeLists.txt
+++ b/examples/cmake_with_data/lib_a/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.5.1)
+
+project(cmake_with_data_example)
+
+add_subdirectory(src)

--- a/examples/cmake_with_data/lib_a/src/CMakeLists.txt
+++ b/examples/cmake_with_data/lib_a/src/CMakeLists.txt
@@ -1,0 +1,12 @@
+set(LIB_SRC lib_a.cpp lib_a.h)
+
+add_library(lib_a_static STATIC ${LIB_SRC})
+
+set_target_properties(lib_a_static PROPERTIES OUTPUT_NAME "lib_a")
+set_target_properties(lib_a_static PROPERTIES ARCHIVE_OUTPUT_NAME "lib_a")
+set_target_properties(lib_a_static PROPERTIES PREFIX "")
+
+set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
+
+install(TARGETS lib_a_static ARCHIVE DESTINATION lib)
+install(FILES lib_a.h DESTINATION include)

--- a/examples/cmake_with_data/lib_a/src/lib_a.cpp
+++ b/examples/cmake_with_data/lib_a/src/lib_a.cpp
@@ -1,0 +1,25 @@
+#include "lib_a.h"
+
+#include <cassert>
+#include <fstream>
+#include <iostream>
+
+std::string hello_data(std::string path)
+{
+    // Open the file
+    std::ifstream data_file(path.c_str());
+    if (!data_file.good())
+    {
+        throw std::runtime_error("Could not open: " + path);
+    }
+
+    // Read it's contents to a string
+    std::string data_str(
+        (std::istreambuf_iterator<char>(data_file)),
+        (std::istreambuf_iterator<char>()));
+
+    // Close the file
+    data_file.close();
+
+    return data_str;
+}

--- a/examples/cmake_with_data/lib_a/src/lib_a.h
+++ b/examples/cmake_with_data/lib_a/src/lib_a.h
@@ -1,0 +1,8 @@
+#ifndef LIB_H_
+#define LIB_H_
+
+#include <string>
+
+std::string hello_data(std::string path);
+
+#endif

--- a/examples/cmake_with_data/lib_b/BUILD
+++ b/examples/cmake_with_data/lib_b/BUILD
@@ -1,0 +1,7 @@
+cc_library(
+    name = "lib_b",
+    srcs = ["src/lib_b.cpp"],
+    hdrs = ["src/lib_b.h"],
+    linkstatic = False,
+    visibility = ["//cmake_with_data:__pkg__"],
+)

--- a/examples/cmake_with_data/lib_b/src/lib_b.cpp
+++ b/examples/cmake_with_data/lib_b/src/lib_b.cpp
@@ -1,0 +1,6 @@
+#include "lib_b.h"
+
+std::string hello_data(std::string path)
+{
+    return std::string("Hello world!");
+}

--- a/examples/cmake_with_data/lib_b/src/lib_b.h
+++ b/examples/cmake_with_data/lib_b/src/lib_b.h
@@ -1,0 +1,8 @@
+#ifndef LIB_B_H_
+#define LIB_B_H_
+
+#include <string>
+
+std::string hello_world();
+
+#endif

--- a/examples/cmake_with_data/tests/test_cmake_with_data.cpp
+++ b/examples/cmake_with_data/tests/test_cmake_with_data.cpp
@@ -1,0 +1,18 @@
+#include "lib_a.h"
+
+#include <iostream>
+#include <string>
+
+int main(int argc, char* argv[])
+{
+#ifdef _WIN32
+    std::string result = hello_data(".\\cmake_with_data\\cmake_with_data.txt");
+#else
+    std::string result = hello_data("./cmake_with_data/cmake_with_data.txt");
+#endif
+    if (result != "Hallo welt!")
+    {
+        throw std::runtime_error("Wrong result: " + result);
+    }
+    std::cout << "Everything's fine!";
+}

--- a/examples/cmake_with_data/tests/test_cmake_with_shared_lib.cpp
+++ b/examples/cmake_with_data/tests/test_cmake_with_shared_lib.cpp
@@ -1,0 +1,25 @@
+#include <fstream>
+#include <iostream>
+#include <string>
+
+void test_opening_file(std::string path)
+{
+    std::ifstream data_file(path);
+    if (!data_file.good())
+    {
+        throw std::runtime_error("Could not open file: " + path);
+    }
+
+    data_file.close();
+}
+
+int main(int argc, char* argv[])
+{
+    // Make sure the expectd shared library is available
+#ifdef _WIN32
+    test_opening_file(".\\cmake_with_data\\lib_b\\lib_b.lib");
+#else
+    test_opening_file("./cmake_with_data/lib_b/liblib_b.so");
+#endif
+    std::cout << "Everything's fine!";
+}

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -386,7 +386,7 @@ def cc_external_rule_impl(ctx, attrs):
     return [
         DefaultInfo(
             files = depset(direct = rule_outputs + wrapped_files),
-            runfiles = ctx.runfiles(attrs.data),
+            runfiles = ctx.runfiles(ctx.files.data),
         ),
         OutputGroupInfo(**output_groups),
         ForeignCcDeps(artifacts = depset(

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -95,6 +95,12 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
         allow_files = True,
         default = [],
     ),
+    "data": attr.label_list(
+        doc = "Files needed by this rule at runtime. May list file or rule targets. Generally allows any target.",
+        mandatory = False,
+        allow_files = True,
+        default = [],
+    ),
     "tools_deps": attr.label_list(
         doc = (
             "Optional tools to be copied into the directory structure. " +
@@ -353,7 +359,7 @@ def cc_external_rule_impl(ctx, attrs):
             empty.file,
             wrapped_outputs.log_file,
         ],
-        tools = [wrapped_outputs.script_file],
+        tools = depset([wrapped_outputs.script_file] + ctx.files.data),
         # We should take the default PATH passed by Bazel, not that from cc_toolchain
         # for Windows, because the PATH under msys2 is different and that is which we need
         # for shell commands
@@ -378,7 +384,10 @@ def cc_external_rule_impl(ctx, attrs):
     ]
     output_groups[attrs.configure_name + "_logs"] = wrapped_files
     return [
-        DefaultInfo(files = depset(direct = rule_outputs + wrapped_files)),
+        DefaultInfo(
+            files = depset(direct = rule_outputs + wrapped_files),
+            runfiles = ctx.runfiles(attrs.data),
+        ),
         OutputGroupInfo(**output_groups),
         ForeignCcDeps(artifacts = depset(
             [externally_built],


### PR DESCRIPTION
This adds a [`data`](https://docs.bazel.build/versions/master/be/common-definitions.html#typical-attributes) attribute to rules rules built on `framework.bzl` (`boost_build`, `cmake_external`, `configure_make`, and `make`).

Examples have been added to `@rules_foreign_cc_tests//cmake_with_data/...`

Note, the `@rules_foreign_cc_tests//cmake_with_data:test_with_data` examples will not pass without [--enable_runfiles](https://docs.bazel.build/versions/master/command-line-reference.html#flag--enable_runfiles) enabled. This will need to be explicitly set on windows machines