### PR TITLE
Explicitly install cmake for MacOS CI builds

### DIFF
--- a/.bazelci/config.yaml
+++ b/.bazelci/config.yaml
@@ -2,15 +2,22 @@
 tasks:
   ubuntu2004:
     platform: ubuntu2004
-    shell_commands:
-      - cmake --help
     build_targets:
       - "//..."
     test_targets:
       - "//..."
   macos:
     platform: macos
+    environment:
+      PATH: ${PATH}:${HOME}/Applications/CMake.app/Contents/bin
     shell_commands:
+      # TODO: Remove when implemented: https://github.com/bazelbuild/rules_foreign_cc/issues/497
+      - |
+          curl -L https://github.com/Kitware/CMake/releases/download/v3.19.4/cmake-3.19.4-macos-universal.tar.gz -o cmake.tar.gz
+          tar -xf cmake.tar.gz 
+          mv cmake-3.19.4-macos-universal/CMake.app ${HOME}/Applications
+          rm -rf cmake-3.19.4-macos-universal cmake.tar.gz 
+      - env
       - cmake --help
     build_targets:
       - "//..."

--- a/.bazelci/config.yaml
+++ b/.bazelci/config.yaml
@@ -2,12 +2,16 @@
 tasks:
   ubuntu2004:
     platform: ubuntu2004
+    shell_commands:
+      - cmake --help
     build_targets:
       - "//..."
     test_targets:
       - "//..."
   macos:
     platform: macos
+    shell_commands:
+      - cmake --help
     build_targets:
       - "//..."
     test_targets:


### PR DESCRIPTION
It seems like MacOS runners do not have `cmake` installed anymore as proven by https://buildkite.com/bazel/rules-foreign-cc/builds/1623

[rules-foreign-cc_build_1623_darwin-openjdk-8.log](https://github.com/bazelbuild/rules_foreign_cc/files/5976556/rules-foreign-cc_build_1623_darwin-openjdk-8.log)


This PR explicitly installs it to fix this issue. As a result, we should implement https://github.com/bazelbuild/rules_foreign_cc/issues/497