### PR TITLE
Fixed unbound variable in commands and recursive symlinks

### DIFF
--- a/test/expected/inner_fun_text.txt
+++ b/test/expected/inner_fun_text.txt
@@ -12,7 +12,7 @@ IFS=$'
 '
 local children=($(find -H "$1" -maxdepth 1 -mindepth 1))
 IFS=$SAVEIFS
-for child in "${children[@]}"; do
+for child in "${children[@]:-}"; do
 symlink_to_dir "$child" "$target"
 done
 fi
@@ -32,7 +32,7 @@ local children=($(find -H "$1" -maxdepth 1 -mindepth 1))
 IFS=$SAVEIFS
 local dirname=$(basename "$1")
 mkdir -p "$target/$dirname"
-for child in "${children[@]}"; do
+for child in "${children[@]:-}"; do
 if [[ "$dirname" != *.ext_build_deps ]]; then
 symlink_to_dir "$child" "$target/$dirname"
 fi

--- a/test/expected/inner_fun_text_osx.txt
+++ b/test/expected/inner_fun_text_osx.txt
@@ -33,7 +33,9 @@ IFS=$SAVEIFS
 local dirname=$(basename "$1")
 mkdir -p "$target/$dirname"
 for child in "${children[@]:-}"; do
+if [[ "$dirname" != *.ext_build_deps ]]; then
 symlink_to_dir "$child" "$target/$dirname"
+fi
 done
 else
 echo "Can not copy $1"

--- a/test/expected/inner_fun_text_osx.txt
+++ b/test/expected/inner_fun_text_osx.txt
@@ -12,7 +12,7 @@ IFS=$'
 '
 local children=($(find "$1" -maxdepth 1 -mindepth 1))
 IFS=$SAVEIFS
-for child in "${children[@]}"; do
+for child in "${children[@]:-}"; do
 symlink_to_dir "$child" "$target"
 done
 fi
@@ -32,7 +32,7 @@ local children=($(find "$1" -maxdepth 1 -mindepth 1))
 IFS=$SAVEIFS
 local dirname=$(basename "$1")
 mkdir -p "$target/$dirname"
-for child in "${children[@]}"; do
+for child in "${children[@]:-}"; do
 symlink_to_dir "$child" "$target/$dirname"
 done
 else

--- a/tools/build_defs/shell_toolchain/toolchains/impl/default_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/default_commands.bzl
@@ -34,7 +34,7 @@ def mkdirs(path):
     return "mkdir -p " + path
 
 def if_else(condition, if_text, else_text):
-    return """
+    return """\
 if [ {condition} ]; then
   {if_text}
 else
