### PR TITLE
Propagate defines into CFLAGS and CXXFLAGS passed to the framework

### DIFF
--- a/.bazelci/config.yaml
+++ b/.bazelci/config.yaml
@@ -27,6 +27,7 @@ tasks:
     working_directory: examples
     build_targets:
       - "//cmake_android:app"
+      - "//cmake_defines:all"
     test_targets:
       - "//:tests"
   ubuntu1804_examples:
@@ -35,6 +36,7 @@ tasks:
     working_directory: examples
     build_targets:
       - "//cmake_android:app"
+      - "//cmake_defines:all"
     test_targets:
       - "//:tests_no_synthetic"
   macos_examples:
@@ -43,6 +45,7 @@ tasks:
     working_directory: examples
     build_targets:
       - "//cmake_android:app"
+      - "//cmake_defines:all"
     test_targets:
       - "//:mac_tests"
   windows_examples:

--- a/examples/cmake_defines/BUILD
+++ b/examples/cmake_defines/BUILD
@@ -1,0 +1,25 @@
+load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+
+cmake_external(
+    name = "lib_a",
+    lib_source = ":lib_a_sources",
+    static_libraries = ["liblib_a.a"],
+    deps = [":lib_b"],
+)
+
+cmake_external(
+    name = "lib_b",
+    defines = ["FOO"],
+    lib_source = ":lib_b_sources",
+    static_libraries = ["liblib_b.a"],
+)
+
+filegroup(
+    name = "lib_a_sources",
+    srcs = ["lib_a/{}".format(s) for s in ["CMakeLists.txt", "lib_a.cpp"]],
+)
+
+filegroup(
+    name = "lib_b_sources",
+    srcs = ["lib_b/{}".format(s) for s in ["CMakeLists.txt", "lib_b.cpp"]],
+)

--- a/examples/cmake_defines/lib_a/CMakeLists.txt
+++ b/examples/cmake_defines/lib_a/CMakeLists.txt
@@ -1,0 +1,4 @@
+project(cmake_defines)
+
+add_library(lib_a lib_a.cpp)
+install(TARGETS lib_a ARCHIVE DESTINATION lib)

--- a/examples/cmake_defines/lib_a/lib_a.cpp
+++ b/examples/cmake_defines/lib_a/lib_a.cpp
@@ -1,0 +1,3 @@
+#ifndef FOO
+#error FOO is not defined
+#endif

--- a/examples/cmake_defines/lib_b/CMakeLists.txt
+++ b/examples/cmake_defines/lib_b/CMakeLists.txt
@@ -1,0 +1,4 @@
+project(cmake_defines)
+
+add_library(lib_b lib_b.cpp)
+install(TARGETS lib_b ARCHIVE DESTINATION lib)

--- a/test/standard_cxx_flags_test/tests.bzl
+++ b/test/standard_cxx_flags_test/tests.bzl
@@ -43,6 +43,7 @@ def assert_contains_once(arr, value):
 _flags_test = rule(
     implementation = _impl,
     attrs = {
+	"deps": attr.label_list(),
         "out": attr.output(),
         "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
     },

--- a/tools/build_defs/cc_toolchain_util.bzl
+++ b/tools/build_defs/cc_toolchain_util.bzl
@@ -115,6 +115,9 @@ def _files_map(files_list):
         by_names_map[name_] = file_
     return by_names_map
 
+def _defines_from_deps(ctx):
+    return depset(transitive = [dep[CcInfo].compilation_context.defines for dep in ctx.attr.deps])
+
 def _build_cc_link_params(
         ctx,
         user_link_flags,
@@ -294,6 +297,7 @@ def get_flags_info(ctx, link_output_file = None):
     copts = (ctx.fragments.cpp.copts + ctx.fragments.cpp.conlyopts) or []
     cxxopts = (ctx.fragments.cpp.copts + ctx.fragments.cpp.cxxopts) or []
     linkopts = ctx.fragments.cpp.linkopts or []
+    defines = _defines_from_deps(ctx)
 
     flags = CxxFlagsInfo(
         cc = cc_common.get_memory_inefficient_command_line(
@@ -302,6 +306,7 @@ def get_flags_info(ctx, link_output_file = None):
             variables = cc_common.create_compile_variables(
                 feature_configuration = feature_configuration,
                 cc_toolchain = cc_toolchain_,
+                preprocessor_defines = defines,
             ),
         ),
         cxx = cc_common.get_memory_inefficient_command_line(
@@ -310,6 +315,7 @@ def get_flags_info(ctx, link_output_file = None):
             variables = cc_common.create_compile_variables(
                 feature_configuration = feature_configuration,
                 cc_toolchain = cc_toolchain_,
+                preprocessor_defines = defines,
                 add_legacy_cxx_options = True,
             ),
         ),
@@ -350,6 +356,7 @@ def get_flags_info(ctx, link_output_file = None):
             variables = cc_common.create_compile_variables(
                 feature_configuration = feature_configuration,
                 cc_toolchain = cc_toolchain_,
+                preprocessor_defines = defines,
             ),
         ),
     )


### PR DESCRIPTION
(Hopefully) Addresses issue highlighted in #301.

I suspect there are similar issues in propagating includes from deps `CcInfo.compilation_context`.