### PR TITLE
Preserve timestamps in copy_dir_contents_to_dir

### DIFF
--- a/tools/build_defs/shell_toolchain/toolchains/impl/default_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/default_commands.bzl
@@ -61,7 +61,7 @@ fi
     )
 
 def copy_dir_contents_to_dir(source, target):
-    return """cp -L -r --no-target-directory "{}" "{}" """.format(source, target)
+    return """cp -L -p -r --no-target-directory "{}" "{}" """.format(source, target)
 
 def symlink_contents_to_dir(source, target):
     text = """\

--- a/tools/build_defs/shell_toolchain/toolchains/impl/linux_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/linux_commands.bzl
@@ -61,7 +61,7 @@ fi
     )
 
 def copy_dir_contents_to_dir(source, target):
-    return """cp -L -r --no-target-directory "{}" "{}" """.format(source, target)
+    return """cp -L -p -r --no-target-directory "{}" "{}" """.format(source, target)
 
 def symlink_contents_to_dir(source, target):
     text = """\

--- a/tools/build_defs/shell_toolchain/toolchains/impl/osx_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/osx_commands.bzl
@@ -70,7 +70,7 @@ local target="$2"
 mkdir -p "${target}"
 for child in "${children[@]:-}"; do
   if [[ -f "$child" ]]; then
-    cp "$child" "$target"
+    cp -p "$child" "$target"
   elif [[ -L "$child" ]]; then
     local actual=$(readlink "$child")
     if [[ -f "$actual" ]]; then

--- a/tools/build_defs/shell_toolchain/toolchains/impl/windows_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/windows_commands.bzl
@@ -61,7 +61,7 @@ fi
     )
 
 def copy_dir_contents_to_dir(source, target):
-    return """cp -L -r --no-target-directory "{}" "{}" """.format(source, target)
+    return """cp -L -p -r --no-target-directory "{}" "{}" """.format(source, target)
 
 def symlink_contents_to_dir(source, target):
     text = """\


### PR DESCRIPTION
This removes the dependency on autotools for projects such as "make",
where autotools are only invoked if the timestamp of certain files has
changed.