### PR TITLE
Updated uses of `@bazel_tools//src/conditions` to `@platforms//`

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -88,7 +88,7 @@ sh_test(
 toolchain(
     name = "built_ninja_toolchain_osx",
     exec_compatible_with = [
-        "@platforms//os:osx",
+        "@platforms//os:macos",
         "@platforms//cpu:x86_64",
     ],
     toolchain = "@rules_foreign_cc//tools/build_defs/native_tools:built_ninja",

--- a/examples/cmake_crosstool/static/BUILD
+++ b/examples/cmake_crosstool/static/BUILD
@@ -65,7 +65,7 @@ cc_binary(
     # includes just hello.h, include directory: "include/version123"
     srcs = ["hello_client.c"],
     deps = select({
-        "@bazel_tools//src/conditions:windows": [":libhello_win"],
+        "@platforms//os:windows": [":libhello_win"],
         "//conditions:default": [":libhello"],
     }),
 )
@@ -75,7 +75,7 @@ cc_binary(
     # includes just hello.h, include directory: "include/version123"
     srcs = ["hello_client.c"],
     deps = select({
-        "@bazel_tools//src/conditions:windows": [":libhello_win_ninja"],
+        "@platforms//os:windows": [":libhello_win_ninja"],
         "//conditions:default": [":libhello"],
     }),
 )
@@ -85,7 +85,7 @@ cc_binary(
     # includes just hello.h, include directory: "include/version123"
     srcs = ["hello_client.c"],
     deps = select({
-        "@bazel_tools//src/conditions:windows": [":libhello_win_nmake"],
+        "@platforms//os:windows": [":libhello_win_nmake"],
         "//conditions:default": [":libhello"],
     }),
 )

--- a/examples/cmake_hello_world_lib/binary/BUILD
+++ b/examples/cmake_hello_world_lib/binary/BUILD
@@ -12,8 +12,8 @@ filegroup(
 cmake_external(
     name = "libhello",
     binaries = select({
-        "@bazel_tools//src/conditions:windows": ["hello.exe"],
-        "@bazel_tools//src/conditions:darwin": ["hello"],
+        "@platforms//os:windows": ["hello.exe"],
+        "@platforms//os:macos": ["hello"],
         "//conditions:default": ["hello"],
     }),
     # Probably this variable should be set by default.

--- a/examples/cmake_hello_world_lib/shared/BUILD
+++ b/examples/cmake_hello_world_lib/shared/BUILD
@@ -18,8 +18,8 @@ cmake_external(
     },
     lib_source = ":srcs",
     shared_libraries = select({
-        "@bazel_tools//src/conditions:windows": ["libhello.dll"],
-        "@bazel_tools//src/conditions:darwin": ["libhello.dylib"],
+        "@platforms//os:windows": ["libhello.dll"],
+        "@platforms//os:macos": ["libhello.dylib"],
         "//conditions:default": ["libhello.so"],
     }),
 )

--- a/examples/cmake_hello_world_lib/static/BUILD
+++ b/examples/cmake_hello_world_lib/static/BUILD
@@ -61,7 +61,7 @@ cc_binary(
     # includes just hello.h, include directory: "include/version123"
     srcs = ["hello_client.c"],
     deps = select({
-        "@bazel_tools//src/conditions:windows": [":libhello_win"],
+        "@platforms//os:windows": [":libhello_win"],
         "//conditions:default": [":libhello"],
     }),
 )
@@ -71,7 +71,7 @@ cc_binary(
     # includes just hello.h, include directory: "include/version123"
     srcs = ["hello_client.c"],
     deps = select({
-        "@bazel_tools//src/conditions:windows": [":libhello_win_ninja"],
+        "@platforms//os:windows": [":libhello_win_ninja"],
         "//conditions:default": [":libhello"],
     }),
 )
@@ -81,7 +81,7 @@ cc_binary(
     # includes just hello.h, include directory: "include/version123"
     srcs = ["hello_client.c"],
     deps = select({
-        "@bazel_tools//src/conditions:windows": [":libhello_win_nmake"],
+        "@platforms//os:windows": [":libhello_win_nmake"],
         "//conditions:default": [":libhello"],
     }),
 )

--- a/examples/cmake_hello_world_variant/BUILD
+++ b/examples/cmake_hello_world_variant/BUILD
@@ -1,10 +1,27 @@
 load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 
+# TODO: This should not be necessary but there appears to be some inconsistent
+# behavior with the use of `constraint_value`s in `select` statements. A support
+# thread was started at the end of https://github.com/bazelbuild/bazel/pull/12071
+# Once it is possible to replace `:windows` with `@platforms//os:windows` that
+# should be done for this file
+config_setting(
+    name = "windows",
+    constraint_values = ["@platforms//os:windows"],
+    visibility = ["//visibility:private"],
+)
+
+config_setting(
+    name = "macos",
+    constraint_values = ["@platforms//os:macos"],
+    visibility = ["//visibility:private"],
+)
+
 cmake_external(
     name = "hello_world",
     binaries = select({
-        "@bazel_tools//src/conditions:windows": ["CMakeHelloWorld.exe"],
-        "@bazel_tools//src/conditions:darwin": ["CMakeHelloWorld"],
+        ":windows": ["CMakeHelloWorld.exe"],
+        ":macos": ["CMakeHelloWorld"],
         "//conditions:default": ["CMakeHelloWorld"],
     }),
     cmake_options = ["-GNinja"],
@@ -20,8 +37,8 @@ filegroup(
     name = "binary",
     srcs = [":hello_world"],
     output_group = select({
-        "@bazel_tools//src/conditions:windows": "CMakeHelloWorld.exe",
-        "@bazel_tools//src/conditions:darwin": "CMakeHelloWorld",
+        ":windows": "CMakeHelloWorld.exe",
+        ":macos": "CMakeHelloWorld",
         "//conditions:default": "CMakeHelloWorld",
     }),
 )

--- a/examples/cmake_synthetic/BUILD
+++ b/examples/cmake_synthetic/BUILD
@@ -2,7 +2,7 @@ load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 generate_crosstool = select({
-    "@bazel_tools//src/conditions:windows": True,
+    "@platforms//os:windows": True,
     "//conditions:default": False,
 })
 

--- a/examples/configure_gnuplot/BUILD
+++ b/examples/configure_gnuplot/BUILD
@@ -33,7 +33,7 @@ configure_make(
 )
 
 libgd_name = select({
-    "@bazel_tools//src/conditions:windows": ["libgd.lib"],
+    "@platforms//os:windows": ["libgd.lib"],
     "//conditions:default": ["libgd.a"],
 })
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -18,12 +18,12 @@ shell_script_helper_test_rule(
 )
 
 result_file = select({
-    "@bazel_tools//src/conditions:darwin": "expected/inner_fun_text_osx.txt",
+    "@platforms//os:macos": "expected/inner_fun_text_osx.txt",
     "//conditions:default": "expected/inner_fun_text.txt",
 })
 
 result_file_symlink_dirs = select({
-    "@bazel_tools//src/conditions:darwin": "expected/out_symlinked_dirs_osx.txt",
+    "@platforms//os:macos": "expected/out_symlinked_dirs_osx.txt",
     "//conditions:default": "expected/out_symlinked_dirs.txt",
 })
 

--- a/tools/build_defs/shell_toolchain/toolchains/toolchain_mappings.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/toolchain_mappings.bzl
@@ -22,7 +22,7 @@ TOOLCHAIN_MAPPINGS = [
     ),
     ToolchainMapping(
         exec_compatible_with = [
-            "@platforms//os:osx",
+            "@platforms//os:macos",
         ],
         file = "@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains/impl:osx_commands.bzl",
     ),


### PR DESCRIPTION
This is a follow up to https://github.com/bazelbuild/rules_foreign_cc/pull/427 