### PR TITLE
Add keep_install_dir flag

### DIFF
--- a/examples/configure_libunwind/BUILD
+++ b/examples/configure_libunwind/BUILD
@@ -4,6 +4,7 @@ load("@rules_foreign_cc//tools/build_defs:configure.bzl", "configure_make")
 configure_make(
     name = "libunwind",
     autogen = True,
+    keep_install_dir = False,
     configure_in_place = True,
     configure_options = [
         "--disable-coredump",

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -104,6 +104,12 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
         doc = "Optional names of the resulting interface libraries.",
         mandatory = False,
     ),
+    "keep_install_dir": attr.bool(
+        doc = (
+            "Keep the entire install directory for use by downstream libraries (does not affect " +
+            "explicitly specified outputs in static_libraries, shared_libraries, out_* fields"),
+        default = True,
+    ),
     "lib_name": attr.string(
         doc = (
             "Library name. Defines the name of the install directory and the name of the static library, " +
@@ -362,7 +368,7 @@ def cc_external_rule_impl(ctx, attrs):
         # for the results which are in $INSTALLDIR (with placeholder)
         "##replace_absolute_paths## $$INSTALLDIR$$ $$BUILD_TMPDIR$$",
         "##replace_absolute_paths## $$INSTALLDIR$$ $$EXT_BUILD_DEPS$$",
-        installdir_copy.script,
+        installdir_copy.script if ctx.attr.keep_install_dir else "",
         empty.script,
         "cd $$EXT_BUILD_ROOT$$",
     ]


### PR DESCRIPTION
The install_dir is kept as an extra copy so the whole tree is available for downstream foreign builds.  In cases where you don't need it, this is an extra 2x overhead (since it has copies of the libraries/files you declare for downstream use) or more, often unused.  In big projects like gdal, pcl, etc, it can be a large overhead for caching.

This provides a flag `keep_install_dir` to skip copying the install tree for cases when you don't need it.  The `installdir_copy` logic is fairly ingrained so we still declare it, and just omit the final copy.