### PR TITLE
Add tests for checking the minimum supported version to CI

### DIFF
--- a/.bazelci/config.yaml
+++ b/.bazelci/config.yaml
@@ -55,13 +55,13 @@ tasks:
       - "//:win_tests"
   ubuntu2004_flags:
     name: Flags
-    platform: ubuntu1804
+    platform: ubuntu2004
     working_directory: test/standard_cxx_flags_test
     test_targets:
       - "//:flags_test"
   ubuntu1804_flags:
     name: Flags
-    platform: ubuntu1604
+    platform: ubuntu1804
     working_directory: test/standard_cxx_flags_test
     test_targets:
       - "//:flags_test"
@@ -79,13 +79,13 @@ tasks:
       - "//:flags_test"
   ubuntu2004_detect_root:
     name: Detect root
-    platform: ubuntu1804
+    platform: ubuntu2004
     working_directory: test/detect_root_test
     test_targets:
       - "//:tests"
   ubuntu1804_detect_root:
     name: Detect root
-    platform: ubuntu1604
+    platform: ubuntu1804
     working_directory: test/detect_root_test
     test_targets:
       - "//:tests"

--- a/.bazelci/config.yaml
+++ b/.bazelci/config.yaml
@@ -1,69 +1,102 @@
 ---
 tasks:
-  ubuntu1804:
+  ubuntu2004:
+    platform: ubuntu2004
+    build_targets:
+      - "//..."
+    test_targets:
+      - "//..."
+  macos:
+    platform: macos
+    build_targets:
+      - "//..."
+    test_targets:
+      - "//..."
+  windows:
+    platform: windows
+    build_targets:
+      - "//..."
+    test_targets:
+      - "//..."
+      # TODO: TODO make issue
+      - "-//test:shell_method_symlink_contents_to_dir_test"
+      - "-//test:shell_script_inner_fun_test"
+  ubuntu2004_examples:
+    name: Examples
+    platform: ubuntu2004
+    working_directory: examples
+    build_targets:
+      - "//cmake_android:app"
+    test_targets:
+    - "//:tests"
+  ubuntu1804_examples:
+    name: Examples
     platform: ubuntu1804
     working_directory: examples
     build_targets:
       - "//cmake_android:app"
     test_targets:
-      - "//:tests"
-  ubuntu1604:
-    platform: ubuntu1604
-    working_directory: examples
-    build_targets:
-      - "//cmake_android:app"
-    test_targets:
       - "//:tests_no_synthetic"
-  macos:
+  macos_examples:
+    name: Examples
     platform: macos
     working_directory: examples
     build_targets:
       - "//cmake_android:app"
     test_targets:
       - "//:mac_tests"
-  windows:
+  windows_examples:
+    name: Examples
     platform: windows
     working_directory: examples
     test_flags:
       - "--enable_runfiles"
     test_targets:
       - "//:win_tests"
-  ubuntu1804_flags:
+  ubuntu2004_flags:
+    name: Flags
     platform: ubuntu1804
     working_directory: test/standard_cxx_flags_test
     test_targets:
       - "//:flags_test"
-  ubuntu1604_flags:
+  ubuntu1804_flags:
+    name: Flags
     platform: ubuntu1604
     working_directory: test/standard_cxx_flags_test
     test_targets:
       - "//:flags_test"
   macos_flags:
+    name: Flags
     platform: macos
     working_directory: test/standard_cxx_flags_test
     test_targets:
       - "//:flags_test"
   windows_flags:
+    name: Flags
     platform: windows
     working_directory: test/standard_cxx_flags_test
     test_targets:
       - "//:flags_test"
-  ubuntu1804_detect_root:
+  ubuntu2004_detect_root:
+    name: Detect root
     platform: ubuntu1804
     working_directory: test/detect_root_test
     test_targets:
       - "//:tests"
-  ubuntu1604_detect_root:
+  ubuntu1804_detect_root:
+    name: Detect root
     platform: ubuntu1604
     working_directory: test/detect_root_test
     test_targets:
       - "//:tests"
   macos_detect_root:
+    name: Detect root
     platform: macos
     working_directory: test/detect_root_test
     test_targets:
       - "//:tests"
   windows_detect_root:
+    name: Detect root
     platform: windows
     working_directory: test/detect_root_test
     test_targets:
@@ -74,3 +107,20 @@ tasks:
     working_directory: docs
     build_targets:
     - //...
+  min_supported_version:
+    name: "Minimum Supported Version"
+    bazel: "3.4.0"
+    platform: ubuntu1604
+    build_targets:
+      - "//..."
+    test_targets:
+      - "//..."
+  min_supported_version_examples:
+    name: "Minimum Supported Version Examples"
+    bazel: "3.4.0"
+    platform: ubuntu1604
+    working_directory: examples
+    build_targets:
+      - "//cmake_android:app"
+    test_targets:
+      - "//:tests_no_synthetic"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ Documentation for all rules and providers are available [here](./docs/README.md)
 
 ## Bazel versions compatibility
 
