### PR TITLE
Reduce noise in build logs

### DIFF
--- a/tools/build_defs/configure_script.bzl
+++ b/tools/build_defs/configure_script.bzl
@@ -7,8 +7,7 @@ def _pkgconfig_script(ext_build_dirs):
     script = []
     for ext_dir in ext_build_dirs:
         script.append("##increment_pkg_config_path## $$EXT_BUILD_DEPS$$/" + ext_dir.basename)
-
-    script.append("echo \"PKG_CONFIG_PATH=$${PKG_CONFIG_PATH:-}$$\"")
+        script.append("echo \"PKG_CONFIG_PATH=$${PKG_CONFIG_PATH:-}$$\"")
 
     script.append("##define_absolute_paths## $$EXT_BUILD_DEPS$$ $$EXT_BUILD_DEPS$$")
 
@@ -99,7 +98,7 @@ def create_make_script(
     script = _pkgconfig_script(ext_build_dirs)
 
     script.append("##symlink_contents_to_dir## $$EXT_BUILD_ROOT$$/{} $$BUILD_TMPDIR$$".format(root))
-    script.append("" + " && ".join(make_commands))
+    script.extend(make_commands)
     return "\n".join(script)
 
 # buildifier: disable=function-docstring

--- a/tools/build_defs/configure_script.bzl
+++ b/tools/build_defs/configure_script.bzl
@@ -5,8 +5,9 @@ load(":framework.bzl", "get_foreign_cc_dep")
 def _pkgconfig_script(ext_build_dirs):
     """Create a script fragment to configure pkg-config"""
     script = []
-    for ext_dir in ext_build_dirs:
-        script.append("##increment_pkg_config_path## $$EXT_BUILD_DEPS$$/" + ext_dir.basename)
+    if ext_build_dirs:
+        for ext_dir in ext_build_dirs:
+            script.append("##increment_pkg_config_path## $$EXT_BUILD_DEPS$$/" + ext_dir.basename)
         script.append("echo \"PKG_CONFIG_PATH=$${PKG_CONFIG_PATH:-}$$\"")
 
     script.append("##define_absolute_paths## $$EXT_BUILD_DEPS$$ $$EXT_BUILD_DEPS$$")

--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -409,9 +409,8 @@ def cc_external_rule_impl(ctx, attrs):
             [wrapped_outputs.script_file] + extra_tools + ctx.files.data + ctx.files.tools_deps + ctx.files.additional_tools,
             transitive = [cc_toolchain.all_files] + [data[DefaultInfo].default_runfiles.files for data in data_dependencies],
         ),
-        # We should take the default PATH passed by Bazel, not that from cc_toolchain
-        # for Windows, because the PATH under msys2 is different and that is which we need
-        # for shell commands
+        # TODO: Default to never using the default shell environment to make builds more hermetic. For now, every platform
+        # but MacOS will take the default PATH passed by Bazel, not that from cc_toolchain.
         use_default_shell_env = execution_os_name != "osx",
         executable = wrapper,
         execution_requirements = execution_requirements,

--- a/tools/build_defs/shell_toolchain/toolchains/impl/default_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/default_commands.bzl
@@ -10,7 +10,7 @@ def pwd():
     return "$(pwd)"
 
 def echo(text):
-    return "printf \"{text}\"".format(text = text)
+    return "echo \"{text}\"".format(text = text)
 
 def export_var(name, value):
     return "export {name}={value}".format(name = name, value = value)

--- a/tools/build_defs/shell_toolchain/toolchains/impl/linux_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/linux_commands.bzl
@@ -10,7 +10,7 @@ def pwd():
     return "$(pwd)"
 
 def echo(text):
-    return "printf \"{text}\"".format(text = text)
+    return "echo \"{text}\"".format(text = text)
 
 def export_var(name, value):
     return "export {name}={value}".format(name = name, value = value)

--- a/tools/build_defs/shell_toolchain/toolchains/impl/osx_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/osx_commands.bzl
@@ -10,7 +10,7 @@ def pwd():
     return "$(pwd)"
 
 def echo(text):
-    return "printf \"{text}\"".format(text = text)
+    return "echo \"{text}\"".format(text = text)
 
 def export_var(name, value):
     return "export {name}={value}".format(name = name, value = value)

--- a/tools/build_defs/shell_toolchain/toolchains/impl/windows_commands.bzl
+++ b/tools/build_defs/shell_toolchain/toolchains/impl/windows_commands.bzl
@@ -10,7 +10,7 @@ def pwd():
     return "$(type -t cygpath > /dev/null && cygpath $(pwd) -w || pwd -W)"
 
 def echo(text):
-    return "printf \"{text}\"".format(text = text)
+    return "echo \"{text}\"".format(text = text)
 
 def export_var(name, value):
     return "export {name}={value}".format(name = name, value = value)


### PR DESCRIPTION
This PR cleans up the error outputs so they're reasonably parseable. This is done by replacing the use of [ctx.actions.run_shell](https://docs.bazel.build/versions/master/skylark/lib/actions.html#run_shell) with [ctx.actions.run](https://docs.bazel.build/versions/master/skylark/lib/actions.html#run) in the core framework and instead writing the code to a file.

Windows is a bit unique in that it also builds a `.bat` script to wrap the `.sh` script and, like Bazel ([Using Bazel without Bash msys2](https://docs.bazel.build/versions/3.5.0/windows.html#using-bazel-without-bash-msys2)), it expects bash to be available on the host.

One other notable change here is that the `echo` alias is now actually `echo` and no longer `printf`. This significantly cleans up the code required for formatting generated scripts and build logs.

Finally, this PR also fixes a bug where when a build failure occurs, the error was getting swallowed up and the only issues surfaced to users were that the `static_libraries`, `shared_libraries`, `binaries`, etc... targets they requested were not created. Now users will see the full log of the build failure so they don't have to go digging for the output build log (which is not very easy to do for builds in CI).

Examples of the new errors can be seen here: https://buildkite.com/bazel/rules-foreign-cc/builds/1821#a565cc8e-7125-4bea-b8df-0fa99a024e9d