@@ -53,7 +53,8 @@ def define_function(name, text):
 
 def replace_in_files(dir, from_, to_):
     return FunctionAndCall(
-        text = """if [ -d "$1" ]; then
+        text = """\
+if [ -d "$1" ]; then
   find -L $1 -type f   \\( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.cmake" \\)   -exec sed -i 's@'"$2"'@'"$3"'@g' {} ';'
 fi
 """,
@@ -63,7 +64,8 @@ def copy_dir_contents_to_dir(source, target):
     return """cp -L -r --no-target-directory "{}" "{}" """.format(source, target)
 
 def symlink_contents_to_dir(source, target):
-    text = """local target="$2"
+    text = """\
+local target="$2"
 mkdir -p "$target"
 if [[ -f "$1" ]]; then
   ##symlink_to_dir## "$1" "$target"
@@ -75,7 +77,7 @@ elif [[ -d "$1" ]]; then
   IFS=$'\n'
   local children=($(find -H "$1" -maxdepth 1 -mindepth 1))
   IFS=$SAVEIFS
-  for child in "${children[@]}"; do
+  for child in "${children[@]:-}"; do
     ##symlink_to_dir## "$child" "$target"
   done
 fi
@@ -83,7 +85,8 @@ fi
     return FunctionAndCall(text = text)
 
 def symlink_to_dir(source, target):
-    text = """local target="$2"
+    text = """\
+local target="$2"
 mkdir -p "$target"
 if [[ -f "$1" ]]; then
   ln -s -f -t "$target" "$1"
@@ -96,7 +99,7 @@ elif [[ -d "$1" ]]; then
   local children=($(find -H "$1" -maxdepth 1 -mindepth 1))
   IFS=$SAVEIFS
   local dirname=$(basename "$1")
-  for child in "${children[@]}"; do
+  for child in "${children[@]:-}"; do
     if [[ "$dirname" != *.ext_build_deps ]]; then
       ##symlink_to_dir## "$child" "$target/$dirname"
     fi
@@ -111,7 +114,8 @@ def script_prelude():
     return "set -euo pipefail"
 
 def increment_pkg_config_path(source):
-    text = """local children=$(find $1 -mindepth 1 -name '*.pc')
+    text = """\
+local children=$(find $1 -mindepth 1 -name '*.pc')
 # assume there is only one directory with pkg config
 for child in $children; do
   export PKG_CONFIG_PATH="$${PKG_CONFIG_PATH:-}$$:$(dirname $child)"
@@ -141,7 +145,8 @@ def cleanup_function(on_success, on_failure):
     return FunctionAndCall(text = text, call = "trap \"cleanup_function\" EXIT")
 
 def children_to_path(dir_):
-    text = """if [ -d {dir_} ]; then
+    text = """\
+if [ -d {dir_} ]; then
   local tools=$(find $EXT_BUILD_DEPS/bin -maxdepth 1 -mindepth 1)
   for tool in $tools;
   do

--- a/tools/build_defs/shell_toolchain/toolchains/impl/linux_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/linux_commands.bzl
@@ -53,7 +53,8 @@ def define_function(name, text):
 
 def replace_in_files(dir, from_, to_):
     return FunctionAndCall(
-        text = """if [ -d "$1" ]; then
+        text = """\
+if [ -d "$1" ]; then
   find -L $1 -type f   \\( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.cmake" \\)   -exec sed -i 's@'"$2"'@'"$3"'@g' {} ';'
 fi
 """,
@@ -63,7 +64,8 @@ def copy_dir_contents_to_dir(source, target):
     return """cp -L -r --no-target-directory "{}" "{}" """.format(source, target)
 
 def symlink_contents_to_dir(source, target):
-    text = """local target="$2"
+    text = """\
+local target="$2"
 mkdir -p "$target"
 if [[ -f "$1" ]]; then
   ##symlink_to_dir## "$1" "$target"
@@ -75,7 +77,7 @@ elif [[ -d "$1" ]]; then
   IFS=$'\n'
   local children=($(find -H "$1" -maxdepth 1 -mindepth 1))
   IFS=$SAVEIFS
-  for child in "${children[@]}"; do
+  for child in "${children[@]:-}"; do
     ##symlink_to_dir## "$child" "$target"
   done
 fi
@@ -83,7 +85,8 @@ fi
     return FunctionAndCall(text = text)
 
 def symlink_to_dir(source, target):
-    text = """local target="$2"
+    text = """\
+local target="$2"
 mkdir -p "$target"
 if [[ -f "$1" ]]; then
   ln -s -f -t "$target" "$1"
@@ -96,7 +99,7 @@ elif [[ -d "$1" ]]; then
   IFS=$SAVEIFS
   local dirname=$(basename "$1")
   mkdir -p "$target/$dirname"
-  for child in "${children[@]}"; do
+  for child in "${children[@]:-}"; do
     if [[ "$dirname" != *.ext_build_deps ]]; then
       ##symlink_to_dir## "$child" "$target/$dirname"
     fi
@@ -111,7 +114,8 @@ def script_prelude():
     return "set -euo pipefail"
 
 def increment_pkg_config_path(source):
-    text = """local children=$(find $1 -mindepth 1 -name '*.pc')
+    text = """\
+local children=$(find $1 -mindepth 1 -name '*.pc')
 # assume there is only one directory with pkg config
 for child in $children; do
   export PKG_CONFIG_PATH="$${PKG_CONFIG_PATH:-}$$:$(dirname $child)"
@@ -141,7 +145,8 @@ def cleanup_function(on_success, on_failure):
     return FunctionAndCall(text = text, call = "trap \"cleanup_function\" EXIT")
 
 def children_to_path(dir_):
-    text = """if [ -d {dir_} ]; then
+    text = """\
+if [ -d {dir_} ]; then
   local tools=$(find $EXT_BUILD_DEPS/bin -maxdepth 1 -mindepth 1)
   for tool in $tools;
   do

--- a/tools/build_defs/shell_toolchain/toolchains/impl/osx_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/osx_commands.bzl
@@ -126,7 +126,9 @@ elif [[ -d "$1" ]]; then
   local dirname=$(basename "$1")
   mkdir -p "$target/$dirname"
   for child in "${children[@]:-}"; do
-    ##symlink_to_dir## "$child" "$target/$dirname"
+    if [[ "$dirname" != *.ext_build_deps ]]; then
+      ##symlink_to_dir## "$child" "$target/$dirname"
+    fi
   done
 else
   echo "Can not copy $1"

--- a/tools/build_defs/shell_toolchain/toolchains/impl/osx_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/osx_commands.bzl
@@ -34,7 +34,7 @@ def mkdirs(path):
     return "mkdir -p " + path
 
 def if_else(condition, if_text, else_text):
-    return """
+    return """\
 if [ {condition} ]; then
   {if_text}
 else
@@ -53,14 +53,15 @@ def define_function(name, text):
 
 def replace_in_files(dir, from_, to_):
     return FunctionAndCall(
-        text = """if [ -d "$1" ]; then
+        text = """\
+if [ -d "$1" ]; then
     find -L -f $1 \\( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.cmake" \\)     -exec sed -i -e 's@'"$2"'@'"$3"'@g' {} ';'
 fi
 """,
     )
 
 def copy_dir_contents_to_dir(source, target):
-    text = """
+    text = """\
 SAVEIFS=$IFS
 IFS=$'\n'
 local children=($(find "$1" -maxdepth 1 -mindepth 1))
@@ -89,7 +90,8 @@ done
     return FunctionAndCall(text = text)
 
 def symlink_contents_to_dir(source, target):
-    text = """local target="$2"
+    text = """\
+local target="$2"
 mkdir -p "$target"
 if [[ -f "$1" ]]; then
   ##symlink_to_dir## "$1" "$target"
@@ -101,7 +103,7 @@ elif [[ -d "$1" ]]; then
   IFS=$'\n'
   local children=($(find "$1" -maxdepth 1 -mindepth 1))
   IFS=$SAVEIFS
-  for child in "${children[@]}"; do
+  for child in "${children[@]:-}"; do
     ##symlink_to_dir## "$child" "$target"
   done
 fi
@@ -109,7 +111,8 @@ fi
     return FunctionAndCall(text = text)
 
 def symlink_to_dir(source, target):
-    text = """local target="$2"
+    text = """\
+local target="$2"
 mkdir -p "$target"
 if [[ -f "$1" ]]; then
   ln -s -f "$1" "$target"
@@ -122,7 +125,7 @@ elif [[ -d "$1" ]]; then
   IFS=$SAVEIFS
   local dirname=$(basename "$1")
   mkdir -p "$target/$dirname"
-  for child in "${children[@]}"; do
+  for child in "${children[@]:-}"; do
     ##symlink_to_dir## "$child" "$target/$dirname"
   done
 else
@@ -135,7 +138,7 @@ def script_prelude():
     return "set -euo pipefail"
 
 def increment_pkg_config_path(source):
-    text = """
+    text = """\
 local children=$(find $1 -mindepth 1 -name '*.pc')
 # assume there is only one directory with pkg config
 for child in $children; do
@@ -166,7 +169,8 @@ def cleanup_function(on_success, on_failure):
     return FunctionAndCall(text = text, call = "trap \"cleanup_function\" EXIT")
 
 def children_to_path(dir_):
-    text = """if [ -d {dir_} ]; then
+    text = """\
+if [ -d {dir_} ]; then
   local tools=$(find $EXT_BUILD_DEPS/bin -maxdepth 1 -mindepth 1)
   for tool in $tools;
   do

--- a/tools/build_defs/shell_toolchain/toolchains/impl/windows_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/windows_commands.bzl
@@ -34,7 +34,7 @@ def mkdirs(path):
     return "mkdir -p " + path
 
 def if_else(condition, if_text, else_text):
-    return """
+    return """\
 if [ {condition} ]; then
   {if_text}
 else
@@ -53,7 +53,8 @@ def define_function(name, text):
 
 def replace_in_files(dir, from_, to_):
     return FunctionAndCall(
-        text = """if [ -d "$1" ]; then
+        text = """\
+if [ -d "$1" ]; then
   $REAL_FIND -L $1 -type f   \\( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.cmake" \\)   -exec sed -i 's@'"$2"'@'"$3"'@g' {} ';'
 fi
 """,
@@ -63,7 +64,8 @@ def copy_dir_contents_to_dir(source, target):
     return """cp -L -r --no-target-directory "{}" "{}" """.format(source, target)
 
 def symlink_contents_to_dir(source, target):
-    text = """local target="$2"
+    text = """\
+local target="$2"
 mkdir -p "$target"
 if [[ -f "$1" ]]; then
   ##symlink_to_dir## "$1" "$target"
@@ -83,7 +85,8 @@ fi
     return FunctionAndCall(text = text)
 
 def symlink_to_dir(source, target):
-    text = """local target="$2"
+    text = """\
+local target="$2"
 mkdir -p "$target"
 if [[ -f "$1" ]]; then
   ln -s -f -t "$target" "$1"
@@ -108,7 +111,8 @@ fi
     return FunctionAndCall(text = text)
 
 def script_prelude():
-    return """set -euo pipefail
+    return """\
+set -euo pipefail
 if [ -f /usr/bin/find ]; then
   REAL_FIND="/usr/bin/find"
 else
@@ -120,7 +124,8 @@ export SYSTEMDRIVE="C:"
 """
 
 def increment_pkg_config_path(source):
-    text = """local children=$($REAL_FIND $1 -mindepth 1 -name '*.pc')
+    text = """\
+local children=$($REAL_FIND $1 -mindepth 1 -name '*.pc')
 # assume there is only one directory with pkg config
 for child in $children; do
   export PKG_CONFIG_PATH="$${PKG_CONFIG_PATH:-}$$:$(dirname $child)"
@@ -150,7 +155,8 @@ def cleanup_function(on_success, on_failure):
     return FunctionAndCall(text = text, call = "trap \"cleanup_function\" EXIT")
 
 def children_to_path(dir_):
-    text = """if [ -d {dir_} ]; then
+    text = """\
+if [ -d {dir_} ]; then
   local tools=$($REAL_FIND $EXT_BUILD_DEPS/bin -maxdepth 1 -mindepth 1)
   for tool in $tools;
   do


### PR DESCRIPTION
closes https://github.com/bazelbuild/rules_foreign_cc/issues/505

- 0122473a8c59682a193427f5589ebf772e5fb57e fixes some unbound variables. This change is proven by the change in between [this build](https://buildkite.com/bazel/rules-foreign-cc/builds/1761#83c5581e-433d-40d2-a8ee-a5a245dd2bb3) and [this build](https://buildkite.com/bazel/rules-foreign-cc/builds/1764#8fb42e4c-6e09-4254-b48a-aecf111f42c2) where this change was cherry picked and fixed an error
- f9f230385cbcf2e854304815c44ccca4447d5f4b fixes recursive symlink issues on macos. This change is proven by the change in behavior between [this build](https://buildkite.com/bazel/rules-foreign-cc/builds/1764#0e264415-91c9-47dc-a721-3296d472607c) and [this build](https://buildkite.com/bazel/rules-foreign-cc/builds/1765#4ebd633f-e873-4c39-bb66-c165aaa780a3) where the change was cherry picked.