-Works with Bazel after 3.0.0 without any flags.
+Works with Bazel after 3.4.0 without any flags.
+
+Note that the rules may be compatible with older versions of Bazel but support may break
+in future changes as these older versions are not tested.
 
 ## News
 

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -13,11 +13,6 @@ tests = [
     # from out workspace or same workspace
     # Uncomment after nested workspaces are supported on CI
     #    "//built_ninja:test_ninja_version",
-    "@rules_foreign_cc//test:cmake_script_test_suite",
-    "@rules_foreign_cc//test:shell_script_conversion_suite",
-    "@rules_foreign_cc//test:utils_test_suite",
-    "@rules_foreign_cc//test:shell_script_inner_fun_test",
-    "@rules_foreign_cc//test:shell_method_symlink_contents_to_dir_test",
     "//cc_configure_make:libevent_echosrv1",
     "//cmake_with_data:data_attr_tests",
 ]

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -1,6 +1,24 @@
 load("@foreign_cc_platform_utils//:bazel_version.bzl", "BAZEL_VERSION")
 load(":select_windows_tests.bzl", "select_windows_tests")
 
+# TODO: This should not be necessary but there appears to be some inconsistent
+# behavior with the use of `constraint_value`s in `select` statements. A support
+# thread was started at the end of https://github.com/bazelbuild/bazel/pull/12071
+# Once it is possible to replace `:windows` with `@platforms//os:windows` that
+# should be done for this file. Note actioning on this will set the minimum
+# supported version of Bazel to 4.0.0 for these examples.
+config_setting(
+    name = "windows",
+    constraint_values = ["@platforms//os:windows"],
+    visibility = ["//:__subpackages__"],
+)
+
+config_setting(
+    name = "macos",
+    constraint_values = ["@platforms//os:macos"],
+    visibility = ["//:__subpackages__"],
+)
+
 tests = [
     "//cmake:test_libgd",
     "//cmake:test_libpng",

--- a/examples/cmake_crosstool/static/BUILD
+++ b/examples/cmake_crosstool/static/BUILD
@@ -66,7 +66,7 @@ cc_binary(
     # includes just hello.h, include directory: "include/version123"
     srcs = ["hello_client.c"],
     deps = select({
-        "@platforms//os:windows": [":libhello_win"],
+        "//:windows": [":libhello_win"],
         "//conditions:default": [":libhello"],
     }),
 )
@@ -76,7 +76,7 @@ cc_binary(
     # includes just hello.h, include directory: "include/version123"
     srcs = ["hello_client.c"],
     deps = select({
-        "@platforms//os:windows": [":libhello_win_ninja"],
+        "//:windows": [":libhello_win_ninja"],
         "//conditions:default": [":libhello"],
     }),
 )
@@ -86,7 +86,7 @@ cc_binary(
     # includes just hello.h, include directory: "include/version123"
     srcs = ["hello_client.c"],
     deps = select({
-        "@platforms//os:windows": [":libhello_win_nmake"],
+        "//:windows": [":libhello_win_nmake"],
         "//conditions:default": [":libhello"],
     }),
 )

--- a/examples/cmake_hello_world_lib/binary/BUILD
+++ b/examples/cmake_hello_world_lib/binary/BUILD
@@ -12,8 +12,8 @@ filegroup(
 cmake_external(
     name = "libhello",
     binaries = select({
-        "@platforms//os:windows": ["hello.exe"],
-        "@platforms//os:macos": ["hello"],
+        "//:windows": ["hello.exe"],
+        "//:macos": ["hello"],
         "//conditions:default": ["hello"],
     }),
     # Probably this variable should be set by default.

--- a/examples/cmake_hello_world_lib/shared/BUILD
+++ b/examples/cmake_hello_world_lib/shared/BUILD
@@ -19,8 +19,8 @@ cmake_external(
     },
     lib_source = ":srcs",
     shared_libraries = select({
-        "@platforms//os:windows": ["libhello.dll"],
-        "@platforms//os:macos": ["libhello.dylib"],
+        "//:windows": ["libhello.dll"],
+        "//:macos": ["libhello.dylib"],
         "//conditions:default": ["libhello.so"],
     }),
 )

--- a/examples/cmake_hello_world_lib/static/BUILD
+++ b/examples/cmake_hello_world_lib/static/BUILD
@@ -62,7 +62,7 @@ cc_binary(
     # includes just hello.h, include directory: "include/version123"
     srcs = ["hello_client.c"],
     deps = select({
-        "@platforms//os:windows": [":libhello_win"],
+        "//:windows": [":libhello_win"],
         "//conditions:default": [":libhello"],
     }),
 )
@@ -72,7 +72,7 @@ cc_binary(
     # includes just hello.h, include directory: "include/version123"
     srcs = ["hello_client.c"],
     deps = select({
-        "@platforms//os:windows": [":libhello_win_ninja"],
+        "//:windows": [":libhello_win_ninja"],
         "//conditions:default": [":libhello"],
     }),
 )
@@ -82,7 +82,7 @@ cc_binary(
     # includes just hello.h, include directory: "include/version123"
     srcs = ["hello_client.c"],
     deps = select({
-        "@platforms//os:windows": [":libhello_win_nmake"],
+        "//:windows": [":libhello_win_nmake"],
         "//conditions:default": [":libhello"],
     }),
 )

--- a/examples/cmake_hello_world_variant/BUILD
+++ b/examples/cmake_hello_world_variant/BUILD
@@ -1,27 +1,10 @@
 load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 
-# TODO: This should not be necessary but there appears to be some inconsistent
-# behavior with the use of `constraint_value`s in `select` statements. A support
-# thread was started at the end of https://github.com/bazelbuild/bazel/pull/12071
-# Once it is possible to replace `:windows` with `@platforms//os:windows` that
-# should be done for this file
-config_setting(
-    name = "windows",
-    constraint_values = ["@platforms//os:windows"],
-    visibility = ["//visibility:private"],
-)
-
-config_setting(
-    name = "macos",
-    constraint_values = ["@platforms//os:macos"],
-    visibility = ["//visibility:private"],
-)
-
 cmake_external(
     name = "hello_world",
     binaries = select({
-        ":windows": ["CMakeHelloWorld.exe"],
-        ":macos": ["CMakeHelloWorld"],
+        "//:windows": ["CMakeHelloWorld.exe"],
+        "//:macos": ["CMakeHelloWorld"],
         "//conditions:default": ["CMakeHelloWorld"],
     }),
     cmake_options = ["-GNinja"],
@@ -37,8 +20,8 @@ filegroup(
     name = "binary",
     srcs = [":hello_world"],
     output_group = select({
-        ":windows": "CMakeHelloWorld.exe",
-        ":macos": "CMakeHelloWorld",
+        "//:windows": "CMakeHelloWorld.exe",
+        "//:macos": "CMakeHelloWorld",
         "//conditions:default": "CMakeHelloWorld",
     }),
 )

--- a/examples/cmake_synthetic/BUILD
+++ b/examples/cmake_synthetic/BUILD
@@ -3,7 +3,7 @@ load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 generate_crosstool = select({
-    "@platforms//os:windows": True,
+    "//:windows": True,
     "//conditions:default": False,
 })
 

--- a/examples/configure_gnuplot/BUILD
+++ b/examples/configure_gnuplot/BUILD
@@ -34,7 +34,7 @@ configure_make(
 )
 
 libgd_name = select({
-    "@platforms//os:windows": ["libgd.lib"],
+    "//:windows": ["libgd.lib"],
     "//conditions:default": ["libgd.a"],
 })
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -17,13 +17,25 @@ shell_script_helper_test_rule(
     script = ["##symlink_contents_to_dir## $$SOURCE_DIR$$ $$TARGET_DIR$$"],
 )
 
+# TODO: This should not be necessary but there appears to be some inconsistent
+# behavior with the use of `constraint_value`s in `select` statements. A support
+# thread was started at the end of https://github.com/bazelbuild/bazel/pull/12071
+# Once it is possible to replace `:macos` with `@platforms//os:macos` that
+# should be done for this file. Note actioning on this will set the minimum
+# supported version of Bazel to 4.0.0 for these examples.
+config_setting(
+    name = "macos",
+    constraint_values = ["@platforms//os:macos"],
+    visibility = ["//visibility:private"],
+)
+
 result_file = select({
-    "@platforms//os:macos": "expected/inner_fun_text_osx.txt",
+    ":macos": "expected/inner_fun_text_osx.txt",
     "//conditions:default": "expected/inner_fun_text.txt",
 })
 
 result_file_symlink_dirs = select({
-    "@platforms//os:macos": "expected/out_symlinked_dirs_osx.txt",
+    ":macos": "expected/out_symlinked_dirs_osx.txt",
     "//conditions:default": "expected/out_symlinked_dirs.txt",
 })
 


### PR DESCRIPTION
This adds new builds to CI to test the root of the repo as well as the examples. Among those new builds are two checks for the minimum supported Bazel version.

In the future it might be better to consolidate all these tests into smaller tests cases such that we only have jobs for testing the root, examples, and docs directories. But I think making sure everything is being tested is a better place to be in.