### PR TITLE
Fix test target on macOS with Bazel@HEAD

### DIFF
--- a/examples/cmake_with_data/lib_b/BUILD
+++ b/examples/cmake_with_data/lib_b/BUILD
@@ -1,9 +1,11 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_cc//cc:defs.bzl", "cc_binary")
 
-cc_library(
+cc_binary(
     name = "lib_b",
-    srcs = ["src/lib_b.cpp"],
-    hdrs = ["src/lib_b.h"],
-    linkstatic = False,
+    srcs = [
+        "src/lib_b.cpp",
+        "src/lib_b.h",
+    ],
+    linkshared = True,
     visibility = ["//cmake_with_data:__pkg__"],
 )

--- a/examples/cmake_with_data/tests/test_cmake_with_shared_lib.cpp
+++ b/examples/cmake_with_data/tests/test_cmake_with_shared_lib.cpp
@@ -17,7 +17,7 @@ int main(int argc, char* argv[])
 {
     // Make sure the expectd shared library is available
 #ifdef _WIN32
-    test_opening_file(".\\cmake_with_data\\lib_b\\lib_b.lib");
+    test_opening_file(".\\cmake_with_data\\lib_b\\lib_b.dll");
 #else
     test_opening_file("./cmake_with_data/lib_b/liblib_b.so");
 #endif


### PR DESCRIPTION
supports_dynamic_linker feature was removed from cc toolchain for macOS,
cc_binary should be used to build shared library.

Context: bazelbuild/bazel#4341 (comment)