### PR TITLE
Example for CMake with Transitive Shared Libraries

### DIFF
--- a/examples/cmake_synthetic/liba/BUILD
+++ b/examples/cmake_synthetic/liba/BUILD
@@ -13,3 +13,26 @@ cc_library(
     includes = ["src"],
     visibility = ["//visibility:public"],
 )
+
+cc_binary(
+    name = "liba.so",
+    linkshared = 1,
+    linkstatic = 1,
+    srcs = ["src/liba.cpp", "src/liba.h"],
+    linkopts = select({
+        "//:macos": ["-Wl,-install_name", "-Wl,@rpath/liba.so"]
+    })
+)
+
+cc_import(
+    name = "lib_a_so_import",
+    shared_library = "liba.so",
+)
+
+cc_library(
+    name = "lib_a_so",
+    deps = [":lib_a_so_import"],
+    hdrs = ["src/liba.h"],
+    includes = ["src"],
+    visibility = ["//visibility:public"],
+)

--- a/examples/cmake_with_bazel_transitive/BUILD
+++ b/examples/cmake_with_bazel_transitive/BUILD
@@ -11,6 +11,7 @@ cmake_external(
         # as currently we copy all libraries, built with Bazel, into $EXT_BUILD_DEPS/lib
         # and the headers into $EXT_BUILD_DEPS/include
         "LIBA_DIR": "$EXT_BUILD_DEPS",
+        "LIBA_PATH": "$EXT_BUILD_DEPS/lib/liba.a",
     },
     cmake_options = ["-GNinja"],
     lib_source = "//cmake_with_bazel_transitive/libb:b_srcs",
@@ -23,6 +24,30 @@ cmake_external(
     deps = ["//cmake_synthetic/liba:lib_a_bazel"],
 )
 
+cmake_external(
+    name = "cmake_libb_shared",
+    cache_entries = {
+        "BUILD_SHARED_LIBS": "ON",
+        "CMAKE_SHARED_LIBRARY_SUFFIX_CXX": ".so", # easier consistency on macos
+        "CMAKE_MACOSX_RPATH": "True",
+        # CMake's find_package wants to find cmake config for liba,
+        # which we do not have -> disable search
+        "CMAKE_DISABLE_FIND_PACKAGE_LIBA": "True",
+        # as currently we copy all libraries, built with Bazel, into $EXT_BUILD_DEPS/lib
+        # and the headers into $EXT_BUILD_DEPS/include
+        "LIBA_DIR": "$EXT_BUILD_DEPS",
+        #"LIBA_PATHx": "$EXT_BUILD_DEPS/lib/liba.so",
+    },
+    cmake_options = ["-GNinja", "--trace", "--debug-find"],
+    lib_source = "//cmake_with_bazel_transitive/libb:b_srcs",
+    make_commands = [
+        "ninja",
+        "ninja install",
+    ],
+    shared_libraries = ["libb.so"],
+    deps = ["//cmake_synthetic/liba:lib_a_so"],
+)
+
 # And cc_test built with cmake_external dependency and transitive Bazel dependency
 cc_test(
     name = "test",
@@ -32,5 +57,17 @@ cc_test(
     deps = [
         # liba should come from transitive dependencies
         ":cmake_libb",
+    ],
+)
+
+# And cc_test built with cmake_external shared dependency and transitive shared Bazel dependency
+cc_test(
+    name = "test_shared",
+    srcs = [
+        "test_libb.cpp",
+    ],
+    deps = [
+        # liba should come from transitive dependencies
+        ":cmake_libb_shared",
     ],
 )

--- a/examples/cmake_with_bazel_transitive/libb/src/CMakeLists.txt
+++ b/examples/cmake_with_bazel_transitive/libb/src/CMakeLists.txt
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 2.8.4)
 
 set(LIBB_SRC libb.cpp libb.h)
 
-add_library(libb_static STATIC ${LIBB_SRC})
-set_target_properties(libb_static PROPERTIES OUTPUT_NAME "libb")
+add_library(libb_static ${LIBB_SRC})
+set_target_properties(libb_static PROPERTIES OUTPUT_NAME "b")
 IF (WIN32)
   set_target_properties(libb_static PROPERTIES ARCHIVE_OUTPUT_NAME "libb")
 ELSE()
@@ -14,11 +14,18 @@ find_package(LIBA NAMES alib liba libliba)
 
 # LIBA_INCLUDE_DIRS is not set, so giving the path relative to liba_config.cmake
 # would be happy to improve that
-target_link_libraries(libb_static PUBLIC ${LIBA_DIR}/lib/liba.a)
+if (LIBA_PATH)
+  target_link_libraries(libb_static PUBLIC ${LIBA_PATH})
+else()
+  find_library(LIBA_LIB NAMES a)
+  message(STATUS "Found liba ${LIBA_LIB}")
+  target_link_libraries(libb_static PUBLIC ${LIBA_LIB})
+endif()
+
 target_include_directories(libb_static PUBLIC ${LIBA_DIR}/include)
 
 set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
 
-install(TARGETS libb_static ARCHIVE DESTINATION lib)
+install(TARGETS libb_static ARCHIVE DESTINATION lib LIBRARY DESTINATION lib)
 
 install(FILES libb.h DESTINATION include)


### PR DESCRIPTION
The existing example shows how things work for static libs; this expands it a bit to show building a shared library, injecting it into CMake, and getting everything just right so a final binary built on top of a CMake shared lib works.