### PR TITLE
Remove a print from the cleanup function

### DIFF
--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -455,8 +455,7 @@ def wrap_outputs(ctx, lib_name, configure_name, script_text):
     cleanup_on_success_function = create_function(
         ctx,
         "cleanup_on_success",
-        """##echo## \"rules_foreign_cc: Cleaning temp directories\"
-rm -rf $BUILD_TMPDIR $EXT_BUILD_DEPS""",
+        """rm -rf $BUILD_TMPDIR $EXT_BUILD_DEPS""",
     )
     cleanup_on_failure_function = create_function(
         ctx,


### PR DESCRIPTION
It somehow causes empty newlines to be printed in Bazel build output.

Cherry-picked from c835382026896f4316b3a1af9164977eeb46abea.