### PR TITLE
Fixed incorrect detection of lib_source root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,4 +79,6 @@ fabric.properties
 /bazel-*
 /docs/bazel-*
 /examples/bazel-*
+/test/detect_root_test/bazel-*
+/test/standard_cxx_flags_test/bazel-*
 .ijwb/

--- a/examples/cmake_working_dir/BUILD
+++ b/examples/cmake_working_dir/BUILD
@@ -3,10 +3,7 @@ load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
 
 filegroup(
     name = "sources",
-    srcs = glob(
-        ["source_root/**"],
-        exclude_directories = 0,
-    ),
+    srcs = glob(["source_root/**"]),
 )
 
 cmake_external(

--- a/examples/cmake_working_dir/source_root/.keep
+++ b/examples/cmake_working_dir/source_root/.keep
@@ -1,0 +1,3 @@
+# This file must exist so Bazel will detect that `source_root` is the highest level
+# directory for `cmake_working_dir`, thus enabling the `working_directory` to take
+# effect and use `cmake_dir` as the working directory.

--- a/test/BUILD
+++ b/test/BUILD
@@ -47,18 +47,12 @@ diff_test(
 
 filegroup(
     name = "dir1_fg",
-    srcs = glob(
-        ["dir1/**"],
-        exclude_directories = 0,
-    ),
+    srcs = glob(["dir1/**"]),
 )
 
 filegroup(
     name = "dir2_fg",
-    srcs = glob(
-        ["dir2/**"],
-        exclude_directories = 0,
-    ),
+    srcs = glob(["dir2/**"]),
 )
 
 symlink_contents_to_dir_test_rule(

--- a/test/detect_root_test/BUILD
+++ b/test/detect_root_test/BUILD
@@ -5,7 +5,6 @@ filegroup(
     name = "fg",
     srcs = glob(
         ["dir1/**"],
-        exclude_directories = 0,
     ),
 )
 
@@ -13,7 +12,6 @@ filegroup(
     name = "fg_srcs",
     srcs = glob(
         ["dir1/srcs/**"],
-        exclude_directories = 0,
     ),
 )
 
@@ -31,7 +29,7 @@ detect_root_test_rule(
 
 detect_root_test_rule(
     name = "srcs_in_repo",
-    srcs = "@repo//:srcs",
+    srcs = "@rules_foreign_cc_detect_root_test_repo//:srcs",
     out = "out_repo.txt",
 )
 

--- a/test/detect_root_test/WORKSPACE
+++ b/test/detect_root_test/WORKSPACE
@@ -1,3 +1,5 @@
+workspace(name = "rules_foreign_cc_detect_root_test")
+
 # We do not initialize rules_foreign_cc, because we only need to access
 # detect_root.bzl file from them.
 local_repository(
@@ -9,10 +11,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "bazel_skylib",
-    sha256 = "97e70364e9249702246c0e9444bccdc4b847bed1eb03c5a3ece4f83dfe6abc44",
+    sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
     ],
 )
 
@@ -21,9 +23,13 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 bazel_skylib_workspace()
 
 new_local_repository(
-    name = "repo",
-    build_file_content =
-        """filegroup(name = "srcs", srcs = glob(["**/**"]),
-  visibility=["//visibility:public"])""",
+    name = "rules_foreign_cc_detect_root_test_repo",
+    build_file_content = """\
+filegroup(
+    name = "srcs", 
+    srcs = glob(["**/**"]),
+    visibility = ["//visibility:public"],
+)
+""",
     path = "dir1",
 )

--- a/test/detect_root_test/expected/out_fg.txt
+++ b/test/detect_root_test/expected/out_fg.txt
@@ -1,1 +1,1 @@
-dir1
+dir1/srcs

--- a/test/detect_root_test/expected/out_repo.txt
+++ b/test/detect_root_test/expected/out_repo.txt
@@ -1,1 +1,1 @@
-external/repo
+external/rules_foreign_cc_detect_root_test_repo

--- a/test/expected/out_symlinked_dirs.txt
+++ b/test/expected/out_symlinked_dirs.txt
@@ -1,6 +1,3 @@
 aaa:
-include
-
-aaa/include:
 header1.h
 header2.h

--- a/test/expected/out_symlinked_dirs_osx.txt
+++ b/test/expected/out_symlinked_dirs_osx.txt
@@ -1,5 +1,2 @@
-include
-
-aaa/include:
 header1.h
 header2.h

--- a/tools/build_defs/detect_root.bzl
+++ b/tools/build_defs/detect_root.bzl
@@ -1,41 +1,58 @@
 # buildifier: disable=module-docstring
 # buildifier: disable=function-docstring-header
-# buildifier: disable=function-docstring-args
-# buildifier: disable=function-docstring-return
 def detect_root(source):
     """Detects the path to the topmost directory of the 'source' outputs.
     To be used with external build systems to point to the source code/tools directories.
+
+    Args:
+        source (Target): A filegroup of source files
+
+    Returns:
+        string: The relative path to the root source directory
     """
 
-    root = ""
     sources = source.files.to_list()
-    if (root and len(root) > 0) or len(sources) == 0:
-        return root
+    if len(sources) == 0:
+        return ""
 
-    root = ""
+    root = None
     level = -1
-    num_at_level = 0
 
     # find topmost directory
     for file in sources:
         file_level = _get_level(file.path)
+
+        # If there is no level set or the current file's level
+        # is greather than what we have logged, update the root
         if level == -1 or level > file_level:
-            root = file.path
+            root = file
             level = file_level
-            num_at_level = 1
-        elif level == file_level:
-            num_at_level += 1
 
-    if num_at_level == 1:
-        return root
+    if not root:
+        fail("No root source or directory was found")
 
-    (before, sep, after) = root.rpartition("/")
-    if before and sep and after:
-        return before
-    return root
+    if root.is_source:
+        return root.dirname
+
+    # If the root is not a source file, it must be a directory.
+    # Thus the path is returned
+    return root.path
 
 def _get_level(path):
+    """Determine the number of sub directories `path` is contained in
+
+    Args:
+        path (string): The target path
+
+    Returns:
+        int: The directory depth of `path`
+    """
     normalized = path
+
+    # This for loop ensures there are no double `//` substrings.
+    # A for loop is used because there's not currently a `while`
+    # or a better mechanism for guaranteeing all `//` have been
+    # cleaned up.
     for i in range(len(path)):
         new_normalized = normalized.replace("//", "/")
         if len(new_normalized) == len(normalized):


### PR DESCRIPTION
This fixes some inconsistent behavior I was seeing in how the source root was detected. Using `exclude_directories=0` on [glob](https://docs.bazel.build/versions/master/be/functions.html#glob) returns incorrect results in that directories will have [File.is_source](https://docs.bazel.build/versions/master/skylark/lib/File.html#is_source) set to `True`. This should be `False` and [File.is_directory](https://docs.bazel.build/versions/master/skylark/lib/File.html#is_directory) should be `True` instead.

The original implementation seems to have been introduced in https://github.com/bazelbuild/rules_foreign_cc/pull/57 and seemed to try and account for the use of `exclude_directories=0` without the correct [File.is_directory](https://docs.bazel.build/versions/master/skylark/lib/File.html#is_directory) behavior. I would rather file an upstream bug and have this setup to use the correct behavior so users don't run into unexpected behavior.