### PR TITLE
Remove a print from the cleanup function

### DIFF
--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -454,8 +454,7 @@ def wrap_outputs(ctx, lib_name, configure_name, script_text):
     cleanup_on_success_function = create_function(
         ctx,
         "cleanup_on_success",
-        """##echo## \"rules_foreign_cc: Cleaning temp directories\"
-rm -rf $BUILD_TMPDIR $EXT_BUILD_DEPS""",
+        "rm -rf $BUILD_TMPDIR $EXT_BUILD_DEPS",
     )
     cleanup_on_failure_function = create_function(
         ctx,


### PR DESCRIPTION
This is the similar change to https://github.com/bazelbuild/rules_foreign_cc/pull/481. Shout outs to @scele 😄 