### PR TITLE
Moved example dependencies into loadable bzl files

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,18 +2,16 @@ workspace(name = "rules_foreign_cc")
 
 load("//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
 
-rules_foreign_cc_dependencies([
-    "@rules_foreign_cc_tests//:built_cmake_toolchain",
-    "@rules_foreign_cc_tests//:built_ninja_toolchain_osx",
-    "@rules_foreign_cc_tests//:built_ninja_toolchain_linux",
-])
+rules_foreign_cc_dependencies()
 
 local_repository(
     name = "rules_foreign_cc_tests",
     path = "examples",
 )
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@rules_foreign_cc_tests//deps:repositories.bzl", examples_repositories = "repositories")
+
+examples_repositories()
 
 android_sdk_repository(
     name = "androidsdk",
@@ -23,22 +21,10 @@ android_ndk_repository(
     name = "androidndk",
 )
 
-# TODO(jin): replace legacy gmaven_rules targets with `maven_install` from the new rules_jvm_external
-RULES_JVM_EXTERNAL_TAG = "1.0"
+load("@rules_foreign_cc_tests//deps:deps_jvm_external.bzl", examples_deps_jvm_external = "deps_jvm_external")
 
-RULES_JVM_EXTERNAL_SHA = "48e0f1aab74fabba98feb8825459ef08dcc75618d381dff63ec9d4dd9860deaa"
+examples_deps_jvm_external()
 
-http_archive(
-    name = "gmaven_rules",
-    sha256 = RULES_JVM_EXTERNAL_SHA,
-    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
-    url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
-)
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
-load("@gmaven_rules//:gmaven.bzl", "gmaven_rules")
-
-gmaven_rules()
-
-load("@rules_foreign_cc_tests//:examples_repositories.bzl", "include_examples_repositories")
-
-include_examples_repositories()
+bazel_skylib_workspace()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,13 +13,9 @@ load("@rules_foreign_cc_tests//deps:repositories.bzl", examples_repositories = "
 
 examples_repositories()
 
-android_sdk_repository(
-    name = "androidsdk",
-)
+load("@rules_foreign_cc_tests//deps:deps_android.bzl", examples_deps_android = "deps_android")
 
-android_ndk_repository(
-    name = "androidndk",
-)
+examples_deps_android()
 
 load("@rules_foreign_cc_tests//deps:deps_jvm_external.bzl", examples_deps_jvm_external = "deps_jvm_external")
 

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -20,13 +20,9 @@ load("//deps:repositories.bzl", "repositories")
 
 repositories()
 
-android_sdk_repository(
-    name = "androidsdk",
-)
+load("//deps:deps_android.bzl", "deps_android")
 
-android_ndk_repository(
-    name = "androidndk",
-)
+deps_android()
 
 load("//deps:deps_jvm_external.bzl", "deps_jvm_external")
 

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -16,7 +16,9 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("//deps:repositories.bzl", "repositories")
+
+repositories()
 
 android_sdk_repository(
     name = "androidsdk",
@@ -26,31 +28,6 @@ android_ndk_repository(
     name = "androidndk",
 )
 
-RULES_JVM_EXTERNAL_TAG = "2.3"
+load("//deps:deps_jvm_external.bzl", "deps_jvm_external")
 
-RULES_JVM_EXTERNAL_SHA = "375b1592e3f4e0a46e6236e19fc30c8020c438803d4d49b13b40aaacd2703c30"
-
-http_archive(
-    name = "rules_jvm_external",
-    sha256 = RULES_JVM_EXTERNAL_SHA,
-    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
-    url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
-)
-
-load("@rules_jvm_external//:defs.bzl", "maven_install")
-
-maven_install(
-    artifacts = [
-        "com.android.support.constraint:constraint-layout:aar:1.1.2",
-        "com.android.support:appcompat-v7:aar:26.1.0",
-    ],
-    repositories = [
-        "https://jcenter.bintray.com/",
-        "https://maven.google.com",
-        "https://repo1.maven.org/maven2",
-    ],
-)
-
-load(":examples_repositories.bzl", "include_examples_repositories")
-
-include_examples_repositories()
+deps_jvm_external()

--- a/examples/cc_configure_make/BUILD
+++ b/examples/cc_configure_make/BUILD
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
 load("@rules_foreign_cc//tools/build_defs:configure.bzl", "configure_make")
 
 configure_make(

--- a/examples/cmake/BUILD
+++ b/examples/cmake/BUILD
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary")
 load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 
 cmake_external(

--- a/examples/cmake_android/BUILD
+++ b/examples/cmake_android/BUILD
@@ -1,3 +1,4 @@
+load("@rules_android//android:rules.bzl", "android_binary", "android_library")
 load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 
 cmake_external(

--- a/examples/cmake_cares/BUILD
+++ b/examples/cmake_cares/BUILD
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
 load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 
 # This should NOT be used anymore. However, keeping it here to test backwards-compatibility.

--- a/examples/cmake_crosstool/BUILD
+++ b/examples/cmake_crosstool/BUILD
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 
 filegroup(

--- a/examples/cmake_crosstool/static/BUILD
+++ b/examples/cmake_crosstool/static/BUILD
@@ -1,6 +1,7 @@
 # example code is taken from https://github.com/Akagi201/learning-cmake/tree/master/hello-world-lib
 # for test only
 
+load("@rules_cc//cc:defs.bzl", "cc_binary")
 load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 
 filegroup(

--- a/examples/cmake_crosstool/tools/arm_compiler/BUILD
+++ b/examples/cmake_crosstool/tools/arm_compiler/BUILD
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_toolchain", "cc_toolchain_suite")
+
 # This is the entry point for --crosstool_top.  Toolchains are found
 # by lopping off the name of --crosstool_top and searching for
 # 'cc-compiler-${CPU}' in this BUILD file, where CPU is the target CPU

--- a/examples/cmake_hello_world_lib/shared/BUILD
+++ b/examples/cmake_hello_world_lib/shared/BUILD
@@ -1,6 +1,7 @@
 # example code is taken from https://github.com/Akagi201/learning-cmake/tree/master/hello-world-lib
 # for test only
 
+load("@rules_cc//cc:defs.bzl", "cc_test")
 load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 
 filegroup(

--- a/examples/cmake_hello_world_lib/static/BUILD
+++ b/examples/cmake_hello_world_lib/static/BUILD
@@ -1,6 +1,7 @@
 # example code is taken from https://github.com/Akagi201/learning-cmake/tree/master/hello-world-lib
 # for test only
 
+load("@rules_cc//cc:defs.bzl", "cc_binary")
 load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 
 filegroup(

--- a/examples/cmake_nghttp2/BUILD
+++ b/examples/cmake_nghttp2/BUILD
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
 load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 
 cmake_external(

--- a/examples/cmake_synthetic/BUILD
+++ b/examples/cmake_synthetic/BUILD
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
 load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 

--- a/examples/cmake_synthetic/liba/BUILD
+++ b/examples/cmake_synthetic/liba/BUILD
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 filegroup(
     name = "a_srcs",
     srcs = glob(["**"]),

--- a/examples/cmake_synthetic/libb/BUILD
+++ b/examples/cmake_synthetic/libb/BUILD
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 filegroup(
     name = "b_srcs",
     srcs = glob(["**"]),

--- a/examples/cmake_with_bazel_transitive/BUILD
+++ b/examples/cmake_with_bazel_transitive/BUILD
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
 load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 
 # Example of the cmake_external target built with Bazel-built dependency

--- a/examples/cmake_working_dir/BUILD
+++ b/examples/cmake_working_dir/BUILD
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
 load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 
 filegroup(

--- a/examples/configure_gnuplot/BUILD
+++ b/examples/configure_gnuplot/BUILD
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
 load("@rules_foreign_cc//tools/build_defs:configure.bzl", "configure_make")
 load("@bazel_tools//tools/build_rules:test_rules.bzl", "file_test")
 

--- a/examples/configure_libunwind/BUILD
+++ b/examples/configure_libunwind/BUILD
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
 load("@rules_foreign_cc//tools/build_defs:configure.bzl", "configure_make")
 
 configure_make(

--- a/examples/configure_mpc/BUILD
+++ b/examples/configure_mpc/BUILD
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
 load("@rules_foreign_cc//tools/build_defs:configure.bzl", "configure_make")
 
 configure_make(

--- a/examples/configure_with_bazel_transitive/BUILD
+++ b/examples/configure_with_bazel_transitive/BUILD
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("@rules_foreign_cc//tools/build_defs:configure.bzl", "configure_make")
 
 cc_library(

--- a/examples/deps/deps_android.bzl
+++ b/examples/deps/deps_android.bzl
@@ -1,0 +1,12 @@
+"""A module for bringing in transitive dependencies of rules_android"""
+
+load("@rules_android//android:rules.bzl", "android_ndk_repository", "android_sdk_repository")
+
+def deps_android():
+    android_sdk_repository(
+        name = "androidsdk",
+    )
+
+    android_ndk_repository(
+        name = "androidndk",
+    )

--- a/examples/deps/deps_jvm_external.bzl
+++ b/examples/deps/deps_jvm_external.bzl
@@ -1,0 +1,16 @@
+"""A module for bringing in transitive dependencies of rules_jvm_external"""
+
+load("@rules_jvm_external//:defs.bzl", "maven_install")
+
+def deps_jvm_external():
+    maven_install(
+        artifacts = [
+            "com.android.support.constraint:constraint-layout:aar:1.1.2",
+            "com.android.support:appcompat-v7:aar:26.1.0",
+        ],
+        repositories = [
+            "https://jcenter.bintray.com/",
+            "https://maven.google.com",
+            "https://repo1.maven.org/maven2",
+        ],
+    )

--- a/examples/deps/repositories.bzl
+++ b/examples/deps/repositories.bzl
@@ -7,6 +7,14 @@ def repositories():
     """Load all repositories needed for the targets of rules_foreign_cc_tests"""
 
     http_archive(
+        name = "rules_cc",
+        strip_prefix = "rules_cc-b1c40e1de81913a3c40e5948f78719c28152486d",
+        url = "https://github.com/bazelbuild/rules_cc/archive/b1c40e1de81913a3c40e5948f78719c28152486d.zip",
+        sha256 = "d0c573b94a6ef20ef6ff20154a23d0efcb409fb0e1ff0979cec318dfe42f0cdd",
+        type = "zip",
+    )
+
+    http_archive(
         name = "rules_android",
         urls = ["https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"],
         sha256 = "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",

--- a/examples/deps/repositories.bzl
+++ b/examples/deps/repositories.bzl
@@ -1,8 +1,21 @@
+# buildifier: disable=module-docstring
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 all_content = """filegroup(name = "all", srcs = glob(["**"]), visibility = ["//visibility:public"])"""
 
-def include_examples_repositories():
+def repositories():
+    """Load all repositories needed for the targets of rules_foreign_cc_tests"""
+
+    RULES_JVM_EXTERNAL_TAG = "4.0"
+    RULES_JVM_EXTERNAL_SHA = "31701ad93dbfe544d597dbe62c9a1fdd76d81d8a9150c2bf1ecf928ecdf97169"
+
+    http_archive(
+        name = "rules_jvm_external",
+        strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
+        sha256 = RULES_JVM_EXTERNAL_SHA,
+        url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
+    )
+
     http_archive(
         name = "libevent",
         build_file_content = all_content,
@@ -11,6 +24,7 @@ def include_examples_repositories():
             "https://mirror.bazel.build/github.com/libevent/libevent/releases/download/release-2.1.8-stable/libevent-2.1.8-stable.tar.gz",
             "https://github.com/libevent/libevent/releases/download/release-2.1.8-stable/libevent-2.1.8-stable.tar.gz",
         ],
+        sha256 = "965cc5a8bb46ce4199a47e9b2c9e1cae3b137e8356ffdad6d94d3b9069b71dc2",
     )
 
     http_archive(
@@ -65,6 +79,7 @@ def include_examples_repositories():
             "https://mirror.bazel.build/github.com/pybind/pybind11/archive/v2.2.3.tar.gz",
             "https://github.com/pybind/pybind11/archive/v2.2.3.tar.gz",
         ],
+        sha256 = "3a3b7b651afab1c5ba557f4c37d785a522b8030dfc765da26adc2ecd1de940ea",
     )
 
     http_archive(
@@ -89,6 +104,7 @@ def include_examples_repositories():
             "https://mirror.bazel.build/github.com/nghttp2/nghttp2/archive/e5b3f9addd49bca27e2f99c5c65a564eb5c0cf6d.tar.gz",
             "https://github.com/nghttp2/nghttp2/archive/e5b3f9addd49bca27e2f99c5c65a564eb5c0cf6d.tar.gz",
         ],
+        sha256 = "d3012f33384f6ff980ebbe75efcb6fc5402dca5f82f092d21200b3b12425d3f5",
     )
 
     http_archive(
@@ -99,6 +115,7 @@ def include_examples_repositories():
             "https://mirror.bazel.build/github.com/eigenteam/eigen-git-mirror/archive/3.3.5.tar.gz",
             "https://github.com/eigenteam/eigen-git-mirror/archive/3.3.5.tar.gz",
         ],
+        sha256 = "992855522dfdd0dea74d903dcd082cdb01c1ae72be5145e2fe646a0892989e43",
     )
 
     http_archive(
@@ -109,6 +126,7 @@ def include_examples_repositories():
             "https://mirror.bazel.build/github.com/xianyi/OpenBLAS/archive/v0.3.2.tar.gz",
             "https://github.com/xianyi/OpenBLAS/archive/v0.3.2.tar.gz",
         ],
+        sha256 = "e8ba64f6b103c511ae13736100347deb7121ba9b41ba82052b1a018a65c0cb15",
     )
 
     http_archive(
@@ -119,6 +137,7 @@ def include_examples_repositories():
             "https://mirror.bazel.build/github.com/mariusmuja/flann/archive/1.9.1.tar.gz",
             "https://github.com/mariusmuja/flann/archive/1.9.1.tar.gz",
         ],
+        sha256 = "b23b5f4e71139faa3bcb39e6bbcc76967fbaf308c4ee9d4f5bfbeceaa76cc5d3",
     )
 
     http_archive(
@@ -129,6 +148,7 @@ def include_examples_repositories():
             "https://mirror.bazel.build/github.com/PointCloudLibrary/pcl/archive/pcl-1.8.1.tar.gz",
             "https://github.com/PointCloudLibrary/pcl/archive/pcl-1.8.1.tar.gz",
         ],
+        sha256 = "5a102a2fbe2ba77c775bf92c4a5d2e3d8170be53a68c3a76cfc72434ff7b9783",
     )
 
     http_archive(
@@ -150,6 +170,7 @@ def include_examples_repositories():
             "https://mirror.bazel.build/ftp.gnu.org/gnu/bison/bison-3.3.tar.gz",
             "http://ftp.gnu.org/gnu/bison/bison-3.3.tar.gz",
         ],
+        sha256 = "fdeafb7fffade05604a61e66b8c040af4b2b5cbb1021dcfe498ed657ac970efd",
     )
 
     http_archive(
@@ -160,6 +181,7 @@ def include_examples_repositories():
             "https://mirror.bazel.build/www-us.apache.org/dist/httpd/httpd-2.4.39.tar.gz",
             "https://www-us.apache.org/dist/httpd/httpd-2.4.39.tar.gz",
         ],
+        sha256 = "8b95fe249f3a6c50aad3ca125eef3e02d619116cde242e1bc3c266b7b5c37c30",
     )
 
     http_archive(
@@ -170,6 +192,7 @@ def include_examples_repositories():
             "https://mirror.bazel.build/ftp.pcre.org/pub/pcre/pcre-8.43.tar.gz",
             "https://ftp.pcre.org/pub/pcre/pcre-8.43.tar.gz",
         ],
+        sha256 = "0b8e7465dc5e98c757cc3650a20a7843ee4c3edf50aaf60bb33fd879690d2c73",
     )
 
     http_archive(
@@ -180,6 +203,7 @@ def include_examples_repositories():
             "https://mirror.bazel.build/www-eu.apache.org/dist//apr/apr-1.6.5.tar.gz",
             "https://www-eu.apache.org/dist//apr/apr-1.6.5.tar.gz",
         ],
+        sha256 = "70dcf9102066a2ff2ffc47e93c289c8e54c95d8dda23b503f9e61bb0cbd2d105",
     )
 
     http_archive(

--- a/examples/deps/repositories.bzl
+++ b/examples/deps/repositories.bzl
@@ -6,6 +6,13 @@ all_content = """filegroup(name = "all", srcs = glob(["**"]), visibility = ["//v
 def repositories():
     """Load all repositories needed for the targets of rules_foreign_cc_tests"""
 
+    http_archive(
+        name = "rules_android",
+        urls = ["https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"],
+        sha256 = "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
+        strip_prefix = "rules_android-0.1.1",
+    )
+
     RULES_JVM_EXTERNAL_TAG = "4.0"
     RULES_JVM_EXTERNAL_SHA = "31701ad93dbfe544d597dbe62c9a1fdd76d81d8a9150c2bf1ecf928ecdf97169"
 

--- a/examples/simple_make/BUILD
+++ b/examples/simple_make/BUILD
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
 load("@rules_foreign_cc//tools/build_defs:make.bzl", "make")
 
 make(

--- a/examples/use_malloc/BUILD
+++ b/examples/use_malloc/BUILD
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
 load("@rules_foreign_cc//tools/build_defs:configure.bzl", "configure_make")
 
 configure_make(

--- a/tools/build_defs/cmake.bzl
+++ b/tools/build_defs/cmake.bzl
@@ -18,7 +18,6 @@ load(
     "is_debug_mode",
 )
 load(":cmake_script.bzl", "create_cmake_script")
-load("//tools/build_defs/shell_toolchain/toolchains:access.bzl", "create_context")
 load(
     "//tools/build_defs/native_tools:tool_access.bzl",
     "get_cmake_data",


### PR DESCRIPTION
This should prevent the dependencies in the root workspace from becoming outdated (which they were).

This also adds `rules_cc` and `rules_android` repositories to the examples. Buildifier will now no longer alter files with the `-lint=fix` mode enabled but the repo is still not Buildifier compliant.