### PR TITLE
Ensure symlink_contents_to_dir traverses symlinks on OSX

### DIFF
--- a/tools/build_defs/shell_toolchain/toolchains/impl/osx_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/osx_commands.bzl
@@ -99,7 +99,7 @@ elif [[ -L "$1" && ! -d "$1" ]]; then
 elif [[ -d "$1" ]]; then
   SAVEIFS=$IFS
   IFS=$'\n'
-  local children=($(find "$1" -maxdepth 1 -mindepth 1))
+  local children=($(find "$1/" -maxdepth 1 -mindepth 1))
   IFS=$SAVEIFS
   for child in "${children[@]}"; do
     ##symlink_to_dir## "$child" "$target"


### PR DESCRIPTION
If the `source` arg to symlink_contents_to_dir is itself a symlink, the `find` call wouldn't traverse it.  I believe I encountered this when trying to chain `configure_make` rules where the first rule generated a shared library. 

Another solution would be to pass `-L` to find, but that would make it traverse all symlinks, not just the root, and this seemed closer to original intent.