### PR TITLE
Made buildifier checks more aggressive

### DIFF
--- a/.bazelci/config.yaml
+++ b/.bazelci/config.yaml
@@ -28,7 +28,7 @@ tasks:
     build_targets:
       - "//cmake_android:app"
     test_targets:
-    - "//:tests"
+      - "//:tests"
   ubuntu1804_examples:
     name: Examples
     platform: ubuntu1804
@@ -106,7 +106,7 @@ tasks:
     platform: ubuntu2004
     working_directory: docs
     build_targets:
-    - //...
+      - //...
   min_supported_version:
     name: "Minimum Supported Version"
     bazel: "3.4.0"
@@ -125,4 +125,6 @@ tasks:
     test_targets:
       - "//:tests_no_synthetic"
 
-buildifier: latest
+buildifier:
+  version: latest
+  warnings: "all"

--- a/cc_configure_make/def.bzl
+++ b/cc_configure_make/def.bzl
@@ -69,8 +69,8 @@ def _cc_configure_make_impl(ctx):
 _cc_configure_make_rule = rule(
     attrs = {
         "configure_flags": attr.string_list(),
-        "src": attr.label(mandatory = True),
         "out_lib_path": attr.string(mandatory = True),
+        "src": attr.label(mandatory = True),
     },
     fragments = ["cpp"],
     output_to_genfiles = True,

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
 
 genrule(
     name = "flatten_header_vm",

--- a/docs/docs.bzl
+++ b/docs/docs.bzl
@@ -5,14 +5,8 @@ load("@rules_foreign_cc//for_workspace:cmake_build.bzl", _cmake_tool = "cmake_to
 load("@rules_foreign_cc//for_workspace:make_build.bzl", _make_tool = "make_tool")
 load("@rules_foreign_cc//for_workspace:ninja_build.bzl", _ninja_tool = "ninja_tool")
 load("@rules_foreign_cc//tools/build_defs:boost_build.bzl", _boost_build = "boost_build")
-load(
-    "@rules_foreign_cc//tools/build_defs/native_tools:native_tools_toolchain.bzl",
-    _ToolInfo = "ToolInfo",
-    _native_tool_toolchain = "native_tool_toolchain",
-)
 load("@rules_foreign_cc//tools/build_defs:cmake.bzl", _cmake_external = "cmake_external")
 load("@rules_foreign_cc//tools/build_defs:configure.bzl", _configure_make = "configure_make")
-load("@rules_foreign_cc//tools/build_defs:make.bzl", _make = "make")
 load(
     "@rules_foreign_cc//tools/build_defs:framework.bzl",
     _ConfigureParameters = "ConfigureParameters",
@@ -20,6 +14,12 @@ load(
     _ForeignCcDeps = "ForeignCcDeps",
     _InputFiles = "InputFiles",
     _WrappedOutputs = "WrappedOutputs",
+)
+load("@rules_foreign_cc//tools/build_defs:make.bzl", _make = "make")
+load(
+    "@rules_foreign_cc//tools/build_defs/native_tools:native_tools_toolchain.bzl",
+    _ToolInfo = "ToolInfo",
+    _native_tool_toolchain = "native_tool_toolchain",
 )
 
 # Rules Foreign CC symbols

--- a/examples/cmake/BUILD
+++ b/examples/cmake/BUILD
@@ -57,9 +57,9 @@ sh_test(
 cmake_external(
     name = "freetype",
     cache_entries = {
-        "ZLIB_ROOT": "$EXT_BUILD_DEPS/libz",
         "PNG_LIBRARY": "$EXT_BUILD_DEPS/libpng/lib/libpng16.a",
         "PNG_PNG_INCLUDE_DIR": "$EXT_BUILD_DEPS/libpng/include",
+        "ZLIB_ROOT": "$EXT_BUILD_DEPS/libz",
     },
     lib_source = "@freetype//:all",
     out_include_dir = "include/freetype2",
@@ -75,13 +75,13 @@ cmake_external(
     cache_entries = {
         "BUILD_SHARED_LIBS": "OFF",
         "BUILD_STATIC_LIBS": "ON",
-        "ENABLE_PNG": "1",
         "ENABLE_FREETYPE": "1",
-        "ZLIB_ROOT": "$EXT_BUILD_DEPS/libz",
+        "ENABLE_PNG": "1",
+        "FREETYPE_INCLUDE_DIRS": "$EXT_BUILD_DEPS/freetype/include/freetype2",
+        "FREETYPE_LIBRARY": "$EXT_BUILD_DEPS/freetype/lib/libfreetype.a",
         "PNG_LIBRARY": "$EXT_BUILD_DEPS/libpng/lib/libpng16.a",
         "PNG_PNG_INCLUDE_DIR": "$EXT_BUILD_DEPS/libpng/include",
-        "FREETYPE_LIBRARY": "$EXT_BUILD_DEPS/freetype/lib/libfreetype.a",
-        "FREETYPE_INCLUDE_DIRS": "$EXT_BUILD_DEPS/freetype/include/freetype2",
+        "ZLIB_ROOT": "$EXT_BUILD_DEPS/libz",
     },
     defines = ["HAVE_LIBPNG"],
     lib_source = "@libgd//:all",

--- a/examples/cmake_android/BUILD
+++ b/examples/cmake_android/BUILD
@@ -1,5 +1,5 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_android//android:rules.bzl", "android_binary", "android_library")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 
 cmake_external(

--- a/examples/cmake_crosstool/tools/arm_compiler/BUILD
+++ b/examples/cmake_crosstool/tools/arm_compiler/BUILD
@@ -33,8 +33,8 @@ cc_toolchain_suite(
     # target_cpu | compiler
     toolchains = {
         "armeabi-v7a": "cc-compiler-armeabi-v7a",
-        "k8": "cc-compiler-k8",
         "armeabi-v7a|gcc": "cc-compiler-armeabi-v7a",
+        "k8": "cc-compiler-k8",
         "k8|compiler": "cc-compiler-k8",
     },
     visibility = ["//visibility:public"],

--- a/examples/cmake_hello_world_lib/binary/BUILD
+++ b/examples/cmake_hello_world_lib/binary/BUILD
@@ -12,8 +12,8 @@ filegroup(
 cmake_external(
     name = "libhello",
     binaries = select({
-        "//:windows": ["hello.exe"],
         "//:macos": ["hello"],
+        "//:windows": ["hello.exe"],
         "//conditions:default": ["hello"],
     }),
     # Probably this variable should be set by default.

--- a/examples/cmake_hello_world_lib/shared/BUILD
+++ b/examples/cmake_hello_world_lib/shared/BUILD
@@ -19,8 +19,8 @@ cmake_external(
     },
     lib_source = ":srcs",
     shared_libraries = select({
-        "//:windows": ["libhello.dll"],
         "//:macos": ["libhello.dylib"],
+        "//:windows": ["libhello.dll"],
         "//conditions:default": ["libhello.so"],
     }),
 )

--- a/examples/cmake_hello_world_variant/BUILD
+++ b/examples/cmake_hello_world_variant/BUILD
@@ -3,8 +3,8 @@ load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 cmake_external(
     name = "hello_world",
     binaries = select({
-        "//:windows": ["CMakeHelloWorld.exe"],
         "//:macos": ["CMakeHelloWorld"],
+        "//:windows": ["CMakeHelloWorld.exe"],
         "//conditions:default": ["CMakeHelloWorld"],
     }),
     cmake_options = ["-GNinja"],
@@ -20,8 +20,8 @@ filegroup(
     name = "binary",
     srcs = [":hello_world"],
     output_group = select({
-        "//:windows": "CMakeHelloWorld.exe",
         "//:macos": "CMakeHelloWorld",
+        "//:windows": "CMakeHelloWorld.exe",
         "//conditions:default": "CMakeHelloWorld",
     }),
 )

--- a/examples/cmake_nghttp2/BUILD
+++ b/examples/cmake_nghttp2/BUILD
@@ -4,8 +4,8 @@ load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 cmake_external(
     name = "nghttp2",
     cache_entries = {
-        "ENABLE_STATIC_LIB": "on",
         "ENABLE_LIB_ONLY": "on",
+        "ENABLE_STATIC_LIB": "on",
     },
     cmake_options = ["-GNinja"],
     lib_source = "@nghttp2//:all",

--- a/examples/cmake_pcl/BUILD
+++ b/examples/cmake_pcl/BUILD
@@ -1,5 +1,5 @@
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 load("@rules_foreign_cc//tools/build_defs:boost_build.bzl", "boost_build")
+load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 
 # This takes something about 10 minutes
 boost_build(
@@ -53,8 +53,8 @@ boost_build(
 cmake_external(
     name = "openblas",
     cache_entries = {
-        "NOFORTRAN": "on",
         "BUILD_WITHOUT_LAPACK": "no",
+        "NOFORTRAN": "on",
     },
     lib_source = "@openblas//:all",
     static_libraries = ["libopenblas.a"],
@@ -63,8 +63,8 @@ cmake_external(
 cmake_external(
     name = "eigen",
     cache_entries = {
-        "BLA_VENDOR": "OpenBLAS",
         "BLAS_LIBRARIES": "$EXT_BUILD_DEPS/openblas/lib/libopenblas.a",
+        "BLA_VENDOR": "OpenBLAS",
     },
     headers_only = True,
     lib_source = "@eigen//:all",
@@ -82,28 +82,28 @@ cmake_external(
 cmake_external(
     name = "pcl",
     cache_entries = {
-        "WITH_LIBUSB": "no",
-        "EIGEN_INCLUDE_DIRS": "$EXT_BUILD_DEPS/eigen/include/eigen3",
+        "BOOST_INCLUDEDIR": "$EXT_BUILD_DEPS/boost/include",
+        "BOOST_ROOT": "$EXT_BUILD_DEPS/boost/",
         "EIGEN_INCLUDE_DIR": "$EXT_BUILD_DEPS/eigen/include/eigen3",
-        "FLANN_LIBRARY": "$EXT_BUILD_DEPS/flann/lib/libflann_s.a",
-        "FLANN_INCLUDE_DIRS": "$EXT_BUILD_DEPS/flann/include",
+        "EIGEN_INCLUDE_DIRS": "$EXT_BUILD_DEPS/eigen/include/eigen3",
         "FLANN_INCLUDE_DIR": "$EXT_BUILD_DEPS/flann/include",
-        "WITH_PNG": "no",
-        "WITH_QHULL": "no",
+        "FLANN_INCLUDE_DIRS": "$EXT_BUILD_DEPS/flann/include",
+        "FLANN_LIBRARY": "$EXT_BUILD_DEPS/flann/lib/libflann_s.a",
         "WITH_CUDA": "no",
-        "WITH_QT": "no",
-        "WITH_VTK": "no",
-        "WITH_PCAP": "no",
+        "WITH_DAVIDSDK": "no",
+        "WITH_DSSDK": "no",
+        "WITH_ENSENSO": "no",
+        "WITH_FZAPI": "no",
+        "WITH_LIBUSB": "no",
         "WITH_OPENGL": "no",
         "WITH_OPENNI": "no",
         "WITH_OPENNI2": "no",
-        "WITH_FZAPI": "no",
-        "WITH_ENSENSO": "no",
-        "WITH_DAVIDSDK": "no",
-        "WITH_DSSDK": "no",
+        "WITH_PCAP": "no",
+        "WITH_PNG": "no",
+        "WITH_QHULL": "no",
+        "WITH_QT": "no",
         "WITH_RSSDK": "no",
-        "BOOST_ROOT": "$EXT_BUILD_DEPS/boost/",
-        "BOOST_INCLUDEDIR": "$EXT_BUILD_DEPS/boost/include",
+        "WITH_VTK": "no",
     },
     headers_only = True,
     lib_source = "@pcl//:all",

--- a/examples/cmake_synthetic/BUILD
+++ b/examples/cmake_synthetic/BUILD
@@ -1,6 +1,6 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_cc//cc:defs.bzl", "cc_test")
 load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
-load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 generate_crosstool = select({
     "//:windows": True,

--- a/examples/cmake_with_bazel_transitive/BUILD
+++ b/examples/cmake_with_bazel_transitive/BUILD
@@ -5,12 +5,12 @@ load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 cmake_external(
     name = "cmake_libb",
     cache_entries = {
-        # as currently we copy all libraries, built with Bazel, into $EXT_BUILD_DEPS/lib
-        # and the headers into $EXT_BUILD_DEPS/include
-        "LIBA_DIR": "$EXT_BUILD_DEPS",
         # CMake's find_package wants to find cmake config for liba,
         # which we do not have -> disable search
         "CMAKE_DISABLE_FIND_PACKAGE_LIBA": "True",
+        # as currently we copy all libraries, built with Bazel, into $EXT_BUILD_DEPS/lib
+        # and the headers into $EXT_BUILD_DEPS/include
+        "LIBA_DIR": "$EXT_BUILD_DEPS",
     },
     cmake_options = ["-GNinja"],
     lib_source = "//cmake_with_bazel_transitive/libb:b_srcs",

--- a/examples/configure_gnuplot/BUILD
+++ b/examples/configure_gnuplot/BUILD
@@ -1,6 +1,6 @@
+load("@bazel_tools//tools/build_rules:test_rules.bzl", "file_test")
 load("@rules_cc//cc:defs.bzl", "cc_test")
 load("@rules_foreign_cc//tools/build_defs:configure.bzl", "configure_make")
-load("@bazel_tools//tools/build_rules:test_rules.bzl", "file_test")
 
 configure_make(
     name = "libz",

--- a/examples/make_luajit/BUILD
+++ b/examples/make_luajit/BUILD
@@ -8,9 +8,9 @@ make(
     # Probably you want to explore other variables more exactly;
     # For instance, CFLAGS are not copied into TARGET_FLAGS
     make_env_vars = {
+        "LSAN_OPTIONS": "exitcode=0",
         "TARGET_CFLAGS": "-fno-function-sections -fno-data-sections",
         "TARGET_LDFLAGS": "-fno-function-sections -fno-data-sections",
-        "LSAN_OPTIONS": "exitcode=0",
     },
     static_libraries = ["libluajit-5.1.a"],
 )

--- a/examples/pybind11/BUILD
+++ b/examples/pybind11/BUILD
@@ -17,8 +17,8 @@ cmake_external(
     name = "example_bind",
     # include system headers, change this to appropriate value
     env_vars = {
-        "CXXFLAGS": "-isystem=/usr/include/python2.7 -fPIC",
         "CFLAGS": "-isystem=/usr/include/python2.7 -fPIC",
+        "CXXFLAGS": "-isystem=/usr/include/python2.7 -fPIC",
     },
     lib_source = ":example_src",
     shared_libraries = ["example.cpython-35m-x86_64-linux-gnu.so"],

--- a/examples/with_prebuilt_ninja_artefact/BUILD
+++ b/examples/with_prebuilt_ninja_artefact/BUILD
@@ -1,8 +1,8 @@
+load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 load(
     "@rules_foreign_cc//tools/build_defs/native_tools:native_tools_toolchain.bzl",
     "native_tool_toolchain",
 )
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 
 native_tool_toolchain(
     name = "ninja_tool",

--- a/for_workspace/install_ws_dependency.bzl
+++ b/for_workspace/install_ws_dependency.bzl
@@ -22,11 +22,11 @@ _generate_install_rule = repository_rule(
     local = True,
     implementation = _generate_install_rule_impl,
     attrs = {
-        "url": attr.string(mandatory = True),
-        "stripPrefix": attr.string(mandatory = False),
+        "init_expression": attr.string(mandatory = True),
         "init_file": attr.string(mandatory = True),
         "init_function": attr.string(mandatory = True),
-        "init_expression": attr.string(mandatory = True),
+        "stripPrefix": attr.string(mandatory = False),
+        "url": attr.string(mandatory = True),
     },
 )
 

--- a/for_workspace/make_build.bzl
+++ b/for_workspace/make_build.bzl
@@ -1,7 +1,7 @@
 """ Rule for building GNU Make from sources. """
 
-load("//tools/build_defs:detect_root.bzl", "detect_root")
 load("@rules_foreign_cc//tools/build_defs:shell_script_helper.bzl", "convert_shell_script")
+load("//tools/build_defs:detect_root.bzl", "detect_root")
 
 def _make_tool(ctx):
     root = detect_root(ctx.attr.make_srcs)

--- a/for_workspace/ninja_build.bzl
+++ b/for_workspace/ninja_build.bzl
@@ -1,7 +1,7 @@
 """ Rule for building Ninja from sources. """
 
-load("//tools/build_defs:detect_root.bzl", "detect_root")
 load("@rules_foreign_cc//tools/build_defs:shell_script_helper.bzl", "convert_shell_script")
+load("//tools/build_defs:detect_root.bzl", "detect_root")
 
 def _ninja_tool(ctx):
     root = detect_root(ctx.attr.ninja_srcs)

--- a/test/BUILD
+++ b/test/BUILD
@@ -1,9 +1,9 @@
+load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load(":cmake_text_tests.bzl", "cmake_script_test_suite")
 load(":convert_shell_script_test.bzl", "shell_script_conversion_suite")
-load(":utils_test.bzl", "utils_test_suite")
 load(":shell_script_helper_test_rule.bzl", "shell_script_helper_test_rule")
-load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load(":symlink_contents_to_dir_test_rule.bzl", "symlink_contents_to_dir_test_rule")
+load(":utils_test.bzl", "utils_test_suite")
 
 cmake_script_test_suite()
 

--- a/test/cmake_text_tests.bzl
+++ b/test/cmake_text_tests.bzl
@@ -252,7 +252,7 @@ def _merge_flag_values_no_toolchain_file_test(ctx):
         user_env,
         [],
     )
-    expected = """CC=\"/usr/bin/gcc\" CXX=\"/usr/bin/gcc\" CXXFLAGS=\"foo=\\\"bar\\\" -Fbat" cmake -DCMAKE_AR=\"/usr/bin/ar\" -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DCMAKE_PREFIX_PATH=\"$EXT_BUILD_DEPS\" -DCMAKE_INSTALL_PREFIX=\"test_rule\" -DCMAKE_RANLIB=\"\"  $EXT_BUILD_ROOT/external/test_rule"""
+    expected = """CC="/usr/bin/gcc" CXX="/usr/bin/gcc" CXXFLAGS="foo=\\"bar\\" -Fbat" cmake -DCMAKE_AR="/usr/bin/ar" -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$EXT_BUILD_DEPS" -DCMAKE_RANLIB=""  $EXT_BUILD_ROOT/external/test_rule"""
     asserts.equals(env, expected, script)
 
     return unittest.end(env)
@@ -293,7 +293,7 @@ def _create_min_cmake_script_no_toolchain_file_test(ctx):
         user_env,
         ["-GNinja"],
     )
-    expected = "CC=\"/usr/bin/gcc\" CXX=\"/usr/bin/gcc\" CFLAGS=\"-U_FORTIFY_SOURCE -fstack-protector -Wall\" CXXFLAGS=\"-U_FORTIFY_SOURCE -fstack-protector -Wall\" ASMFLAGS=\"-U_FORTIFY_SOURCE -fstack-protector -Wall\" cmake -DCMAKE_AR=\"/usr/bin/ar\" -DCMAKE_SHARED_LINKER_FLAGS=\"-shared -fuse-ld=gold\" -DCMAKE_EXE_LINKER_FLAGS=\"-fuse-ld=gold -Wl -no-as-needed\" -DNOFORTRAN=\"on\" -DCMAKE_PREFIX_PATH=\"$EXT_BUILD_DEPS;/abc/def\" -DCMAKE_INSTALL_PREFIX=\"test_rule\" -DCMAKE_BUILD_TYPE=\"Debug\" -DCMAKE_RANLIB=\"\" -GNinja $EXT_BUILD_ROOT/external/test_rule"
+    expected = """CC="/usr/bin/gcc" CXX="/usr/bin/gcc" CFLAGS="-U_FORTIFY_SOURCE -fstack-protector -Wall" CXXFLAGS="-U_FORTIFY_SOURCE -fstack-protector -Wall" ASMFLAGS="-U_FORTIFY_SOURCE -fstack-protector -Wall" cmake -DCMAKE_AR="/usr/bin/ar" -DCMAKE_SHARED_LINKER_FLAGS="-shared -fuse-ld=gold" -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=gold -Wl -no-as-needed" -DNOFORTRAN="on" -DCMAKE_BUILD_TYPE="Debug" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$EXT_BUILD_DEPS;/abc/def" -DCMAKE_RANLIB="" -GNinja $EXT_BUILD_ROOT/external/test_rule"""
     asserts.equals(env, expected, script)
 
     return unittest.end(env)
@@ -337,7 +337,7 @@ def _create_min_cmake_script_wipe_toolchain_test(ctx):
         user_env,
         ["-GNinja"],
     )
-    expected = "CC=\"/usr/bin/gcc\" CXX=\"/usr/bin/gcc\" CFLAGS=\"-U_FORTIFY_SOURCE -fstack-protector -Wall\" CXXFLAGS=\"-U_FORTIFY_SOURCE -fstack-protector -Wall\" ASMFLAGS=\"-U_FORTIFY_SOURCE -fstack-protector -Wall\" cmake -DCMAKE_AR=\"/usr/bin/ar\" -DCMAKE_EXE_LINKER_FLAGS=\"-fuse-ld=gold -Wl -no-as-needed\" -DCMAKE_PREFIX_PATH=\"$EXT_BUILD_DEPS;/abc/def\" -DCMAKE_INSTALL_PREFIX=\"test_rule\" -DCMAKE_BUILD_TYPE=\"Debug\" -DCMAKE_RANLIB=\"\" -GNinja $EXT_BUILD_ROOT/external/test_rule"
+    expected = """CC="/usr/bin/gcc" CXX="/usr/bin/gcc" CFLAGS="-U_FORTIFY_SOURCE -fstack-protector -Wall" CXXFLAGS="-U_FORTIFY_SOURCE -fstack-protector -Wall" ASMFLAGS="-U_FORTIFY_SOURCE -fstack-protector -Wall" cmake -DCMAKE_AR="/usr/bin/ar" -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=gold -Wl -no-as-needed" -DCMAKE_BUILD_TYPE="Debug" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$EXT_BUILD_DEPS;/abc/def" -DCMAKE_RANLIB="" -GNinja $EXT_BUILD_ROOT/external/test_rule"""
     asserts.equals(env, expected, script)
 
     return unittest.end(env)
@@ -380,16 +380,16 @@ def _create_min_cmake_script_toolchain_file_test(ctx):
     expected = """cat > crosstool_bazel.cmake <<EOF
 set(CMAKE_AR "/usr/bin/ar" CACHE FILEPATH "Archiver")
 set(CMAKE_ASM_FLAGS_INIT "-U_FORTIFY_SOURCE -fstack-protector -Wall")
-set(CMAKE_C_COMPILER "/usr/bin/gcc")
-set(CMAKE_C_FLAGS_INIT "-U_FORTIFY_SOURCE -fstack-protector -Wall")
 set(CMAKE_CXX_COMPILER "/usr/bin/gcc")
 set(CMAKE_CXX_FLAGS_INIT "-U_FORTIFY_SOURCE -fstack-protector -Wall")
+set(CMAKE_C_COMPILER "/usr/bin/gcc")
+set(CMAKE_C_FLAGS_INIT "-U_FORTIFY_SOURCE -fstack-protector -Wall")
 set(CMAKE_EXE_LINKER_FLAGS_INIT "-fuse-ld=gold -Wl -no-as-needed")
 set(CMAKE_SHARED_LINKER_FLAGS_INIT "-shared -fuse-ld=gold")
 set(CMAKE_SYSTEM_NAME "Linux")
 EOF
 
- cmake -DNOFORTRAN="on" -DCMAKE_TOOLCHAIN_FILE="crosstool_bazel.cmake" -DCMAKE_PREFIX_PATH="$EXT_BUILD_DEPS" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_BUILD_TYPE=\"Debug\" -DCMAKE_RANLIB=\"\" -GNinja $EXT_BUILD_ROOT/external/test_rule"""
+ cmake -DNOFORTRAN="on" -DCMAKE_TOOLCHAIN_FILE="crosstool_bazel.cmake" -DCMAKE_BUILD_TYPE="Debug" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$EXT_BUILD_DEPS" -DCMAKE_RANLIB=\"\" -GNinja $EXT_BUILD_ROOT/external/test_rule"""
     asserts.equals(env, expected.splitlines(), script.splitlines())
 
     return unittest.end(env)
@@ -443,7 +443,7 @@ def _create_cmake_script_no_toolchain_file_test(ctx):
         user_env,
         ["-GNinja"],
     )
-    expected = "CC=\"sink-cc-value\" CXX=\"sink-cxx-value\" CFLAGS=\"-cc-flag -gcc_toolchain cc-toolchain --from-env --additional-flag\" CXXFLAGS=\"--quoted=\\\"abc def\\\" --sysroot=/abc/sysroot --gcc_toolchain cxx-toolchain\" ASMFLAGS=\"assemble assemble-user\" CUSTOM_ENV=\"YES\" cmake -DCMAKE_AR=\"/cxx_linker_static\" -DCMAKE_CXX_LINK_EXECUTABLE=\"became\" -DCMAKE_SHARED_LINKER_FLAGS=\"shared1 shared2\" -DCMAKE_EXE_LINKER_FLAGS=\"executable\" -DCUSTOM_CACHE=\"YES\" -DCMAKE_BUILD_TYPE=\"user_type\" -DCMAKE_PREFIX_PATH=\"$EXT_BUILD_DEPS\" -DCMAKE_INSTALL_PREFIX=\"test_rule\" -DCMAKE_RANLIB=\"\" -GNinja $EXT_BUILD_ROOT/external/test_rule"
+    expected = """CC="sink-cc-value" CXX="sink-cxx-value" CFLAGS="-cc-flag -gcc_toolchain cc-toolchain --from-env --additional-flag" CXXFLAGS="--quoted=\\"abc def\\" --sysroot=/abc/sysroot --gcc_toolchain cxx-toolchain" ASMFLAGS="assemble assemble-user" CUSTOM_ENV="YES" cmake -DCMAKE_AR="/cxx_linker_static" -DCMAKE_CXX_LINK_EXECUTABLE="became" -DCMAKE_SHARED_LINKER_FLAGS="shared1 shared2" -DCMAKE_EXE_LINKER_FLAGS="executable" -DCMAKE_BUILD_TYPE="user_type" -DCUSTOM_CACHE="YES" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$EXT_BUILD_DEPS" -DCMAKE_RANLIB="" -GNinja $EXT_BUILD_ROOT/external/test_rule"""
     asserts.equals(env, expected, script)
 
     return unittest.end(env)
@@ -499,20 +499,20 @@ def _create_cmake_script_toolchain_file_test(ctx):
     expected = """cat > crosstool_bazel.cmake <<EOF
 set(CMAKE_AR "/cxx_linker_static" CACHE FILEPATH "Archiver")
 set(CMAKE_ASM_FLAGS_INIT "assemble assemble-user")
-set(CMAKE_C_COMPILER "sink-cc-value")
-set(CMAKE_C_COMPILER_EXTERNAL_TOOLCHAIN "cc-toolchain")
-set(CMAKE_C_FLAGS_INIT "-cc-flag -gcc_toolchain cc-toolchain --from-env --additional-flag")
 set(CMAKE_CXX_COMPILER "sink-cxx-value")
 set(CMAKE_CXX_COMPILER_EXTERNAL_TOOLCHAIN "cxx-toolchain")
 set(CMAKE_CXX_FLAGS_INIT "--quoted=\\\"abc def\\\" --sysroot=/abc/sysroot --gcc_toolchain cxx-toolchain")
 set(CMAKE_CXX_LINK_EXECUTABLE "became")
+set(CMAKE_C_COMPILER "sink-cc-value")
+set(CMAKE_C_COMPILER_EXTERNAL_TOOLCHAIN "cc-toolchain")
+set(CMAKE_C_FLAGS_INIT "-cc-flag -gcc_toolchain cc-toolchain --from-env --additional-flag")
 set(CMAKE_EXE_LINKER_FLAGS_INIT "executable")
 set(CMAKE_SHARED_LINKER_FLAGS_INIT "shared1 shared2")
 set(CMAKE_SYSROOT "/abc/sysroot")
 set(CMAKE_SYSTEM_NAME "Apple")
 EOF
 
-CUSTOM_ENV="YES" cmake -DCUSTOM_CACHE="YES" -DCMAKE_TOOLCHAIN_FILE="crosstool_bazel.cmake" -DCMAKE_PREFIX_PATH="$EXT_BUILD_DEPS" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_BUILD_TYPE=\"Debug\" -DCMAKE_RANLIB=\"\" -GNinja $EXT_BUILD_ROOT/external/test_rule"""
+CUSTOM_ENV=\"YES\" cmake -DCUSTOM_CACHE=\"YES\" -DCMAKE_TOOLCHAIN_FILE=\"crosstool_bazel.cmake\" -DCMAKE_BUILD_TYPE=\"Debug\" -DCMAKE_INSTALL_PREFIX=\"test_rule\" -DCMAKE_PREFIX_PATH=\"$EXT_BUILD_DEPS\" -DCMAKE_RANLIB=\"\" -GNinja $EXT_BUILD_ROOT/external/test_rule"""
     asserts.equals(env, expected.splitlines(), script.splitlines())
 
     return unittest.end(env)

--- a/test/cmake_text_tests.bzl
+++ b/test/cmake_text_tests.bzl
@@ -1,19 +1,19 @@
 """ Unit tests for CMake script creation """
 
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
-load("//tools/build_defs:cmake_script.bzl", "create_cmake_script", "export_for_test")
 load("//tools/build_defs:cc_toolchain_util.bzl", "CxxFlagsInfo", "CxxToolsInfo")
+load("//tools/build_defs:cmake_script.bzl", "create_cmake_script", "export_for_test")
 
 def _absolutize_test(ctx):
     env = unittest.begin(ctx)
 
     cases = {
-        "abs/a12": "abs/a12",
-        "/abs/a12": "/abs/a12",
-        "external/cmake/aaa": "$EXT_BUILD_ROOT/external/cmake/aaa",
         "-Lexternal/cmake/aaa": "-L$EXT_BUILD_ROOT/external/cmake/aaa",
-        "ws/cmake/aaa": "$EXT_BUILD_ROOT/ws/cmake/aaa",
+        "/abs/a12": "/abs/a12",
+        "abs/a12": "abs/a12",
+        "external/cmake/aaa": "$EXT_BUILD_ROOT/external/cmake/aaa",
         "name=ws/cmake/aaa": "name=$EXT_BUILD_ROOT/ws/cmake/aaa",
+        "ws/cmake/aaa": "$EXT_BUILD_ROOT/ws/cmake/aaa",
     }
 
     for case in cases:
@@ -91,18 +91,18 @@ def _fill_crossfile_from_toolchain_test(ctx):
     asserts.true(env, system != None)
 
     expected = {
-        "CMAKE_SYSROOT": "/abc/sysroot",
-        "CMAKE_C_COMPILER_EXTERNAL_TOOLCHAIN": "cc-toolchain",
-        "CMAKE_CXX_COMPILER_EXTERNAL_TOOLCHAIN": "cxx-toolchain",
-        "CMAKE_C_COMPILER": "/some-cc-value",
-        "CMAKE_CXX_COMPILER": "$EXT_BUILD_ROOT/external/cxx-value",
         "CMAKE_AR": "/cxx_linker_static",
-        "CMAKE_CXX_LINK_EXECUTABLE": "$EXT_BUILD_ROOT/ws/cxx_linker_executable <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>",
-        "CMAKE_C_FLAGS_INIT": "-cc-flag -gcc_toolchain cc-toolchain",
-        "CMAKE_CXX_FLAGS_INIT": "--quoted=\\\"abc def\\\" --sysroot=/abc/sysroot --gcc_toolchain cxx-toolchain",
         "CMAKE_ASM_FLAGS_INIT": "assemble",
-        "CMAKE_SHARED_LINKER_FLAGS_INIT": "shared1 shared2",
+        "CMAKE_CXX_COMPILER": "$EXT_BUILD_ROOT/external/cxx-value",
+        "CMAKE_CXX_COMPILER_EXTERNAL_TOOLCHAIN": "cxx-toolchain",
+        "CMAKE_CXX_FLAGS_INIT": "--quoted=\\\"abc def\\\" --sysroot=/abc/sysroot --gcc_toolchain cxx-toolchain",
+        "CMAKE_CXX_LINK_EXECUTABLE": "$EXT_BUILD_ROOT/ws/cxx_linker_executable <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>",
+        "CMAKE_C_COMPILER": "/some-cc-value",
+        "CMAKE_C_COMPILER_EXTERNAL_TOOLCHAIN": "cc-toolchain",
+        "CMAKE_C_FLAGS_INIT": "-cc-flag -gcc_toolchain cc-toolchain",
         "CMAKE_EXE_LINKER_FLAGS_INIT": "executable",
+        "CMAKE_SHARED_LINKER_FLAGS_INIT": "shared1 shared2",
+        "CMAKE_SYSROOT": "/abc/sysroot",
     }
 
     for key in expected:
@@ -114,21 +114,21 @@ def _move_dict_values_test(ctx):
     env = unittest.begin(ctx)
 
     target = {
-        "CMAKE_C_COMPILER": "some-cc-value",
         "CMAKE_CXX_COMPILER": "$EXT_BUILD_ROOT/external/cxx-value",
-        "CMAKE_C_FLAGS_INIT": "-cc-flag -gcc_toolchain cc-toolchain",
         "CMAKE_CXX_LINK_EXECUTABLE": "was",
+        "CMAKE_C_COMPILER": "some-cc-value",
+        "CMAKE_C_FLAGS_INIT": "-cc-flag -gcc_toolchain cc-toolchain",
     }
     source_env = {
         "CC": "sink-cc-value",
-        "CXX": "sink-cxx-value",
         "CFLAGS": "--from-env",
         "CUSTOM": "YES",
+        "CXX": "sink-cxx-value",
     }
     source_cache = {
-        "CMAKE_C_FLAGS": "--additional-flag",
         "CMAKE_ASM_FLAGS": "assemble",
         "CMAKE_CXX_LINK_EXECUTABLE": "became",
+        "CMAKE_C_FLAGS": "--additional-flag",
         "CUSTOM": "YES",
     }
     export_for_test.move_dict_values(
@@ -143,11 +143,11 @@ def _move_dict_values_test(ctx):
     )
 
     expected_target = {
-        "CMAKE_C_COMPILER": "sink-cc-value",
-        "CMAKE_CXX_COMPILER": "sink-cxx-value",
-        "CMAKE_C_FLAGS_INIT": "-cc-flag -gcc_toolchain cc-toolchain --from-env --additional-flag",
         "CMAKE_ASM_FLAGS_INIT": "assemble",
+        "CMAKE_CXX_COMPILER": "sink-cxx-value",
         "CMAKE_CXX_LINK_EXECUTABLE": "became",
+        "CMAKE_C_COMPILER": "sink-cc-value",
+        "CMAKE_C_FLAGS_INIT": "-cc-flag -gcc_toolchain cc-toolchain --from-env --additional-flag",
     }
     for key in expected_target:
         asserts.equals(env, expected_target[key], target[key])
@@ -164,21 +164,15 @@ def _reverse_descriptor_dict_test(ctx):
 
     res = export_for_test.reverse_descriptor_dict(export_for_test.CMAKE_CACHE_ENTRIES_CROSSTOOL)
     expected = {
-        "CMAKE_SYSTEM_NAME": struct(value = "CMAKE_SYSTEM_NAME", replace = True),
         "CMAKE_AR": struct(value = "CMAKE_AR", replace = True),
+        "CMAKE_ASM_FLAGS_INIT": struct(value = "CMAKE_ASM_FLAGS", replace = False),
+        "CMAKE_CXX_FLAGS_INIT": struct(value = "CMAKE_CXX_FLAGS", replace = False),
         "CMAKE_CXX_LINK_EXECUTABLE": struct(value = "CMAKE_CXX_LINK_EXECUTABLE", replace = True),
         "CMAKE_C_FLAGS_INIT": struct(value = "CMAKE_C_FLAGS", replace = False),
-        "CMAKE_CXX_FLAGS_INIT": struct(value = "CMAKE_CXX_FLAGS", replace = False),
-        "CMAKE_ASM_FLAGS_INIT": struct(value = "CMAKE_ASM_FLAGS", replace = False),
-        "CMAKE_STATIC_LINKER_FLAGS_INIT": struct(
-            value = "CMAKE_STATIC_LINKER_FLAGS",
-            replace = False,
-        ),
-        "CMAKE_SHARED_LINKER_FLAGS_INIT": struct(
-            value = "CMAKE_SHARED_LINKER_FLAGS",
-            replace = False,
-        ),
         "CMAKE_EXE_LINKER_FLAGS_INIT": struct(value = "CMAKE_EXE_LINKER_FLAGS", replace = False),
+        "CMAKE_SHARED_LINKER_FLAGS_INIT": struct(value = "CMAKE_SHARED_LINKER_FLAGS", replace = False),
+        "CMAKE_STATIC_LINKER_FLAGS_INIT": struct(value = "CMAKE_STATIC_LINKER_FLAGS", replace = False),
+        "CMAKE_SYSTEM_NAME": struct(value = "CMAKE_SYSTEM_NAME", replace = True),
     }
 
     for key in expected:
@@ -190,16 +184,16 @@ def _merge_toolchain_and_user_values_test(ctx):
     env = unittest.begin(ctx)
 
     target = {
-        "CMAKE_C_COMPILER": "some-cc-value",
         "CMAKE_CXX_COMPILER": "$EXT_BUILD_ROOT/external/cxx-value",
-        "CMAKE_C_FLAGS_INIT": "-cc-flag -gcc_toolchain cc-toolchain",
         "CMAKE_CXX_FLAGS_INIT": "-ccx-flag",
         "CMAKE_CXX_LINK_EXECUTABLE": "was",
+        "CMAKE_C_COMPILER": "some-cc-value",
+        "CMAKE_C_FLAGS_INIT": "-cc-flag -gcc_toolchain cc-toolchain",
     }
     source_cache = {
-        "CMAKE_C_FLAGS": "--additional-flag",
         "CMAKE_ASM_FLAGS": "assemble",
         "CMAKE_CXX_LINK_EXECUTABLE": "became",
+        "CMAKE_C_FLAGS": "--additional-flag",
         "CUSTOM": "YES",
     }
 
@@ -210,10 +204,10 @@ def _merge_toolchain_and_user_values_test(ctx):
     )
 
     expected_target = {
-        "CMAKE_C_FLAGS": "-cc-flag -gcc_toolchain cc-toolchain --additional-flag",
-        "CMAKE_CXX_FLAGS": "-ccx-flag",
         "CMAKE_ASM_FLAGS": "assemble",
+        "CMAKE_CXX_FLAGS": "-ccx-flag",
         "CMAKE_CXX_LINK_EXECUTABLE": "became",
+        "CMAKE_C_FLAGS": "-cc-flag -gcc_toolchain cc-toolchain --additional-flag",
         "CUSTOM": "YES",
     }
 
@@ -241,8 +235,8 @@ def _merge_flag_values_no_toolchain_file_test(ctx):
     )
     user_env = {}
     user_cache = {
-        "CMAKE_CXX_FLAGS": "-Fbat",
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CMAKE_CXX_FLAGS": "-Fbat",
     }
 
     script = create_cmake_script(
@@ -282,8 +276,8 @@ def _create_min_cmake_script_no_toolchain_file_test(ctx):
     )
     user_env = {}
     user_cache = {
-        "NOFORTRAN": "on",
         "CMAKE_PREFIX_PATH": "/abc/def",
+        "NOFORTRAN": "on",
     }
 
     script = create_cmake_script(
@@ -384,15 +378,15 @@ def _create_min_cmake_script_toolchain_file_test(ctx):
         ["-GNinja"],
     )
     expected = """cat > crosstool_bazel.cmake <<EOF
-set(CMAKE_SYSTEM_NAME "Linux")
-set(CMAKE_C_COMPILER "/usr/bin/gcc")
-set(CMAKE_CXX_COMPILER "/usr/bin/gcc")
 set(CMAKE_AR "/usr/bin/ar" CACHE FILEPATH "Archiver")
-set(CMAKE_C_FLAGS_INIT "-U_FORTIFY_SOURCE -fstack-protector -Wall")
-set(CMAKE_CXX_FLAGS_INIT "-U_FORTIFY_SOURCE -fstack-protector -Wall")
 set(CMAKE_ASM_FLAGS_INIT "-U_FORTIFY_SOURCE -fstack-protector -Wall")
-set(CMAKE_SHARED_LINKER_FLAGS_INIT "-shared -fuse-ld=gold")
+set(CMAKE_C_COMPILER "/usr/bin/gcc")
+set(CMAKE_C_FLAGS_INIT "-U_FORTIFY_SOURCE -fstack-protector -Wall")
+set(CMAKE_CXX_COMPILER "/usr/bin/gcc")
+set(CMAKE_CXX_FLAGS_INIT "-U_FORTIFY_SOURCE -fstack-protector -Wall")
 set(CMAKE_EXE_LINKER_FLAGS_INIT "-fuse-ld=gold -Wl -no-as-needed")
+set(CMAKE_SHARED_LINKER_FLAGS_INIT "-shared -fuse-ld=gold")
+set(CMAKE_SYSTEM_NAME "Linux")
 EOF
 
  cmake -DNOFORTRAN="on" -DCMAKE_TOOLCHAIN_FILE="crosstool_bazel.cmake" -DCMAKE_PREFIX_PATH="$EXT_BUILD_DEPS" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_BUILD_TYPE=\"Debug\" -DCMAKE_RANLIB=\"\" -GNinja $EXT_BUILD_ROOT/external/test_rule"""
@@ -424,16 +418,16 @@ def _create_cmake_script_no_toolchain_file_test(ctx):
     )
     user_env = {
         "CC": "sink-cc-value",
-        "CXX": "sink-cxx-value",
         "CFLAGS": "--from-env",
         "CUSTOM_ENV": "YES",
+        "CXX": "sink-cxx-value",
     }
     user_cache = {
-        "CMAKE_C_FLAGS": "--additional-flag",
         "CMAKE_ASM_FLAGS": "assemble-user",
-        "CMAKE_CXX_LINK_EXECUTABLE": "became",
-        "CUSTOM_CACHE": "YES",
         "CMAKE_BUILD_TYPE": "user_type",
+        "CMAKE_CXX_LINK_EXECUTABLE": "became",
+        "CMAKE_C_FLAGS": "--additional-flag",
+        "CUSTOM_CACHE": "YES",
     }
 
     script = create_cmake_script(
@@ -478,14 +472,14 @@ def _create_cmake_script_toolchain_file_test(ctx):
     )
     user_env = {
         "CC": "sink-cc-value",
-        "CXX": "sink-cxx-value",
         "CFLAGS": "--from-env",
         "CUSTOM_ENV": "YES",
+        "CXX": "sink-cxx-value",
     }
     user_cache = {
-        "CMAKE_C_FLAGS": "--additional-flag",
         "CMAKE_ASM_FLAGS": "assemble-user",
         "CMAKE_CXX_LINK_EXECUTABLE": "became",
+        "CMAKE_C_FLAGS": "--additional-flag",
         "CUSTOM_CACHE": "YES",
     }
 
@@ -503,19 +497,19 @@ def _create_cmake_script_toolchain_file_test(ctx):
         ["-GNinja"],
     )
     expected = """cat > crosstool_bazel.cmake <<EOF
-set(CMAKE_SYSTEM_NAME "Apple")
-set(CMAKE_SYSROOT "/abc/sysroot")
-set(CMAKE_C_COMPILER_EXTERNAL_TOOLCHAIN "cc-toolchain")
-set(CMAKE_CXX_COMPILER_EXTERNAL_TOOLCHAIN "cxx-toolchain")
-set(CMAKE_C_COMPILER "sink-cc-value")
-set(CMAKE_CXX_COMPILER "sink-cxx-value")
 set(CMAKE_AR "/cxx_linker_static" CACHE FILEPATH "Archiver")
-set(CMAKE_CXX_LINK_EXECUTABLE "became")
-set(CMAKE_C_FLAGS_INIT "-cc-flag -gcc_toolchain cc-toolchain --from-env --additional-flag")
-set(CMAKE_CXX_FLAGS_INIT "--quoted=\\\"abc def\\\" --sysroot=/abc/sysroot --gcc_toolchain cxx-toolchain")
 set(CMAKE_ASM_FLAGS_INIT "assemble assemble-user")
-set(CMAKE_SHARED_LINKER_FLAGS_INIT "shared1 shared2")
+set(CMAKE_C_COMPILER "sink-cc-value")
+set(CMAKE_C_COMPILER_EXTERNAL_TOOLCHAIN "cc-toolchain")
+set(CMAKE_C_FLAGS_INIT "-cc-flag -gcc_toolchain cc-toolchain --from-env --additional-flag")
+set(CMAKE_CXX_COMPILER "sink-cxx-value")
+set(CMAKE_CXX_COMPILER_EXTERNAL_TOOLCHAIN "cxx-toolchain")
+set(CMAKE_CXX_FLAGS_INIT "--quoted=\\\"abc def\\\" --sysroot=/abc/sysroot --gcc_toolchain cxx-toolchain")
+set(CMAKE_CXX_LINK_EXECUTABLE "became")
 set(CMAKE_EXE_LINKER_FLAGS_INIT "executable")
+set(CMAKE_SHARED_LINKER_FLAGS_INIT "shared1 shared2")
+set(CMAKE_SYSROOT "/abc/sysroot")
+set(CMAKE_SYSTEM_NAME "Apple")
 EOF
 
 CUSTOM_ENV="YES" cmake -DCUSTOM_CACHE="YES" -DCMAKE_TOOLCHAIN_FILE="crosstool_bazel.cmake" -DCMAKE_PREFIX_PATH="$EXT_BUILD_DEPS" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_BUILD_TYPE=\"Debug\" -DCMAKE_RANLIB=\"\" -GNinja $EXT_BUILD_ROOT/external/test_rule"""

--- a/test/convert_shell_script_test.bzl
+++ b/test/convert_shell_script_test.bzl
@@ -20,12 +20,12 @@ def _replace_vars_test(ctx):
     env = unittest.begin(ctx)
 
     cases = {
-        "$$ABC$$": "$ABC",
-        "x$$ABC$$": "x$ABC",
-        "$$ABC$$x": "$ABCx",
         " $$ABC$$ ": " $ABC ",
+        "$$ABC$$": "$ABC",
         "$$ABC$$/$$DEF$$": "$ABC/$DEF",
+        "$$ABC$$x": "$ABCx",
         "test before $$ABC$$$ and after": "test before $ABC$ and after",
+        "x$$ABC$$": "x$ABC",
     }
 
     shell_ = struct(
@@ -45,12 +45,12 @@ def _replace_vars_win_test(ctx):
     env = unittest.begin(ctx)
 
     cases = {
-        "$$ABC$$": "%ABC%",
-        "x$$ABC$$": "x%ABC%",
-        "$$ABC$$x": "%ABC%x",
         " $$ABC$$ ": " %ABC% ",
+        "$$ABC$$": "%ABC%",
         "$$ABC$$/$$DEF$$": "%ABC%/%DEF%",
+        "$$ABC$$x": "%ABC%x",
         "test before $$ABC$$$ and after": "test before %ABC%$ and after",
+        "x$$ABC$$": "x%ABC%",
     }
 
     shell_ = struct(
@@ -76,10 +76,10 @@ def _split_arguments_test(ctx):
     env = unittest.begin(ctx)
 
     cases = {
-        " 1 2 3": ["1", "2", "3"],
-        "1 2": ["1", "2"],
         " \"\ntext\n\"": ["\"\ntext\n\""],
+        " 1 2 3": ["1", "2", "3"],
         " usual \"quoted argument\"": ["usual", "\"quoted argument\""],
+        "1 2": ["1", "2"],
     }
     for case in cases:
         result = split_arguments(case)
@@ -103,13 +103,13 @@ def _do_function_call_test(ctx):
     env = unittest.begin(ctx)
 
     cases = {
-        "##symlink_contents_to_dir## 1 2": "1_2",
         "##echo## \"\ntext\n\"": "echo1 \"\ntext\n\"",
+        "##os_name##": "Fuchsia",
+        "##script_prelude##": "set -e",
+        "##symlink_contents_to_dir## 1 2": "1_2",
+        "export ROOT=\"A B C\"": "export1 ROOT=\"A B C\"",
         "export ROOT=\"ABC\"": "export1 ROOT=\"ABC\"",
         "export ROOT=ABC": "export1 ROOT=ABC",
-        "export ROOT=\"A B C\"": "export1 ROOT=\"A B C\"",
-        "##script_prelude##": "set -e",
-        "##os_name##": "Fuchsia",
     }
     shell_ = struct(
         symlink_contents_to_dir = _funny_fun,
@@ -158,11 +158,8 @@ def _do_function_call_with_body_test(ctx):
     env = unittest.begin(ctx)
 
     cases = {
-        "##touch## a/b/c": {
-            "text": "function touch() {\n  call_touch $1\n}",
-            "call": "touch a/b/c",
-        },
         "##cleanup_function## \"echo $$CLEANUP_MSG$$\" \"echo $$KEEP_MSG1$$ && echo $$KEEP_MSG2$$\"": {
+            "call": "cleanup_function \"echo $$CLEANUP_MSG$$\" \"echo $$KEEP_MSG1$$ && echo $$KEEP_MSG2$$\"",
             "text": """function cleanup_function() {
   local ecode=$?
 if [ $ecode -eq 0 ]; then
@@ -174,7 +171,10 @@ echo $$KEEP_MSG1$$ && echo $$KEEP_MSG2$$
 echo ""
 fi
 }""",
-            "call": "cleanup_function \"echo $$CLEANUP_MSG$$\" \"echo $$KEEP_MSG1$$ && echo $$KEEP_MSG2$$\"",
+        },
+        "##touch## a/b/c": {
+            "call": "touch a/b/c",
+            "text": "function touch() {\n  call_touch $1\n}",
         },
     }
     shell_ = struct(

--- a/test/detect_root_test/BUILD
+++ b/test/detect_root_test/BUILD
@@ -1,5 +1,5 @@
-load(":detect_root_test_rule.bzl", "detect_root_test_rule")
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+load(":detect_root_test_rule.bzl", "detect_root_test_rule")
 
 filegroup(
     name = "fg",

--- a/test/detect_root_test/detect_root_test_rule.bzl
+++ b/test/detect_root_test/detect_root_test_rule.bzl
@@ -14,7 +14,7 @@ def _impl(ctx):
 detect_root_test_rule = rule(
     implementation = _impl,
     attrs = {
-        "srcs": attr.label(mandatory = True),
         "out": attr.string(mandatory = True),
+        "srcs": attr.label(mandatory = True),
     },
 )

--- a/test/shell_script_helper_test_rule.bzl
+++ b/test/shell_script_helper_test_rule.bzl
@@ -16,8 +16,8 @@ def _impl(ctx):
 shell_script_helper_test_rule = rule(
     implementation = _impl,
     attrs = {
-        "script": attr.string_list(mandatory = True),
         "out": attr.string(mandatory = True),
+        "script": attr.string_list(mandatory = True),
     },
     toolchains = [
         "@rules_foreign_cc//tools/build_defs/shell_toolchain/toolchains:shell_commands",

--- a/test/standard_cxx_flags_test/tests.bzl
+++ b/test/standard_cxx_flags_test/tests.bzl
@@ -43,8 +43,8 @@ def assert_contains_once(arr, value):
 _flags_test = rule(
     implementation = _impl,
     attrs = {
-        "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
         "out": attr.output(),
+        "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
     },
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
     fragments = ["cpp"],

--- a/test/symlink_contents_to_dir_test_rule.bzl
+++ b/test/symlink_contents_to_dir_test_rule.bzl
@@ -1,9 +1,9 @@
 # buildifier: disable=module-docstring
+load("@rules_foreign_cc//tools/build_defs:detect_root.bzl", "detect_root", "filter_containing_dirs_from_inputs")
 load(
     "@rules_foreign_cc//tools/build_defs:shell_script_helper.bzl",
     "convert_shell_script",
 )
-load("@rules_foreign_cc//tools/build_defs:detect_root.bzl", "detect_root", "filter_containing_dirs_from_inputs")
 
 def _impl(ctx):
     out = ctx.actions.declare_file(ctx.attr.out)

--- a/tools/build_defs/boost_build.bzl
+++ b/tools/build_defs/boost_build.bzl
@@ -1,12 +1,12 @@
 """ Rule for building Boost from sources. """
 
+load("//tools/build_defs:detect_root.bzl", "detect_root")
 load(
     "//tools/build_defs:framework.bzl",
     "CC_EXTERNAL_RULE_ATTRIBUTES",
     "cc_external_rule_impl",
     "create_attrs",
 )
-load("//tools/build_defs:detect_root.bzl", "detect_root")
 
 def _boost_build(ctx):
     attrs = create_attrs(

--- a/tools/build_defs/cc_toolchain_util.bzl
+++ b/tools/build_defs/cc_toolchain_util.bzl
@@ -1,7 +1,7 @@
 """ Defines create_linking_info, which wraps passed libraries into CcLinkingInfo
 """
 
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@bazel_skylib//lib:collections.bzl", "collections")
 load(
     "@bazel_tools//tools/build_defs/cc:action_names.bzl",
     "ASSEMBLE_ACTION_NAME",
@@ -11,7 +11,7 @@ load(
     "CPP_LINK_STATIC_LIBRARY_ACTION_NAME",
     "C_COMPILE_ACTION_NAME",
 )
-load("@bazel_skylib//lib:collections.bzl", "collections")
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 
 LibrariesToLinkInfo = provider(
     doc = "Libraries to be wrapped into CcLinkingInfo",
@@ -172,10 +172,10 @@ def _build_cc_link_params(
         )
 
     return {
-        "static_mode_params_for_dynamic_library": static_shared,
-        "static_mode_params_for_executable": static_no_shared,
         "dynamic_mode_params_for_dynamic_library": no_static_shared,
         "dynamic_mode_params_for_executable": no_static_no_shared,
+        "static_mode_params_for_dynamic_library": static_shared,
+        "static_mode_params_for_executable": static_no_shared,
     }
 
 def targets_windows(ctx, cc_toolchain):

--- a/tools/build_defs/cmake.bzl
+++ b/tools/build_defs/cmake.bzl
@@ -1,6 +1,17 @@
 """ Defines the rule for building external library with CMake
 """
 
+load("@rules_foreign_cc//tools/build_defs:shell_script_helper.bzl", "os_name")
+load(
+    "//tools/build_defs:cc_toolchain_util.bzl",
+    "get_flags_info",
+    "get_tools_info",
+    "is_debug_mode",
+)
+load(
+    "//tools/build_defs:detect_root.bzl",
+    "detect_root",
+)
 load(
     "//tools/build_defs:framework.bzl",
     "CC_EXTERNAL_RULE_ATTRIBUTES",
@@ -8,23 +19,12 @@ load(
     "create_attrs",
 )
 load(
-    "//tools/build_defs:detect_root.bzl",
-    "detect_root",
-)
-load(
-    "//tools/build_defs:cc_toolchain_util.bzl",
-    "get_flags_info",
-    "get_tools_info",
-    "is_debug_mode",
-)
-load(":cmake_script.bzl", "create_cmake_script")
-load(
     "//tools/build_defs/native_tools:tool_access.bzl",
     "get_cmake_data",
     "get_make_data",
     "get_ninja_data",
 )
-load("@rules_foreign_cc//tools/build_defs:shell_script_helper.bzl", "os_name")
+load(":cmake_script.bzl", "create_cmake_script")
 
 def _cmake_external(ctx):
     cmake_data = get_cmake_data(ctx)
@@ -102,10 +102,6 @@ def _get_install_prefix(ctx):
 def _attrs():
     attrs = dict(CC_EXTERNAL_RULE_ATTRIBUTES)
     attrs.update({
-        "install_prefix": attr.string(
-            doc = "Relative install prefix to be passed to CMake in -DCMAKE_INSTALL_PREFIX",
-            mandatory = False,
-        ),
         "cache_entries": attr.string_dict(
             doc = (
                 "CMake cache entries to initialize (they will be passed with -Dkey=value) " +
@@ -115,6 +111,11 @@ def _attrs():
             mandatory = False,
             default = {},
         ),
+        "cmake_options": attr.string_list(
+            doc = "Other CMake options",
+            mandatory = False,
+            default = [],
+        ),
         "env_vars": attr.string_dict(
             doc = (
                 "CMake environment variable values to join with toolchain-defined. " +
@@ -122,11 +123,6 @@ def _attrs():
             ),
             mandatory = False,
             default = {},
-        ),
-        "cmake_options": attr.string_list(
-            doc = "Other CMake options",
-            mandatory = False,
-            default = [],
         ),
         "generate_crosstool_file": attr.bool(
             doc = (
@@ -140,6 +136,10 @@ def _attrs():
             ),
             mandatory = False,
             default = False,
+        ),
+        "install_prefix": attr.string(
+            doc = "Relative install prefix to be passed to CMake in -DCMAKE_INSTALL_PREFIX",
+            mandatory = False,
         ),
         "working_directory": attr.string(
             doc = (

--- a/tools/build_defs/cmake_script.bzl
+++ b/tools/build_defs/cmake_script.bzl
@@ -55,9 +55,9 @@ def create_cmake_script(
         "Debug" if is_debug_mode else "Release",
     )
     params.cache.update({
-        "CMAKE_PREFIX_PATH": merged_prefix_path,
-        "CMAKE_INSTALL_PREFIX": install_prefix,
         "CMAKE_BUILD_TYPE": build_type,
+        "CMAKE_INSTALL_PREFIX": install_prefix,
+        "CMAKE_PREFIX_PATH": merged_prefix_path,
     })
 
     # Give user the ability to suppress some value, taken from Bazel's toolchain,
@@ -101,26 +101,26 @@ def _merge_prefix_path(user_cache, include_dirs):
     return ";".join(values)
 
 _CMAKE_ENV_VARS_FOR_CROSSTOOL = {
-    "CC": struct(value = "CMAKE_C_COMPILER", replace = True),
-    "CXX": struct(value = "CMAKE_CXX_COMPILER", replace = True),
-    "CFLAGS": struct(value = "CMAKE_C_FLAGS_INIT", replace = False),
-    "CXXFLAGS": struct(value = "CMAKE_CXX_FLAGS_INIT", replace = False),
     "ASMFLAGS": struct(value = "CMAKE_ASM_FLAGS_INIT", replace = False),
+    "CC": struct(value = "CMAKE_C_COMPILER", replace = True),
+    "CFLAGS": struct(value = "CMAKE_C_FLAGS_INIT", replace = False),
+    "CXX": struct(value = "CMAKE_CXX_COMPILER", replace = True),
+    "CXXFLAGS": struct(value = "CMAKE_CXX_FLAGS_INIT", replace = False),
 }
 
 _CMAKE_CACHE_ENTRIES_CROSSTOOL = {
-    "CMAKE_SYSTEM_NAME": struct(value = "CMAKE_SYSTEM_NAME", replace = True),
     "CMAKE_AR": struct(value = "CMAKE_AR", replace = True),
-    "CMAKE_RANLIB": struct(value = "CMAKE_RANLIB", replace = True),
-    "CMAKE_C_ARCHIVE_CREATE": struct(value = "CMAKE_C_ARCHIVE_CREATE", replace = False),
-    "CMAKE_CXX_ARCHIVE_CREATE": struct(value = "CMAKE_CXX_ARCHIVE_CREATE", replace = False),
-    "CMAKE_CXX_LINK_EXECUTABLE": struct(value = "CMAKE_CXX_LINK_EXECUTABLE", replace = True),
-    "CMAKE_C_FLAGS": struct(value = "CMAKE_C_FLAGS_INIT", replace = False),
-    "CMAKE_CXX_FLAGS": struct(value = "CMAKE_CXX_FLAGS_INIT", replace = False),
     "CMAKE_ASM_FLAGS": struct(value = "CMAKE_ASM_FLAGS_INIT", replace = False),
-    "CMAKE_STATIC_LINKER_FLAGS": struct(value = "CMAKE_STATIC_LINKER_FLAGS_INIT", replace = False),
-    "CMAKE_SHARED_LINKER_FLAGS": struct(value = "CMAKE_SHARED_LINKER_FLAGS_INIT", replace = False),
+    "CMAKE_CXX_ARCHIVE_CREATE": struct(value = "CMAKE_CXX_ARCHIVE_CREATE", replace = False),
+    "CMAKE_CXX_FLAGS": struct(value = "CMAKE_CXX_FLAGS_INIT", replace = False),
+    "CMAKE_CXX_LINK_EXECUTABLE": struct(value = "CMAKE_CXX_LINK_EXECUTABLE", replace = True),
+    "CMAKE_C_ARCHIVE_CREATE": struct(value = "CMAKE_C_ARCHIVE_CREATE", replace = False),
+    "CMAKE_C_FLAGS": struct(value = "CMAKE_C_FLAGS_INIT", replace = False),
     "CMAKE_EXE_LINKER_FLAGS": struct(value = "CMAKE_EXE_LINKER_FLAGS_INIT", replace = False),
+    "CMAKE_RANLIB": struct(value = "CMAKE_RANLIB", replace = True),
+    "CMAKE_SHARED_LINKER_FLAGS": struct(value = "CMAKE_SHARED_LINKER_FLAGS_INIT", replace = False),
+    "CMAKE_STATIC_LINKER_FLAGS": struct(value = "CMAKE_STATIC_LINKER_FLAGS_INIT", replace = False),
+    "CMAKE_SYSTEM_NAME": struct(value = "CMAKE_SYSTEM_NAME", replace = True),
 }
 
 def _create_crosstool_file_text(toolchain_dict, user_cache, user_env):

--- a/tools/build_defs/cmake_script.bzl
+++ b/tools/build_defs/cmake_script.bzl
@@ -140,7 +140,7 @@ def _create_crosstool_file_text(toolchain_dict, user_cache, user_env):
         "CMAKE_TOOLCHAIN_FILE": "crosstool_bazel.cmake",
     })
     return struct(
-        commands = ["cat > crosstool_bazel.cmake <<EOF\n" + "\n".join(lines) + "\nEOF\n"],
+        commands = ["cat > crosstool_bazel.cmake <<EOF\n" + "\n".join(sorted(lines)) + "\nEOF\n"],
         env = env_vars,
         cache = cache_entries,
     )

--- a/tools/build_defs/configure.bzl
+++ b/tools/build_defs/configure.bzl
@@ -1,23 +1,23 @@
 # buildifier: disable=module-docstring
-load(
-    "//tools/build_defs:framework.bzl",
-    "CC_EXTERNAL_RULE_ATTRIBUTES",
-    "cc_external_rule_impl",
-    "create_attrs",
-)
-load(
-    "//tools/build_defs:detect_root.bzl",
-    "detect_root",
-)
+load("@rules_foreign_cc//tools/build_defs:shell_script_helper.bzl", "os_name")
 load(
     "//tools/build_defs:cc_toolchain_util.bzl",
     "get_flags_info",
     "get_tools_info",
     "is_debug_mode",
 )
-load(":configure_script.bzl", "create_configure_script")
+load(
+    "//tools/build_defs:detect_root.bzl",
+    "detect_root",
+)
+load(
+    "//tools/build_defs:framework.bzl",
+    "CC_EXTERNAL_RULE_ATTRIBUTES",
+    "cc_external_rule_impl",
+    "create_attrs",
+)
 load("//tools/build_defs/native_tools:tool_access.bzl", "get_make_data")
-load("@rules_foreign_cc//tools/build_defs:shell_script_helper.bzl", "os_name")
+load(":configure_script.bzl", "create_configure_script")
 
 def _configure_make(ctx):
     make_data = get_make_data(ctx)
@@ -85,48 +85,6 @@ def _get_install_prefix(ctx):
 def _attrs():
     attrs = dict(CC_EXTERNAL_RULE_ATTRIBUTES)
     attrs.update({
-        "configure_command": attr.string(
-            doc = (
-                "The name of the configuration script file, default: configure. " +
-                "The file must be in the root of the source directory."
-            ),
-            default = "configure",
-        ),
-        "configure_options": attr.string_list(
-            doc = "Any options to be put on the 'configure' command line.",
-        ),
-        "configure_env_vars": attr.string_dict(
-            doc = "Environment variables to be set for the 'configure' invocation.",
-        ),
-        "install_prefix": attr.string(
-            doc = (
-                "Install prefix, i.e. relative path to where to install the result of the build. " +
-                "Passed to the 'configure' script with --prefix flag."
-            ),
-            mandatory = False,
-        ),
-        "configure_in_place": attr.bool(
-            doc = (
-                "Set to True if 'configure' should be invoked in place, i.e. from its enclosing " +
-                "directory."
-            ),
-            mandatory = False,
-            default = False,
-        ),
-        "autoreconf": attr.bool(
-            doc = (
-                "Set to True if 'autoreconf' should be invoked before 'configure.', " +
-                "currently requires 'configure_in_place' to be True."
-            ),
-            mandatory = False,
-            default = False,
-        ),
-        "autoreconf_options": attr.string_list(
-            doc = "Any options to be put in the 'autoreconf.sh' command line.",
-        ),
-        "autoreconf_env_vars": attr.string_dict(
-            doc = "Environment variables to be set for 'autoreconf' invocation.",
-        ),
         "autoconf": attr.bool(
             mandatory = False,
             default = False,
@@ -135,11 +93,11 @@ def _attrs():
                 "currently requires 'configure_in_place' to be True."
             ),
         ),
-        "autoconf_options": attr.string_list(
-            doc = "Any options to be put in the 'autoconf.sh' command line.",
-        ),
         "autoconf_env_vars": attr.string_dict(
             doc = "Environment variables to be set for 'autoconf' invocation.",
+        ),
+        "autoconf_options": attr.string_list(
+            doc = "Any options to be put in the 'autoconf.sh' command line.",
         ),
         "autogen": attr.bool(
             doc = (
@@ -157,11 +115,53 @@ def _attrs():
             ),
             default = "autogen.sh",
         ),
+        "autogen_env_vars": attr.string_dict(
+            doc = "Environment variables to be set for 'autogen' invocation.",
+        ),
         "autogen_options": attr.string_list(
             doc = "Any options to be put in the 'autogen.sh' command line.",
         ),
-        "autogen_env_vars": attr.string_dict(
-            doc = "Environment variables to be set for 'autogen' invocation.",
+        "autoreconf": attr.bool(
+            doc = (
+                "Set to True if 'autoreconf' should be invoked before 'configure.', " +
+                "currently requires 'configure_in_place' to be True."
+            ),
+            mandatory = False,
+            default = False,
+        ),
+        "autoreconf_env_vars": attr.string_dict(
+            doc = "Environment variables to be set for 'autoreconf' invocation.",
+        ),
+        "autoreconf_options": attr.string_list(
+            doc = "Any options to be put in the 'autoreconf.sh' command line.",
+        ),
+        "configure_command": attr.string(
+            doc = (
+                "The name of the configuration script file, default: configure. " +
+                "The file must be in the root of the source directory."
+            ),
+            default = "configure",
+        ),
+        "configure_env_vars": attr.string_dict(
+            doc = "Environment variables to be set for the 'configure' invocation.",
+        ),
+        "configure_in_place": attr.bool(
+            doc = (
+                "Set to True if 'configure' should be invoked in place, i.e. from its enclosing " +
+                "directory."
+            ),
+            mandatory = False,
+            default = False,
+        ),
+        "configure_options": attr.string_list(
+            doc = "Any options to be put on the 'configure' command line.",
+        ),
+        "install_prefix": attr.string(
+            doc = (
+                "Install prefix, i.e. relative path to where to install the result of the build. " +
+                "Passed to the 'configure' script with --prefix flag."
+            ),
+            mandatory = False,
         ),
     })
     return attrs

--- a/tools/build_defs/configure_script.bzl
+++ b/tools/build_defs/configure_script.bzl
@@ -181,18 +181,18 @@ def _define_deps_flags(deps, inputs):
 
 # See https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html
 _CONFIGURE_FLAGS = {
-    "CFLAGS": "cc",
-    "CXXFLAGS": "cxx",
     "ARFLAGS": "cxx_linker_static",
     "ASFLAGS": "assemble",
+    "CFLAGS": "cc",
+    "CXXFLAGS": "cxx",
     "LDFLAGS": "cxx_linker_executable",
     # missing: cxx_linker_shared
 }
 
 _CONFIGURE_TOOLS = {
+    "AR": "cxx_linker_static",
     "CC": "cc",
     "CXX": "cxx",
-    "AR": "cxx_linker_static",
     # missing: cxx_linker_executable
 }
 

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -3,14 +3,7 @@
 """
 
 load("@bazel_skylib//lib:collections.bzl", "collections")
-load("@rules_foreign_cc//tools/build_defs:version.bzl", "VERSION")
-load(
-    ":cc_toolchain_util.bzl",
-    "LibrariesToLinkInfo",
-    "create_linking_info",
-    "get_env_vars",
-    "targets_windows",
-)
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("@rules_foreign_cc//tools/build_defs:detect_root.bzl", "detect_root", "filter_containing_dirs_from_inputs")
 load(
     "@rules_foreign_cc//tools/build_defs:run_shell_file_utils.bzl",
@@ -23,7 +16,14 @@ load(
     "create_function",
     "os_name",
 )
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@rules_foreign_cc//tools/build_defs:version.bzl", "VERSION")
+load(
+    ":cc_toolchain_util.bzl",
+    "LibrariesToLinkInfo",
+    "create_linking_info",
+    "get_env_vars",
+    "targets_windows",
+)
 
 # Dict with definitions of the context attributes, that customize cc_external_rule_impl function.
 # Many of the attributes have default values.
@@ -32,31 +32,6 @@ load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 # description dict. See cmake.bzl as an example.
 #
 CC_EXTERNAL_RULE_ATTRIBUTES = {
-    "lib_name": attr.string(
-        doc = (
-            "Library name. Defines the name of the install directory and the name of the static library, " +
-            "if no output files parameters are defined (any of static_libraries, shared_libraries, " +
-            "interface_libraries, binaries_names) " +
-            "Optional. If not defined, defaults to the target's name."
-        ),
-        mandatory = False,
-    ),
-    "lib_source": attr.label(
-        doc = (
-            "Label with source code to build. Typically a filegroup for the source of remote repository. " +
-            "Mandatory."
-        ),
-        mandatory = True,
-        allow_files = True,
-    ),
-    "defines": attr.string_list(
-        doc = (
-            "Optional compilation definitions to be passed to the dependencies of this library. " +
-            "They are NOT passed to the compiler, you should duplicate them in the configuration options."
-        ),
-        mandatory = False,
-        default = [],
-    ),
     "additional_inputs": attr.label_list(
         doc = (
             "Optional additional inputs to be declared as needed for the shell script action." +
@@ -75,14 +50,31 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
         allow_files = True,
         default = [],
     ),
-    "postfix_script": attr.string(
-        doc = "Optional part of the shell script to be added after the make commands",
+    "alwayslink": attr.bool(
+        doc = (
+            "Optional. if true, link all the object files from the static library, " +
+            "even if they are not used."
+        ),
+        mandatory = False,
+        default = False,
+    ),
+    "binaries": attr.string_list(
+        doc = "Optional names of the resulting binaries.",
         mandatory = False,
     ),
-    "make_commands": attr.string_list(
-        doc = "Optinal make commands, defaults to [\"make\", \"make install\"]",
+    "data": attr.label_list(
+        doc = "Files needed by this rule at runtime. May list file or rule targets. Generally allows any target.",
         mandatory = False,
-        default = ["make", "make install"],
+        allow_files = True,
+        default = [],
+    ),
+    "defines": attr.string_list(
+        doc = (
+            "Optional compilation definitions to be passed to the dependencies of this library. " +
+            "They are NOT passed to the compiler, you should duplicate them in the configuration options."
+        ),
+        mandatory = False,
+        default = [],
     ),
     "deps": attr.label_list(
         doc = (
@@ -95,21 +87,46 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
         allow_files = True,
         default = [],
     ),
-    "data": attr.label_list(
-        doc = "Files needed by this rule at runtime. May list file or rule targets. Generally allows any target.",
+    "headers_only": attr.bool(
+        doc = "Flag variable to indicate that the library produces only headers",
         mandatory = False,
-        allow_files = True,
-        default = [],
+        default = False,
     ),
-    "tools_deps": attr.label_list(
+    "interface_libraries": attr.string_list(
+        doc = "Optional names of the resulting interface libraries.",
+        mandatory = False,
+    ),
+    "lib_name": attr.string(
         doc = (
-            "Optional tools to be copied into the directory structure. " +
-            "Similar to deps, those directly required for the external building of the library/binaries."
+            "Library name. Defines the name of the install directory and the name of the static library, " +
+            "if no output files parameters are defined (any of static_libraries, shared_libraries, " +
+            "interface_libraries, binaries_names) " +
+            "Optional. If not defined, defaults to the target's name."
         ),
         mandatory = False,
+    ),
+    "lib_source": attr.label(
+        doc = (
+            "Label with source code to build. Typically a filegroup for the source of remote repository. " +
+            "Mandatory."
+        ),
+        mandatory = True,
         allow_files = True,
-        cfg = "host",
+    ),
+    "linkopts": attr.string_list(
+        doc = "Optional link options to be passed up to the dependencies of this library",
+        mandatory = False,
         default = [],
+    ),
+    "make_commands": attr.string_list(
+        doc = "Optinal make commands, defaults to [\"make\", \"make install\"]",
+        mandatory = False,
+        default = ["make", "make install"],
+    ),
+    "out_bin_dir": attr.string(
+        doc = "Optional name of the output subdirectory with the binary files, defaults to 'bin'.",
+        mandatory = False,
+        default = "bin",
     ),
     "out_include_dir": attr.string(
         doc = "Optional name of the output subdirectory with the header files, defaults to 'include'.",
@@ -121,23 +138,13 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
         mandatory = False,
         default = "lib",
     ),
-    "out_bin_dir": attr.string(
-        doc = "Optional name of the output subdirectory with the binary files, defaults to 'bin'.",
+    "postfix_script": attr.string(
+        doc = "Optional part of the shell script to be added after the make commands",
         mandatory = False,
-        default = "bin",
     ),
-    "alwayslink": attr.bool(
-        doc = (
-            "Optional. if true, link all the object files from the static library, " +
-            "even if they are not used."
-        ),
+    "shared_libraries": attr.string_list(
+        doc = "Optional names of the resulting shared libraries.",
         mandatory = False,
-        default = False,
-    ),
-    "linkopts": attr.string_list(
-        doc = "Optional link options to be passed up to the dependencies of this library",
-        mandatory = False,
-        default = [],
     ),
     #
     # Output files names parameters. If any of them is defined, only these files are passed to
@@ -148,22 +155,15 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
         doc = "Optional names of the resulting static libraries.",
         mandatory = False,
     ),
-    "shared_libraries": attr.string_list(
-        doc = "Optional names of the resulting shared libraries.",
+    "tools_deps": attr.label_list(
+        doc = (
+            "Optional tools to be copied into the directory structure. " +
+            "Similar to deps, those directly required for the external building of the library/binaries."
+        ),
         mandatory = False,
-    ),
-    "interface_libraries": attr.string_list(
-        doc = "Optional names of the resulting interface libraries.",
-        mandatory = False,
-    ),
-    "binaries": attr.string_list(
-        doc = "Optional names of the resulting binaries.",
-        mandatory = False,
-    ),
-    "headers_only": attr.bool(
-        doc = "Flag variable to indicate that the library produces only headers",
-        mandatory = False,
-        default = False,
+        allow_files = True,
+        cfg = "host",
+        default = [],
     ),
     # we need to declare this attribute to access cc_toolchain
     "_cc_toolchain": attr.label(
@@ -210,10 +210,10 @@ Serves to pass transitive information about externally built artifacts up the de
 Can not be used as a top-level provider.
 Instances of ForeignCcArtifact are incapsulated in a depset ForeignCcDeps#artifacts.""",
     fields = {
-        "gen_dir": "Install directory",
         "bin_dir_name": "Bin directory, relative to install directory",
-        "lib_dir_name": "Lib directory, relative to install directory",
+        "gen_dir": "Install directory",
         "include_dir_name": "Include directory, relative to install directory",
+        "lib_dir_name": "Lib directory, relative to install directory",
     },
 )
 
@@ -415,10 +415,10 @@ def cc_external_rule_impl(ctx, attrs):
 WrappedOutputs = provider(
     doc = "Structure for passing the log and scripts file information, and wrapper script text.",
     fields = {
-        "script_file": "Main script file",
         "log_file": "Execution log file",
-        "wrapper_script_file": "Wrapper script file (output for debugging purposes)",
+        "script_file": "Main script file",
         "wrapper_script": "Wrapper script text to execute",
+        "wrapper_script_file": "Wrapper script file (output for debugging purposes)",
     },
 )
 

--- a/tools/build_defs/make.bzl
+++ b/tools/build_defs/make.bzl
@@ -1,21 +1,21 @@
 # buildifier: disable=module-docstring
 load(
-    "//tools/build_defs:framework.bzl",
-    "CC_EXTERNAL_RULE_ATTRIBUTES",
-    "cc_external_rule_impl",
-    "create_attrs",
+    "//tools/build_defs:cc_toolchain_util.bzl",
+    "get_flags_info",
+    "get_tools_info",
 )
 load(
     "//tools/build_defs:detect_root.bzl",
     "detect_root",
 )
 load(
-    "//tools/build_defs:cc_toolchain_util.bzl",
-    "get_flags_info",
-    "get_tools_info",
+    "//tools/build_defs:framework.bzl",
+    "CC_EXTERNAL_RULE_ATTRIBUTES",
+    "cc_external_rule_impl",
+    "create_attrs",
 )
-load(":configure_script.bzl", "create_make_script")
 load("//tools/build_defs/native_tools:tool_access.bzl", "get_make_data")
+load(":configure_script.bzl", "create_make_script")
 
 def _make(ctx):
     make_data = get_make_data(ctx)
@@ -75,6 +75,23 @@ def _get_install_prefix(ctx):
 def _attrs():
     attrs = dict(CC_EXTERNAL_RULE_ATTRIBUTES)
     attrs.update({
+        "keep_going": attr.bool(
+            doc = (
+                "Keep going when some targets can not be made, -k flag is passed to make " +
+                "(applies only if make_commands attribute is not set). " +
+                "Please have a look at _create_make_script for default make_commands."
+            ),
+            mandatory = False,
+            default = True,
+        ),
+        "make_commands": attr.string_list(
+            doc = (
+                "Overriding make_commands default value to be empty, " +
+                "then we can provide better default value programmatically "
+            ),
+            mandatory = False,
+            default = [],
+        ),
         "make_env_vars": attr.string_dict(
             doc = "Environment variables to be set for the 'configure' invocation.",
         ),
@@ -89,23 +106,6 @@ def _attrs():
                 "execution root with \"BAZEL_GEN_ROOT\" value."
             ),
             mandatory = False,
-        ),
-        "make_commands": attr.string_list(
-            doc = (
-                "Overriding make_commands default value to be empty, " +
-                "then we can provide better default value programmatically "
-            ),
-            mandatory = False,
-            default = [],
-        ),
-        "keep_going": attr.bool(
-            doc = (
-                "Keep going when some targets can not be made, -k flag is passed to make " +
-                "(applies only if make_commands attribute is not set). " +
-                "Please have a look at _create_make_script for default make_commands."
-            ),
-            mandatory = False,
-            default = True,
         ),
     })
     return attrs

--- a/tools/build_defs/native_tools/BUILD
+++ b/tools/build_defs/native_tools/BUILD
@@ -1,8 +1,8 @@
-load(":native_tools_toolchain.bzl", "native_tool_toolchain")
-load("//for_workspace:make_build.bzl", "make_tool")
-load("//for_workspace:cmake_build.bzl", "cmake_tool")
-load("//for_workspace:ninja_build.bzl", "ninja_tool")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("//for_workspace:cmake_build.bzl", "cmake_tool")
+load("//for_workspace:make_build.bzl", "make_tool")
+load("//for_workspace:ninja_build.bzl", "ninja_tool")
+load(":native_tools_toolchain.bzl", "native_tool_toolchain")
 
 native_tool_toolchain(
     name = "preinstalled_make",

--- a/tools/build_defs/shell_toolchain/polymorphism/generate_overloads.bzl
+++ b/tools/build_defs/shell_toolchain/polymorphism/generate_overloads.bzl
@@ -82,7 +82,7 @@ def _generate_overloads(rctx):
 generate_overloads = repository_rule(
     implementation = _generate_overloads,
     attrs = {
-        "symbols": attr.string_list(),
         "files": attr.label_list(),
+        "symbols": attr.string_list(),
     },
 )

--- a/tools/build_defs/shell_toolchain/toolchains/BUILD
+++ b/tools/build_defs/shell_toolchain/toolchains/BUILD
@@ -1,5 +1,5 @@
-load(":defs.bzl", "build_part")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load(":defs.bzl", "build_part")
 
 toolchain_type(
     name = "shell_commands",

--- a/tools/build_defs/shell_toolchain/toolchains/commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/commands.bzl
@@ -10,89 +10,36 @@ CommandInfo = provider(
 ArgumentInfo = provider(
     doc = "",
     fields = {
+        "doc": "",
         "name": "",
         "type_": "",
-        "doc": "",
     },
 )
 
 PLATFORM_COMMANDS = {
-    "os_name": CommandInfo(
+    "assert_script_errors": CommandInfo(
         arguments = [],
-        doc = "Returns OS name",
+        doc = "Script fragment that stops the execution after any error",
     ),
-    "pwd": CommandInfo(
-        arguments = [],
-        doc = "Returns command for getting current directory.",
-    ),
-    "echo": CommandInfo(
-        arguments = [ArgumentInfo(name = "text", type_ = type(""), doc = "Text to output")],
-        doc = "Outputs 'text' to stdout",
-    ),
-    "export_var": CommandInfo(
+    "cat": CommandInfo(
         arguments = [
-            ArgumentInfo(name = "name", type_ = type(""), doc = "Variable name"),
-            ArgumentInfo(name = "value", type_ = type(""), doc = "Variable value"),
+            ArgumentInfo(name = "filepath", type_ = type(""), doc = "Path to the file"),
         ],
-        doc = "Defines and exports environment variable.",
+        doc = "Output the file contents to stdout",
     ),
-    "local_var": CommandInfo(
+    "children_to_path": CommandInfo(
         arguments = [
-            ArgumentInfo(name = "name", type_ = type(""), doc = "Variable name"),
-            ArgumentInfo(name = "value", type_ = type(""), doc = "Variable value"),
+            ArgumentInfo(name = "dir_", type_ = type(""), doc = "Directory"),
         ],
-        doc = "Defines local shell variable.",
+        doc = "Put all immediate subdirectories (and symlinks) into PATH",
     ),
-    "use_var": CommandInfo(
+    "cleanup_function": CommandInfo(
         arguments = [
-            ArgumentInfo(name = "name", type_ = type(""), doc = "Variable name"),
+            ArgumentInfo(name = "on_success", type_ = type(""), doc = "Command(s) to be executed on success"),
+            ArgumentInfo(name = "on_failure", type_ = type(""), doc = "Command(s) to be executed on failure"),
         ],
-        doc = "Expression to address the variable.",
-    ),
-    "env": CommandInfo(
-        arguments = [],
-        doc = "Print all environment variables",
-    ),
-    "path": CommandInfo(
-        arguments = [
-            ArgumentInfo(name = "expression", type_ = type(""), doc = "Path"),
-        ],
-        doc = "Adds passed arguments in the beginning of the PATH.",
-    ),
-    "touch": CommandInfo(
-        arguments = [ArgumentInfo(name = "path", type_ = type(""), doc = "Path to file")],
-        doc = "Creates a file",
-    ),
-    "mkdirs": CommandInfo(
-        arguments = [ArgumentInfo(name = "path", type_ = type(""), doc = "Path to directory")],
-        doc = "Creates a directory and, if neccesary, it's parents",
-    ),
-    "tmpdir": CommandInfo(
-        doc = "Creates a temp directory",
-        arguments = [],
-    ),
-    "if_else": CommandInfo(
-        doc = "Creates if-else construct",
-        arguments = [
-            ArgumentInfo(name = "condition", type_ = type(""), doc = "Condition text"),
-            ArgumentInfo(name = "if_text", type_ = type(""), doc = "If block text"),
-            ArgumentInfo(name = "else_text", type_ = type(""), doc = "Else block text"),
-        ],
-    ),
-    "define_function": CommandInfo(
-        arguments = [
-            ArgumentInfo(name = "name", type_ = type(""), doc = "Function name"),
-            ArgumentInfo(name = "text", type_ = type(""), doc = "Function body"),
-        ],
-        doc = "Defines a function with 'text' as the function body.",
-    ),
-    "replace_in_files": CommandInfo(
-        arguments = [
-            ArgumentInfo(name = "dir_", type_ = type(""), doc = "Directory to search recursively"),
-            ArgumentInfo(name = "from_", type_ = type(""), doc = "String to be replaced"),
-            ArgumentInfo(name = "to_", type_ = type(""), doc = "Replace target"),
-        ],
-        doc = "Replaces all occurrences of 'from_' to 'to_' recursively in the directory 'dir'.",
+        doc = "Trap function called after the script is finished",
+        #        doc = "Read the result of the execution of the previous command, execute success or failure callbacks",
     ),
     "copy_dir_contents_to_dir": CommandInfo(
         arguments = [
@@ -104,6 +51,107 @@ PLATFORM_COMMANDS = {
             ArgumentInfo(name = "target", type_ = type(""), doc = "Target directory"),
         ],
         doc = "Copies contents of the directory to target directory",
+    ),
+    "define_absolute_paths": CommandInfo(
+        arguments = [
+            ArgumentInfo(name = "dir_", type_ = type(""), doc = "Directory where to replace"),
+            ArgumentInfo(name = "abs_path", type_ = type(""), doc = "Absolute path value"),
+        ],
+        doc = "Replaces absolute path placeholder inside 'dir_' with a provided value 'abs_path'",
+    ),
+    "define_function": CommandInfo(
+        arguments = [
+            ArgumentInfo(name = "name", type_ = type(""), doc = "Function name"),
+            ArgumentInfo(name = "text", type_ = type(""), doc = "Function body"),
+        ],
+        doc = "Defines a function with 'text' as the function body.",
+    ),
+    "echo": CommandInfo(
+        arguments = [ArgumentInfo(name = "text", type_ = type(""), doc = "Text to output")],
+        doc = "Outputs 'text' to stdout",
+    ),
+    "env": CommandInfo(
+        arguments = [],
+        doc = "Print all environment variables",
+    ),
+    "export_var": CommandInfo(
+        arguments = [
+            ArgumentInfo(name = "name", type_ = type(""), doc = "Variable name"),
+            ArgumentInfo(name = "value", type_ = type(""), doc = "Variable value"),
+        ],
+        doc = "Defines and exports environment variable.",
+    ),
+    "if_else": CommandInfo(
+        doc = "Creates if-else construct",
+        arguments = [
+            ArgumentInfo(name = "condition", type_ = type(""), doc = "Condition text"),
+            ArgumentInfo(name = "if_text", type_ = type(""), doc = "If block text"),
+            ArgumentInfo(name = "else_text", type_ = type(""), doc = "Else block text"),
+        ],
+    ),
+    "increment_pkg_config_path": CommandInfo(
+        arguments = [
+            ArgumentInfo(
+                name = "source",
+                type_ = type(""),
+                doc = "Source directory",
+            ),
+        ],
+        doc = (
+            "Find subdirectory inside a passed directory with *.pc files and add it " +
+            "to the PKG_CONFIG_PATH"
+        ),
+    ),
+    "local_var": CommandInfo(
+        arguments = [
+            ArgumentInfo(name = "name", type_ = type(""), doc = "Variable name"),
+            ArgumentInfo(name = "value", type_ = type(""), doc = "Variable value"),
+        ],
+        doc = "Defines local shell variable.",
+    ),
+    "mkdirs": CommandInfo(
+        arguments = [ArgumentInfo(name = "path", type_ = type(""), doc = "Path to directory")],
+        doc = "Creates a directory and, if neccesary, it's parents",
+    ),
+    "os_name": CommandInfo(
+        arguments = [],
+        doc = "Returns OS name",
+    ),
+    "path": CommandInfo(
+        arguments = [
+            ArgumentInfo(name = "expression", type_ = type(""), doc = "Path"),
+        ],
+        doc = "Adds passed arguments in the beginning of the PATH.",
+    ),
+    "pwd": CommandInfo(
+        arguments = [],
+        doc = "Returns command for getting current directory.",
+    ),
+    "redirect_out_err": CommandInfo(
+        arguments = [
+            ArgumentInfo(name = "from_process", type_ = type(""), doc = "Process to run"),
+            ArgumentInfo(name = "to_file", type_ = type(""), doc = "File to redirect output to"),
+        ],
+        doc = "Read the result of the execution of the previous command, execute success or failure callbacks",
+    ),
+    "replace_absolute_paths": CommandInfo(
+        arguments = [
+            ArgumentInfo(name = "dir_", type_ = type(""), doc = "Directory where to replace"),
+            ArgumentInfo(name = "abs_path", type_ = type(""), doc = "Absolute path value"),
+        ],
+        doc = "Replaces absolute path 'abs_path' inside 'dir_' with a placeholder value",
+    ),
+    "replace_in_files": CommandInfo(
+        arguments = [
+            ArgumentInfo(name = "dir_", type_ = type(""), doc = "Directory to search recursively"),
+            ArgumentInfo(name = "from_", type_ = type(""), doc = "String to be replaced"),
+            ArgumentInfo(name = "to_", type_ = type(""), doc = "Replace target"),
+        ],
+        doc = "Replaces all occurrences of 'from_' to 'to_' recursively in the directory 'dir'.",
+    ),
+    "script_prelude": CommandInfo(
+        arguments = [],
+        doc = "Function for setting necessary environment variables for the platform",
     ),
     "symlink_contents_to_dir": CommandInfo(
         arguments = [
@@ -133,66 +181,18 @@ PLATFORM_COMMANDS = {
             "NB symlinks from the source directory are copied."
         ),
     ),
-    "script_prelude": CommandInfo(
+    "tmpdir": CommandInfo(
+        doc = "Creates a temp directory",
         arguments = [],
-        doc = "Function for setting necessary environment variables for the platform",
     ),
-    "increment_pkg_config_path": CommandInfo(
+    "touch": CommandInfo(
+        arguments = [ArgumentInfo(name = "path", type_ = type(""), doc = "Path to file")],
+        doc = "Creates a file",
+    ),
+    "use_var": CommandInfo(
         arguments = [
-            ArgumentInfo(
-                name = "source",
-                type_ = type(""),
-                doc = "Source directory",
-            ),
+            ArgumentInfo(name = "name", type_ = type(""), doc = "Variable name"),
         ],
-        doc = (
-            "Find subdirectory inside a passed directory with *.pc files and add it " +
-            "to the PKG_CONFIG_PATH"
-        ),
-    ),
-    "assert_script_errors": CommandInfo(
-        arguments = [],
-        doc = "Script fragment that stops the execution after any error",
-    ),
-    "cat": CommandInfo(
-        arguments = [
-            ArgumentInfo(name = "filepath", type_ = type(""), doc = "Path to the file"),
-        ],
-        doc = "Output the file contents to stdout",
-    ),
-    "redirect_out_err": CommandInfo(
-        arguments = [
-            ArgumentInfo(name = "from_process", type_ = type(""), doc = "Process to run"),
-            ArgumentInfo(name = "to_file", type_ = type(""), doc = "File to redirect output to"),
-        ],
-        doc = "Read the result of the execution of the previous command, execute success or failure callbacks",
-    ),
-    "cleanup_function": CommandInfo(
-        arguments = [
-            ArgumentInfo(name = "on_success", type_ = type(""), doc = "Command(s) to be executed on success"),
-            ArgumentInfo(name = "on_failure", type_ = type(""), doc = "Command(s) to be executed on failure"),
-        ],
-        doc = "Trap function called after the script is finished",
-        #        doc = "Read the result of the execution of the previous command, execute success or failure callbacks",
-    ),
-    "children_to_path": CommandInfo(
-        arguments = [
-            ArgumentInfo(name = "dir_", type_ = type(""), doc = "Directory"),
-        ],
-        doc = "Put all immediate subdirectories (and symlinks) into PATH",
-    ),
-    "define_absolute_paths": CommandInfo(
-        arguments = [
-            ArgumentInfo(name = "dir_", type_ = type(""), doc = "Directory where to replace"),
-            ArgumentInfo(name = "abs_path", type_ = type(""), doc = "Absolute path value"),
-        ],
-        doc = "Replaces absolute path placeholder inside 'dir_' with a provided value 'abs_path'",
-    ),
-    "replace_absolute_paths": CommandInfo(
-        arguments = [
-            ArgumentInfo(name = "dir_", type_ = type(""), doc = "Directory where to replace"),
-            ArgumentInfo(name = "abs_path", type_ = type(""), doc = "Absolute path value"),
-        ],
-        doc = "Replaces absolute path 'abs_path' inside 'dir_' with a placeholder value",
+        doc = "Expression to address the variable.",
     ),
 }

--- a/tools/build_defs/shell_toolchain/toolchains/defs.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/defs.bzl
@@ -1,10 +1,10 @@
 # buildifier: disable=module-docstring
+load("@commands_overloads//:toolchain_data_defs.bzl", "get")
 load(
     "//tools/build_defs/shell_toolchain/polymorphism:generate_overloads.bzl",
     "get_file_name",
 )
 load(":toolchain_mappings.bzl", "TOOLCHAIN_MAPPINGS")
-load("@commands_overloads//:toolchain_data_defs.bzl", "get")
 
 def _toolchain_data(ctx):
     return platform_common.ToolchainInfo(data = get(ctx.attr.file_name))

--- a/tools/build_defs/shell_toolchain/toolchains/function_and_call.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/function_and_call.bzl
@@ -3,7 +3,7 @@
 FunctionAndCall = provider(
     doc = "Wrapper to pass function definition and (if custom) function call",
     fields = {
-        "text": "Function body, without wrapping function <name>() {} fragment.",
         "call": "How to call defined function, if different from <function-name> <arg1> ...<argn>",
+        "text": "Function body, without wrapping function <name>() {} fragment.",
     },
 )

--- a/tools/build_defs/shell_toolchain/toolchains/toolchain_mappings.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/toolchain_mappings.bzl
@@ -3,8 +3,8 @@
 ToolchainMapping = provider(
     doc = "Mapping of toolchain definition files to platform constraints",
     fields = {
-        "file": "Toolchain definition file",
         "exec_compatible_with": "Compatible execution platform constraints",
+        "file": "Toolchain definition file",
         "target_compatible_with": "Compatible target platform constraints",
     },
 )


### PR DESCRIPTION
Fixed all buildifier defects and updated CI to enforce changes remain buildifier compliant.

Users can run `buildifier -lint=fix -mode=fix -warnings=all -r ./` to make sure their changes are buildifier compliant