### PR TITLE
Remove version from generated script

### DIFF
--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -303,7 +303,7 @@ def cc_external_rule_impl(ctx, attrs):
     if execution_os_name != "osx":
         set_cc_envs = "\n".join(["export {}=\"{}\"".format(key, cc_env[key]) for key in cc_env])
 
-    version_and_lib = "Bazel external C/C++ Rules. Building library '{}'\\n".format(lib_name)
+    lib_header = "Bazel external C/C++ Rules. Building library '{}'\\n".format(lib_name)
 
     # We can not declare outputs of the action, which are in parent-child relashion,
     # so we need to have a (symlinked) copy of the output directory to provide
@@ -343,7 +343,7 @@ def cc_external_rule_impl(ctx, attrs):
 
     script_lines = [
         "##echo## \"\"",
-        "##echo## \"{}\"".format(version_and_lib),
+        "##echo## \"{}\"".format(lib_header),
         "##echo## \"\"",
         "##script_prelude##",
         "\n".join(define_variables),

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -16,7 +16,6 @@ load(
     "create_function",
     "os_name",
 )
-load("@rules_foreign_cc//tools/build_defs:version.bzl", "VERSION")
 load(
     ":cc_toolchain_util.bzl",
     "LibrariesToLinkInfo",
@@ -304,7 +303,7 @@ def cc_external_rule_impl(ctx, attrs):
     if execution_os_name != "osx":
         set_cc_envs = "\n".join(["export {}=\"{}\"".format(key, cc_env[key]) for key in cc_env])
 
-    version_and_lib = "Bazel external C/C++ Rules #{}. Building library '{}'\\n".format(VERSION, lib_name)
+    version_and_lib = "Bazel external C/C++ Rules. Building library '{}'\\n".format(lib_name)
 
     # We can not declare outputs of the action, which are in parent-child relashion,
     # so we need to have a (symlinked) copy of the output directory to provide


### PR DESCRIPTION
Having the version in the generated script will cause cache invalidations any time the version number is bumped even if the change causing the version bump doesn't affect the build being executed.