### PR TITLE
Prefixed all output attributes with `out_` to make their use clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ cmake(
         "CMAKE_C_FLAGS": "-fPIC",
     },
     lib_source = "@pcre//:all_srcs",
-    static_libraries = ["libpcre.a"],
+    out_static_libs = ["libpcre.a"],
 )
 ```
 
@@ -206,7 +206,7 @@ cmake(
         "nmake install",
     ],
     # expect to find ./lib/hello.lib as the result of the build
-    static_libraries = ["hello.lib"]
+    out_static_libs = ["hello.lib"]
 )
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,8 @@
 <pre>
 boost_build(<a href="#boost_build-name">name</a>, <a href="#boost_build-additional_inputs">additional_inputs</a>, <a href="#boost_build-additional_tools">additional_tools</a>, <a href="#boost_build-alwayslink">alwayslink</a>, <a href="#boost_build-binaries">binaries</a>, <a href="#boost_build-bootstrap_options">bootstrap_options</a>,
             <a href="#boost_build-data">data</a>, <a href="#boost_build-defines">defines</a>, <a href="#boost_build-deps">deps</a>, <a href="#boost_build-env">env</a>, <a href="#boost_build-headers_only">headers_only</a>, <a href="#boost_build-interface_libraries">interface_libraries</a>, <a href="#boost_build-lib_name">lib_name</a>, <a href="#boost_build-lib_source">lib_source</a>,
-            <a href="#boost_build-linkopts">linkopts</a>, <a href="#boost_build-make_commands">make_commands</a>, <a href="#boost_build-out_bin_dir">out_bin_dir</a>, <a href="#boost_build-out_include_dir">out_include_dir</a>, <a href="#boost_build-out_lib_dir">out_lib_dir</a>, <a href="#boost_build-postfix_script">postfix_script</a>,
+            <a href="#boost_build-linkopts">linkopts</a>, <a href="#boost_build-make_commands">make_commands</a>, <a href="#boost_build-out_bin_dir">out_bin_dir</a>, <a href="#boost_build-out_binaries">out_binaries</a>, <a href="#boost_build-out_headers_only">out_headers_only</a>, <a href="#boost_build-out_include_dir">out_include_dir</a>,
+            <a href="#boost_build-out_interface_libs">out_interface_libs</a>, <a href="#boost_build-out_lib_dir">out_lib_dir</a>, <a href="#boost_build-out_shared_libs">out_shared_libs</a>, <a href="#boost_build-out_static_libs">out_static_libs</a>, <a href="#boost_build-postfix_script">postfix_script</a>,
             <a href="#boost_build-shared_libraries">shared_libraries</a>, <a href="#boost_build-static_libraries">static_libraries</a>, <a href="#boost_build-tools_deps">tools_deps</a>, <a href="#boost_build-user_options">user_options</a>)
 </pre>
 
@@ -39,24 +40,29 @@ Rule for building Boost. Invokes bootstrap.sh and then b2 install.
 | <a id="boost_build-additional_inputs"></a>additional_inputs |  Optional additional inputs to be declared as needed for the shell script action.Not used by the shell script part in cc_external_rule_impl.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="boost_build-additional_tools"></a>additional_tools |  Optional additional tools needed for the building. Not used by the shell script part in cc_external_rule_impl.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="boost_build-alwayslink"></a>alwayslink |  Optional. if true, link all the object files from the static library, even if they are not used.   | Boolean | optional | False |
-| <a id="boost_build-binaries"></a>binaries |  Optional names of the resulting binaries.   | List of strings | optional | [] |
+| <a id="boost_build-binaries"></a>binaries |  __deprecated__: Use <code>out_binaries</code> instead.   | List of strings | optional | [] |
 | <a id="boost_build-bootstrap_options"></a>bootstrap_options |  any additional flags to pass to bootstrap.sh   | List of strings | optional | [] |
 | <a id="boost_build-data"></a>data |  Files needed by this rule at runtime. May list file or rule targets. Generally allows any target.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="boost_build-defines"></a>defines |  Optional compilation definitions to be passed to the dependencies of this library. They are NOT passed to the compiler, you should duplicate them in the configuration options.   | List of strings | optional | [] |
 | <a id="boost_build-deps"></a>deps |  Optional dependencies to be copied into the directory structure. Typically those directly required for the external building of the library/binaries. (i.e. those that the external buidl system will be looking for and paths to which are provided by the calling rule)   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="boost_build-env"></a>env |  Environment variables to set during the build. $(execpath) macros may be used to point at files which are listed as data deps, tools_deps, or additional_tools, but unlike with other rules, these will be replaced with absolute paths to those files, because the build does not run in the exec root. No other macros are supported.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
-| <a id="boost_build-headers_only"></a>headers_only |  Flag variable to indicate that the library produces only headers   | Boolean | optional | False |
-| <a id="boost_build-interface_libraries"></a>interface_libraries |  Optional names of the resulting interface libraries.   | List of strings | optional | [] |
+| <a id="boost_build-headers_only"></a>headers_only |  __deprecated__: Use <code>out_headers_only</code> instead.   | Boolean | optional | False |
+| <a id="boost_build-interface_libraries"></a>interface_libraries |  __deprecated__: Use <code>out_interface_libs</code> instead.   | List of strings | optional | [] |
 | <a id="boost_build-lib_name"></a>lib_name |  Library name. Defines the name of the install directory and the name of the static library, if no output files parameters are defined (any of static_libraries, shared_libraries, interface_libraries, binaries_names) Optional. If not defined, defaults to the target's name.   | String | optional | "" |
 | <a id="boost_build-lib_source"></a>lib_source |  Label with source code to build. Typically a filegroup for the source of remote repository. Mandatory.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a id="boost_build-linkopts"></a>linkopts |  Optional link options to be passed up to the dependencies of this library   | List of strings | optional | [] |
 | <a id="boost_build-make_commands"></a>make_commands |  Optinal make commands, defaults to ["make", "make install"]   | List of strings | optional | ["make", "make install"] |
 | <a id="boost_build-out_bin_dir"></a>out_bin_dir |  Optional name of the output subdirectory with the binary files, defaults to 'bin'.   | String | optional | "bin" |
+| <a id="boost_build-out_binaries"></a>out_binaries |  Optional names of the resulting binaries.   | List of strings | optional | [] |
+| <a id="boost_build-out_headers_only"></a>out_headers_only |  Flag variable to indicate that the library produces only headers   | Boolean | optional | False |
 | <a id="boost_build-out_include_dir"></a>out_include_dir |  Optional name of the output subdirectory with the header files, defaults to 'include'.   | String | optional | "include" |
+| <a id="boost_build-out_interface_libs"></a>out_interface_libs |  Optional names of the resulting interface libraries.   | List of strings | optional | [] |
 | <a id="boost_build-out_lib_dir"></a>out_lib_dir |  Optional name of the output subdirectory with the library files, defaults to 'lib'.   | String | optional | "lib" |
+| <a id="boost_build-out_shared_libs"></a>out_shared_libs |  Optional names of the resulting shared libraries.   | List of strings | optional | [] |
+| <a id="boost_build-out_static_libs"></a>out_static_libs |  Optional names of the resulting static libraries. Note that if <code>out_headers_only</code>, <code>out_static_libs</code>, <code>out_shared_libs</code>, and <code>out_binaries</code> are not set, default <code>lib_name.a</code>/<code>lib_name.lib</code> static library is assumed   | List of strings | optional | [] |
 | <a id="boost_build-postfix_script"></a>postfix_script |  Optional part of the shell script to be added after the make commands   | String | optional | "" |
-| <a id="boost_build-shared_libraries"></a>shared_libraries |  Optional names of the resulting shared libraries.   | List of strings | optional | [] |
-| <a id="boost_build-static_libraries"></a>static_libraries |  Optional names of the resulting static libraries.   | List of strings | optional | [] |
+| <a id="boost_build-shared_libraries"></a>shared_libraries |  __deprecated__: Use <code>out_shared_libs</code> instead.   | List of strings | optional | [] |
+| <a id="boost_build-static_libraries"></a>static_libraries |  __deprecated__: Use <code>out_static_libs</code> instead.   | List of strings | optional | [] |
 | <a id="boost_build-tools_deps"></a>tools_deps |  Optional tools to be copied into the directory structure. Similar to deps, those directly required for the external building of the library/binaries.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="boost_build-user_options"></a>user_options |  any additional flags to pass to b2   | List of strings | optional | [] |
 
@@ -68,8 +74,9 @@ Rule for building Boost. Invokes bootstrap.sh and then b2 install.
 <pre>
 cmake(<a href="#cmake-name">name</a>, <a href="#cmake-additional_inputs">additional_inputs</a>, <a href="#cmake-additional_tools">additional_tools</a>, <a href="#cmake-alwayslink">alwayslink</a>, <a href="#cmake-binaries">binaries</a>, <a href="#cmake-cache_entries">cache_entries</a>, <a href="#cmake-cmake_options">cmake_options</a>,
       <a href="#cmake-data">data</a>, <a href="#cmake-defines">defines</a>, <a href="#cmake-deps">deps</a>, <a href="#cmake-env">env</a>, <a href="#cmake-env_vars">env_vars</a>, <a href="#cmake-generate_crosstool_file">generate_crosstool_file</a>, <a href="#cmake-headers_only">headers_only</a>, <a href="#cmake-install_prefix">install_prefix</a>,
-      <a href="#cmake-interface_libraries">interface_libraries</a>, <a href="#cmake-lib_name">lib_name</a>, <a href="#cmake-lib_source">lib_source</a>, <a href="#cmake-linkopts">linkopts</a>, <a href="#cmake-make_commands">make_commands</a>, <a href="#cmake-out_bin_dir">out_bin_dir</a>,
-      <a href="#cmake-out_include_dir">out_include_dir</a>, <a href="#cmake-out_lib_dir">out_lib_dir</a>, <a href="#cmake-postfix_script">postfix_script</a>, <a href="#cmake-shared_libraries">shared_libraries</a>, <a href="#cmake-static_libraries">static_libraries</a>, <a href="#cmake-tools_deps">tools_deps</a>,
+      <a href="#cmake-interface_libraries">interface_libraries</a>, <a href="#cmake-lib_name">lib_name</a>, <a href="#cmake-lib_source">lib_source</a>, <a href="#cmake-linkopts">linkopts</a>, <a href="#cmake-make_commands">make_commands</a>, <a href="#cmake-out_bin_dir">out_bin_dir</a>, <a href="#cmake-out_binaries">out_binaries</a>,
+      <a href="#cmake-out_headers_only">out_headers_only</a>, <a href="#cmake-out_include_dir">out_include_dir</a>, <a href="#cmake-out_interface_libs">out_interface_libs</a>, <a href="#cmake-out_lib_dir">out_lib_dir</a>, <a href="#cmake-out_shared_libs">out_shared_libs</a>,
+      <a href="#cmake-out_static_libs">out_static_libs</a>, <a href="#cmake-postfix_script">postfix_script</a>, <a href="#cmake-shared_libraries">shared_libraries</a>, <a href="#cmake-static_libraries">static_libraries</a>, <a href="#cmake-tools_deps">tools_deps</a>,
       <a href="#cmake-working_directory">working_directory</a>)
 </pre>
 
@@ -84,7 +91,7 @@ Rule for building external library with CMake.
 | <a id="cmake-additional_inputs"></a>additional_inputs |  Optional additional inputs to be declared as needed for the shell script action.Not used by the shell script part in cc_external_rule_impl.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="cmake-additional_tools"></a>additional_tools |  Optional additional tools needed for the building. Not used by the shell script part in cc_external_rule_impl.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="cmake-alwayslink"></a>alwayslink |  Optional. if true, link all the object files from the static library, even if they are not used.   | Boolean | optional | False |
-| <a id="cmake-binaries"></a>binaries |  Optional names of the resulting binaries.   | List of strings | optional | [] |
+| <a id="cmake-binaries"></a>binaries |  __deprecated__: Use <code>out_binaries</code> instead.   | List of strings | optional | [] |
 | <a id="cmake-cache_entries"></a>cache_entries |  CMake cache entries to initialize (they will be passed with -Dkey=value) Values, defined by the toolchain, will be joined with the values, passed here. (Toolchain values come first)   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="cmake-cmake_options"></a>cmake_options |  Other CMake options   | List of strings | optional | [] |
 | <a id="cmake-data"></a>data |  Files needed by this rule at runtime. May list file or rule targets. Generally allows any target.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
@@ -93,19 +100,24 @@ Rule for building external library with CMake.
 | <a id="cmake-env"></a>env |  Environment variables to set during the build. $(execpath) macros may be used to point at files which are listed as data deps, tools_deps, or additional_tools, but unlike with other rules, these will be replaced with absolute paths to those files, because the build does not run in the exec root. No other macros are supported.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="cmake-env_vars"></a>env_vars |  CMake environment variable values to join with toolchain-defined. For example, additional CXXFLAGS.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="cmake-generate_crosstool_file"></a>generate_crosstool_file |  When True, CMake crosstool file will be generated from the toolchain values, provided cache-entries and env_vars (some values will still be passed as -Dkey=value and environment variables). If CMAKE_TOOLCHAIN_FILE cache entry is passed, specified crosstool file will be used When using this option to cross-compile, it is required to specify CMAKE_SYSTEM_NAME in the cache_entries   | Boolean | optional | True |
-| <a id="cmake-headers_only"></a>headers_only |  Flag variable to indicate that the library produces only headers   | Boolean | optional | False |
+| <a id="cmake-headers_only"></a>headers_only |  __deprecated__: Use <code>out_headers_only</code> instead.   | Boolean | optional | False |
 | <a id="cmake-install_prefix"></a>install_prefix |  Relative install prefix to be passed to CMake in -DCMAKE_INSTALL_PREFIX   | String | optional | "" |
-| <a id="cmake-interface_libraries"></a>interface_libraries |  Optional names of the resulting interface libraries.   | List of strings | optional | [] |
+| <a id="cmake-interface_libraries"></a>interface_libraries |  __deprecated__: Use <code>out_interface_libs</code> instead.   | List of strings | optional | [] |
 | <a id="cmake-lib_name"></a>lib_name |  Library name. Defines the name of the install directory and the name of the static library, if no output files parameters are defined (any of static_libraries, shared_libraries, interface_libraries, binaries_names) Optional. If not defined, defaults to the target's name.   | String | optional | "" |
 | <a id="cmake-lib_source"></a>lib_source |  Label with source code to build. Typically a filegroup for the source of remote repository. Mandatory.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a id="cmake-linkopts"></a>linkopts |  Optional link options to be passed up to the dependencies of this library   | List of strings | optional | [] |
 | <a id="cmake-make_commands"></a>make_commands |  Optinal make commands, defaults to ["make", "make install"]   | List of strings | optional | ["make", "make install"] |
 | <a id="cmake-out_bin_dir"></a>out_bin_dir |  Optional name of the output subdirectory with the binary files, defaults to 'bin'.   | String | optional | "bin" |
+| <a id="cmake-out_binaries"></a>out_binaries |  Optional names of the resulting binaries.   | List of strings | optional | [] |
+| <a id="cmake-out_headers_only"></a>out_headers_only |  Flag variable to indicate that the library produces only headers   | Boolean | optional | False |
 | <a id="cmake-out_include_dir"></a>out_include_dir |  Optional name of the output subdirectory with the header files, defaults to 'include'.   | String | optional | "include" |
+| <a id="cmake-out_interface_libs"></a>out_interface_libs |  Optional names of the resulting interface libraries.   | List of strings | optional | [] |
 | <a id="cmake-out_lib_dir"></a>out_lib_dir |  Optional name of the output subdirectory with the library files, defaults to 'lib'.   | String | optional | "lib" |
+| <a id="cmake-out_shared_libs"></a>out_shared_libs |  Optional names of the resulting shared libraries.   | List of strings | optional | [] |
+| <a id="cmake-out_static_libs"></a>out_static_libs |  Optional names of the resulting static libraries. Note that if <code>out_headers_only</code>, <code>out_static_libs</code>, <code>out_shared_libs</code>, and <code>out_binaries</code> are not set, default <code>lib_name.a</code>/<code>lib_name.lib</code> static library is assumed   | List of strings | optional | [] |
 | <a id="cmake-postfix_script"></a>postfix_script |  Optional part of the shell script to be added after the make commands   | String | optional | "" |
-| <a id="cmake-shared_libraries"></a>shared_libraries |  Optional names of the resulting shared libraries.   | List of strings | optional | [] |
-| <a id="cmake-static_libraries"></a>static_libraries |  Optional names of the resulting static libraries.   | List of strings | optional | [] |
+| <a id="cmake-shared_libraries"></a>shared_libraries |  __deprecated__: Use <code>out_shared_libs</code> instead.   | List of strings | optional | [] |
+| <a id="cmake-static_libraries"></a>static_libraries |  __deprecated__: Use <code>out_static_libs</code> instead.   | List of strings | optional | [] |
 | <a id="cmake-tools_deps"></a>tools_deps |  Optional tools to be copied into the directory structure. Similar to deps, those directly required for the external building of the library/binaries.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="cmake-working_directory"></a>working_directory |  Working directory, with the main CMakeLists.txt (otherwise, the top directory of the lib_source label files is used.)   | String | optional | "" |
 
@@ -139,7 +151,8 @@ configure_make(<a href="#configure_make-name">name</a>, <a href="#configure_make
                <a href="#configure_make-autoreconf">autoreconf</a>, <a href="#configure_make-autoreconf_env_vars">autoreconf_env_vars</a>, <a href="#configure_make-autoreconf_options">autoreconf_options</a>, <a href="#configure_make-binaries">binaries</a>, <a href="#configure_make-configure_command">configure_command</a>,
                <a href="#configure_make-configure_env_vars">configure_env_vars</a>, <a href="#configure_make-configure_in_place">configure_in_place</a>, <a href="#configure_make-configure_options">configure_options</a>, <a href="#configure_make-data">data</a>, <a href="#configure_make-defines">defines</a>, <a href="#configure_make-deps">deps</a>, <a href="#configure_make-env">env</a>,
                <a href="#configure_make-headers_only">headers_only</a>, <a href="#configure_make-install_prefix">install_prefix</a>, <a href="#configure_make-interface_libraries">interface_libraries</a>, <a href="#configure_make-lib_name">lib_name</a>, <a href="#configure_make-lib_source">lib_source</a>, <a href="#configure_make-linkopts">linkopts</a>,
-               <a href="#configure_make-make_commands">make_commands</a>, <a href="#configure_make-out_bin_dir">out_bin_dir</a>, <a href="#configure_make-out_include_dir">out_include_dir</a>, <a href="#configure_make-out_lib_dir">out_lib_dir</a>, <a href="#configure_make-postfix_script">postfix_script</a>,
+               <a href="#configure_make-make_commands">make_commands</a>, <a href="#configure_make-out_bin_dir">out_bin_dir</a>, <a href="#configure_make-out_binaries">out_binaries</a>, <a href="#configure_make-out_headers_only">out_headers_only</a>, <a href="#configure_make-out_include_dir">out_include_dir</a>,
+               <a href="#configure_make-out_interface_libs">out_interface_libs</a>, <a href="#configure_make-out_lib_dir">out_lib_dir</a>, <a href="#configure_make-out_shared_libs">out_shared_libs</a>, <a href="#configure_make-out_static_libs">out_static_libs</a>, <a href="#configure_make-postfix_script">postfix_script</a>,
                <a href="#configure_make-shared_libraries">shared_libraries</a>, <a href="#configure_make-static_libraries">static_libraries</a>, <a href="#configure_make-tools_deps">tools_deps</a>)
 </pre>
 
@@ -164,7 +177,7 @@ Rule for building external libraries with configure-make pattern. Some 'configur
 | <a id="configure_make-autoreconf"></a>autoreconf |  Set to True if 'autoreconf' should be invoked before 'configure.', currently requires 'configure_in_place' to be True.   | Boolean | optional | False |
 | <a id="configure_make-autoreconf_env_vars"></a>autoreconf_env_vars |  Environment variables to be set for 'autoreconf' invocation.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="configure_make-autoreconf_options"></a>autoreconf_options |  Any options to be put in the 'autoreconf.sh' command line.   | List of strings | optional | [] |
-| <a id="configure_make-binaries"></a>binaries |  Optional names of the resulting binaries.   | List of strings | optional | [] |
+| <a id="configure_make-binaries"></a>binaries |  __deprecated__: Use <code>out_binaries</code> instead.   | List of strings | optional | [] |
 | <a id="configure_make-configure_command"></a>configure_command |  The name of the configuration script file, default: configure. The file must be in the root of the source directory.   | String | optional | "configure" |
 | <a id="configure_make-configure_env_vars"></a>configure_env_vars |  Environment variables to be set for the 'configure' invocation.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="configure_make-configure_in_place"></a>configure_in_place |  Set to True if 'configure' should be invoked in place, i.e. from its enclosing directory.   | Boolean | optional | False |
@@ -173,19 +186,24 @@ Rule for building external libraries with configure-make pattern. Some 'configur
 | <a id="configure_make-defines"></a>defines |  Optional compilation definitions to be passed to the dependencies of this library. They are NOT passed to the compiler, you should duplicate them in the configuration options.   | List of strings | optional | [] |
 | <a id="configure_make-deps"></a>deps |  Optional dependencies to be copied into the directory structure. Typically those directly required for the external building of the library/binaries. (i.e. those that the external buidl system will be looking for and paths to which are provided by the calling rule)   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="configure_make-env"></a>env |  Environment variables to set during the build. $(execpath) macros may be used to point at files which are listed as data deps, tools_deps, or additional_tools, but unlike with other rules, these will be replaced with absolute paths to those files, because the build does not run in the exec root. No other macros are supported.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
-| <a id="configure_make-headers_only"></a>headers_only |  Flag variable to indicate that the library produces only headers   | Boolean | optional | False |
+| <a id="configure_make-headers_only"></a>headers_only |  __deprecated__: Use <code>out_headers_only</code> instead.   | Boolean | optional | False |
 | <a id="configure_make-install_prefix"></a>install_prefix |  Install prefix, i.e. relative path to where to install the result of the build. Passed to the 'configure' script with --prefix flag.   | String | optional | "" |
-| <a id="configure_make-interface_libraries"></a>interface_libraries |  Optional names of the resulting interface libraries.   | List of strings | optional | [] |
+| <a id="configure_make-interface_libraries"></a>interface_libraries |  __deprecated__: Use <code>out_interface_libs</code> instead.   | List of strings | optional | [] |
 | <a id="configure_make-lib_name"></a>lib_name |  Library name. Defines the name of the install directory and the name of the static library, if no output files parameters are defined (any of static_libraries, shared_libraries, interface_libraries, binaries_names) Optional. If not defined, defaults to the target's name.   | String | optional | "" |
 | <a id="configure_make-lib_source"></a>lib_source |  Label with source code to build. Typically a filegroup for the source of remote repository. Mandatory.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a id="configure_make-linkopts"></a>linkopts |  Optional link options to be passed up to the dependencies of this library   | List of strings | optional | [] |
 | <a id="configure_make-make_commands"></a>make_commands |  Optinal make commands, defaults to ["make", "make install"]   | List of strings | optional | ["make", "make install"] |
 | <a id="configure_make-out_bin_dir"></a>out_bin_dir |  Optional name of the output subdirectory with the binary files, defaults to 'bin'.   | String | optional | "bin" |
+| <a id="configure_make-out_binaries"></a>out_binaries |  Optional names of the resulting binaries.   | List of strings | optional | [] |
+| <a id="configure_make-out_headers_only"></a>out_headers_only |  Flag variable to indicate that the library produces only headers   | Boolean | optional | False |
 | <a id="configure_make-out_include_dir"></a>out_include_dir |  Optional name of the output subdirectory with the header files, defaults to 'include'.   | String | optional | "include" |
+| <a id="configure_make-out_interface_libs"></a>out_interface_libs |  Optional names of the resulting interface libraries.   | List of strings | optional | [] |
 | <a id="configure_make-out_lib_dir"></a>out_lib_dir |  Optional name of the output subdirectory with the library files, defaults to 'lib'.   | String | optional | "lib" |
+| <a id="configure_make-out_shared_libs"></a>out_shared_libs |  Optional names of the resulting shared libraries.   | List of strings | optional | [] |
+| <a id="configure_make-out_static_libs"></a>out_static_libs |  Optional names of the resulting static libraries. Note that if <code>out_headers_only</code>, <code>out_static_libs</code>, <code>out_shared_libs</code>, and <code>out_binaries</code> are not set, default <code>lib_name.a</code>/<code>lib_name.lib</code> static library is assumed   | List of strings | optional | [] |
 | <a id="configure_make-postfix_script"></a>postfix_script |  Optional part of the shell script to be added after the make commands   | String | optional | "" |
-| <a id="configure_make-shared_libraries"></a>shared_libraries |  Optional names of the resulting shared libraries.   | List of strings | optional | [] |
-| <a id="configure_make-static_libraries"></a>static_libraries |  Optional names of the resulting static libraries.   | List of strings | optional | [] |
+| <a id="configure_make-shared_libraries"></a>shared_libraries |  __deprecated__: Use <code>out_shared_libs</code> instead.   | List of strings | optional | [] |
+| <a id="configure_make-static_libraries"></a>static_libraries |  __deprecated__: Use <code>out_static_libs</code> instead.   | List of strings | optional | [] |
 | <a id="configure_make-tools_deps"></a>tools_deps |  Optional tools to be copied into the directory structure. Similar to deps, those directly required for the external building of the library/binaries.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 
 
@@ -196,8 +214,9 @@ Rule for building external libraries with configure-make pattern. Some 'configur
 <pre>
 make(<a href="#make-name">name</a>, <a href="#make-additional_inputs">additional_inputs</a>, <a href="#make-additional_tools">additional_tools</a>, <a href="#make-alwayslink">alwayslink</a>, <a href="#make-binaries">binaries</a>, <a href="#make-data">data</a>, <a href="#make-defines">defines</a>, <a href="#make-deps">deps</a>, <a href="#make-env">env</a>,
      <a href="#make-headers_only">headers_only</a>, <a href="#make-interface_libraries">interface_libraries</a>, <a href="#make-keep_going">keep_going</a>, <a href="#make-lib_name">lib_name</a>, <a href="#make-lib_source">lib_source</a>, <a href="#make-linkopts">linkopts</a>, <a href="#make-make_commands">make_commands</a>,
-     <a href="#make-make_env_vars">make_env_vars</a>, <a href="#make-out_bin_dir">out_bin_dir</a>, <a href="#make-out_include_dir">out_include_dir</a>, <a href="#make-out_lib_dir">out_lib_dir</a>, <a href="#make-postfix_script">postfix_script</a>, <a href="#make-prefix">prefix</a>,
-     <a href="#make-shared_libraries">shared_libraries</a>, <a href="#make-static_libraries">static_libraries</a>, <a href="#make-tools_deps">tools_deps</a>)
+     <a href="#make-make_env_vars">make_env_vars</a>, <a href="#make-out_bin_dir">out_bin_dir</a>, <a href="#make-out_binaries">out_binaries</a>, <a href="#make-out_headers_only">out_headers_only</a>, <a href="#make-out_include_dir">out_include_dir</a>, <a href="#make-out_interface_libs">out_interface_libs</a>,
+     <a href="#make-out_lib_dir">out_lib_dir</a>, <a href="#make-out_shared_libs">out_shared_libs</a>, <a href="#make-out_static_libs">out_static_libs</a>, <a href="#make-postfix_script">postfix_script</a>, <a href="#make-prefix">prefix</a>, <a href="#make-shared_libraries">shared_libraries</a>,
+     <a href="#make-static_libraries">static_libraries</a>, <a href="#make-tools_deps">tools_deps</a>)
 </pre>
 
 Rule for building external libraries with GNU Make. GNU Make commands (make and make install by default) are invoked with prefix="install" (by default), and other environment variables for compilation and linking, taken from Bazel C/C++ toolchain and passed dependencies.
@@ -211,13 +230,13 @@ Rule for building external libraries with GNU Make. GNU Make commands (make and 
 | <a id="make-additional_inputs"></a>additional_inputs |  Optional additional inputs to be declared as needed for the shell script action.Not used by the shell script part in cc_external_rule_impl.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="make-additional_tools"></a>additional_tools |  Optional additional tools needed for the building. Not used by the shell script part in cc_external_rule_impl.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="make-alwayslink"></a>alwayslink |  Optional. if true, link all the object files from the static library, even if they are not used.   | Boolean | optional | False |
-| <a id="make-binaries"></a>binaries |  Optional names of the resulting binaries.   | List of strings | optional | [] |
+| <a id="make-binaries"></a>binaries |  __deprecated__: Use <code>out_binaries</code> instead.   | List of strings | optional | [] |
 | <a id="make-data"></a>data |  Files needed by this rule at runtime. May list file or rule targets. Generally allows any target.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="make-defines"></a>defines |  Optional compilation definitions to be passed to the dependencies of this library. They are NOT passed to the compiler, you should duplicate them in the configuration options.   | List of strings | optional | [] |
 | <a id="make-deps"></a>deps |  Optional dependencies to be copied into the directory structure. Typically those directly required for the external building of the library/binaries. (i.e. those that the external buidl system will be looking for and paths to which are provided by the calling rule)   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="make-env"></a>env |  Environment variables to set during the build. $(execpath) macros may be used to point at files which are listed as data deps, tools_deps, or additional_tools, but unlike with other rules, these will be replaced with absolute paths to those files, because the build does not run in the exec root. No other macros are supported.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
-| <a id="make-headers_only"></a>headers_only |  Flag variable to indicate that the library produces only headers   | Boolean | optional | False |
-| <a id="make-interface_libraries"></a>interface_libraries |  Optional names of the resulting interface libraries.   | List of strings | optional | [] |
+| <a id="make-headers_only"></a>headers_only |  __deprecated__: Use <code>out_headers_only</code> instead.   | Boolean | optional | False |
+| <a id="make-interface_libraries"></a>interface_libraries |  __deprecated__: Use <code>out_interface_libs</code> instead.   | List of strings | optional | [] |
 | <a id="make-keep_going"></a>keep_going |  Keep going when some targets can not be made, -k flag is passed to make (applies only if make_commands attribute is not set). Please have a look at _create_make_script for default make_commands.   | Boolean | optional | True |
 | <a id="make-lib_name"></a>lib_name |  Library name. Defines the name of the install directory and the name of the static library, if no output files parameters are defined (any of static_libraries, shared_libraries, interface_libraries, binaries_names) Optional. If not defined, defaults to the target's name.   | String | optional | "" |
 | <a id="make-lib_source"></a>lib_source |  Label with source code to build. Typically a filegroup for the source of remote repository. Mandatory.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
@@ -225,12 +244,17 @@ Rule for building external libraries with GNU Make. GNU Make commands (make and 
 | <a id="make-make_commands"></a>make_commands |  Overriding make_commands default value to be empty, then we can provide better default value programmatically   | List of strings | optional | [] |
 | <a id="make-make_env_vars"></a>make_env_vars |  Environment variables to be set for the 'configure' invocation.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="make-out_bin_dir"></a>out_bin_dir |  Optional name of the output subdirectory with the binary files, defaults to 'bin'.   | String | optional | "bin" |
+| <a id="make-out_binaries"></a>out_binaries |  Optional names of the resulting binaries.   | List of strings | optional | [] |
+| <a id="make-out_headers_only"></a>out_headers_only |  Flag variable to indicate that the library produces only headers   | Boolean | optional | False |
 | <a id="make-out_include_dir"></a>out_include_dir |  Optional name of the output subdirectory with the header files, defaults to 'include'.   | String | optional | "include" |
+| <a id="make-out_interface_libs"></a>out_interface_libs |  Optional names of the resulting interface libraries.   | List of strings | optional | [] |
 | <a id="make-out_lib_dir"></a>out_lib_dir |  Optional name of the output subdirectory with the library files, defaults to 'lib'.   | String | optional | "lib" |
+| <a id="make-out_shared_libs"></a>out_shared_libs |  Optional names of the resulting shared libraries.   | List of strings | optional | [] |
+| <a id="make-out_static_libs"></a>out_static_libs |  Optional names of the resulting static libraries. Note that if <code>out_headers_only</code>, <code>out_static_libs</code>, <code>out_shared_libs</code>, and <code>out_binaries</code> are not set, default <code>lib_name.a</code>/<code>lib_name.lib</code> static library is assumed   | List of strings | optional | [] |
 | <a id="make-postfix_script"></a>postfix_script |  Optional part of the shell script to be added after the make commands   | String | optional | "" |
 | <a id="make-prefix"></a>prefix |  Install prefix, an absolute path. Passed to the GNU make via "make install PREFIX=&lt;value&gt;". By default, the install directory created under sandboxed execution root is used. Build results are copied to the Bazel's output directory, so the prefix is only important if it is recorded into any text files by Makefile script. In that case, it is important to note that rules_foreign_cc is overriding the paths under execution root with "BAZEL_GEN_ROOT" value.   | String | optional | "" |
-| <a id="make-shared_libraries"></a>shared_libraries |  Optional names of the resulting shared libraries.   | List of strings | optional | [] |
-| <a id="make-static_libraries"></a>static_libraries |  Optional names of the resulting static libraries.   | List of strings | optional | [] |
+| <a id="make-shared_libraries"></a>shared_libraries |  __deprecated__: Use <code>out_shared_libs</code> instead.   | List of strings | optional | [] |
+| <a id="make-static_libraries"></a>static_libraries |  __deprecated__: Use <code>out_static_libs</code> instead.   | List of strings | optional | [] |
 | <a id="make-tools_deps"></a>tools_deps |  Optional tools to be copied into the directory structure. Similar to deps, those directly required for the external building of the library/binaries.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 
 
@@ -280,7 +304,8 @@ Rule for defining the toolchain data of the native tools (cmake, ninja), to be u
 <pre>
 ninja(<a href="#ninja-name">name</a>, <a href="#ninja-additional_inputs">additional_inputs</a>, <a href="#ninja-additional_tools">additional_tools</a>, <a href="#ninja-alwayslink">alwayslink</a>, <a href="#ninja-args">args</a>, <a href="#ninja-binaries">binaries</a>, <a href="#ninja-data">data</a>, <a href="#ninja-defines">defines</a>, <a href="#ninja-deps">deps</a>,
       <a href="#ninja-directory">directory</a>, <a href="#ninja-env">env</a>, <a href="#ninja-headers_only">headers_only</a>, <a href="#ninja-interface_libraries">interface_libraries</a>, <a href="#ninja-lib_name">lib_name</a>, <a href="#ninja-lib_source">lib_source</a>, <a href="#ninja-linkopts">linkopts</a>, <a href="#ninja-out_bin_dir">out_bin_dir</a>,
-      <a href="#ninja-out_include_dir">out_include_dir</a>, <a href="#ninja-out_lib_dir">out_lib_dir</a>, <a href="#ninja-postfix_script">postfix_script</a>, <a href="#ninja-shared_libraries">shared_libraries</a>, <a href="#ninja-static_libraries">static_libraries</a>, <a href="#ninja-targets">targets</a>,
+      <a href="#ninja-out_binaries">out_binaries</a>, <a href="#ninja-out_headers_only">out_headers_only</a>, <a href="#ninja-out_include_dir">out_include_dir</a>, <a href="#ninja-out_interface_libs">out_interface_libs</a>, <a href="#ninja-out_lib_dir">out_lib_dir</a>,
+      <a href="#ninja-out_shared_libs">out_shared_libs</a>, <a href="#ninja-out_static_libs">out_static_libs</a>, <a href="#ninja-postfix_script">postfix_script</a>, <a href="#ninja-shared_libraries">shared_libraries</a>, <a href="#ninja-static_libraries">static_libraries</a>, <a href="#ninja-targets">targets</a>,
       <a href="#ninja-tools_deps">tools_deps</a>)
 </pre>
 
@@ -296,23 +321,28 @@ Rule for building external libraries with [Ninja](https://ninja-build.org/).
 | <a id="ninja-additional_tools"></a>additional_tools |  Optional additional tools needed for the building. Not used by the shell script part in cc_external_rule_impl.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="ninja-alwayslink"></a>alwayslink |  Optional. if true, link all the object files from the static library, even if they are not used.   | Boolean | optional | False |
 | <a id="ninja-args"></a>args |  A list of arguments to pass to the call to <code>ninja</code>   | List of strings | optional | [] |
-| <a id="ninja-binaries"></a>binaries |  Optional names of the resulting binaries.   | List of strings | optional | [] |
+| <a id="ninja-binaries"></a>binaries |  __deprecated__: Use <code>out_binaries</code> instead.   | List of strings | optional | [] |
 | <a id="ninja-data"></a>data |  Files needed by this rule at runtime. May list file or rule targets. Generally allows any target.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="ninja-defines"></a>defines |  Optional compilation definitions to be passed to the dependencies of this library. They are NOT passed to the compiler, you should duplicate them in the configuration options.   | List of strings | optional | [] |
 | <a id="ninja-deps"></a>deps |  Optional dependencies to be copied into the directory structure. Typically those directly required for the external building of the library/binaries. (i.e. those that the external buidl system will be looking for and paths to which are provided by the calling rule)   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="ninja-directory"></a>directory |  A directory to pass as the <code>-C</code> argument. The rule will always use the root directory of the <code>lib_sources</code> attribute if this attribute is not set   | String | optional | "" |
 | <a id="ninja-env"></a>env |  Environment variables to set during the build. $(execpath) macros may be used to point at files which are listed as data deps, tools_deps, or additional_tools, but unlike with other rules, these will be replaced with absolute paths to those files, because the build does not run in the exec root. No other macros are supported.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
-| <a id="ninja-headers_only"></a>headers_only |  Flag variable to indicate that the library produces only headers   | Boolean | optional | False |
-| <a id="ninja-interface_libraries"></a>interface_libraries |  Optional names of the resulting interface libraries.   | List of strings | optional | [] |
+| <a id="ninja-headers_only"></a>headers_only |  __deprecated__: Use <code>out_headers_only</code> instead.   | Boolean | optional | False |
+| <a id="ninja-interface_libraries"></a>interface_libraries |  __deprecated__: Use <code>out_interface_libs</code> instead.   | List of strings | optional | [] |
 | <a id="ninja-lib_name"></a>lib_name |  Library name. Defines the name of the install directory and the name of the static library, if no output files parameters are defined (any of static_libraries, shared_libraries, interface_libraries, binaries_names) Optional. If not defined, defaults to the target's name.   | String | optional | "" |
 | <a id="ninja-lib_source"></a>lib_source |  Label with source code to build. Typically a filegroup for the source of remote repository. Mandatory.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a id="ninja-linkopts"></a>linkopts |  Optional link options to be passed up to the dependencies of this library   | List of strings | optional | [] |
 | <a id="ninja-out_bin_dir"></a>out_bin_dir |  Optional name of the output subdirectory with the binary files, defaults to 'bin'.   | String | optional | "bin" |
+| <a id="ninja-out_binaries"></a>out_binaries |  Optional names of the resulting binaries.   | List of strings | optional | [] |
+| <a id="ninja-out_headers_only"></a>out_headers_only |  Flag variable to indicate that the library produces only headers   | Boolean | optional | False |
 | <a id="ninja-out_include_dir"></a>out_include_dir |  Optional name of the output subdirectory with the header files, defaults to 'include'.   | String | optional | "include" |
+| <a id="ninja-out_interface_libs"></a>out_interface_libs |  Optional names of the resulting interface libraries.   | List of strings | optional | [] |
 | <a id="ninja-out_lib_dir"></a>out_lib_dir |  Optional name of the output subdirectory with the library files, defaults to 'lib'.   | String | optional | "lib" |
+| <a id="ninja-out_shared_libs"></a>out_shared_libs |  Optional names of the resulting shared libraries.   | List of strings | optional | [] |
+| <a id="ninja-out_static_libs"></a>out_static_libs |  Optional names of the resulting static libraries. Note that if <code>out_headers_only</code>, <code>out_static_libs</code>, <code>out_shared_libs</code>, and <code>out_binaries</code> are not set, default <code>lib_name.a</code>/<code>lib_name.lib</code> static library is assumed   | List of strings | optional | [] |
 | <a id="ninja-postfix_script"></a>postfix_script |  Optional part of the shell script to be added after the make commands   | String | optional | "" |
-| <a id="ninja-shared_libraries"></a>shared_libraries |  Optional names of the resulting shared libraries.   | List of strings | optional | [] |
-| <a id="ninja-static_libraries"></a>static_libraries |  Optional names of the resulting static libraries.   | List of strings | optional | [] |
+| <a id="ninja-shared_libraries"></a>shared_libraries |  __deprecated__: Use <code>out_shared_libs</code> instead.   | List of strings | optional | [] |
+| <a id="ninja-static_libraries"></a>static_libraries |  __deprecated__: Use <code>out_static_libs</code> instead.   | List of strings | optional | [] |
 | <a id="ninja-targets"></a>targets |  A list of ninja targets to build. To call the default target, simply pass <code>""</code> as one of the items to this attribute.   | List of strings | optional | [] |
 | <a id="ninja-tools_deps"></a>tools_deps |  Optional tools to be copied into the directory structure. Similar to deps, those directly required for the external building of the library/binaries.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 

--- a/examples/cmake_crosstool/BUILD.bazel
+++ b/examples/cmake_crosstool/BUILD.bazel
@@ -16,7 +16,7 @@ cmake(
     name = "hello_cmake",
     lib_source = "//static:srcs",
     out_include_dir = "include/version123",
-    static_libraries = ["libhello.a"],
+    out_static_libs = ["libhello.a"],
 )
 
 # I do not make it a test, since it is a cross-compilation example,

--- a/examples/cmake_crosstool/static/BUILD.bazel
+++ b/examples/cmake_crosstool/static/BUILD.bazel
@@ -29,7 +29,7 @@ cmake(
     make_commands = ["MSBuild.exe INSTALL.vcxproj"],
     # pass include/version123 to C/C++ provider as include directory
     out_include_dir = "include/version123",
-    static_libraries = ["hello.lib"],
+    out_static_libs = ["hello.lib"],
 )
 
 cmake(
@@ -42,7 +42,7 @@ cmake(
     ],
     # pass include/version123 to C/C++ provider as include directory
     out_include_dir = "include/version123",
-    static_libraries = ["hello.lib"],
+    out_static_libs = ["hello.lib"],
 )
 
 cmake(
@@ -55,7 +55,7 @@ cmake(
     ],
     # pass include/version123 to C/C++ provider as include directory
     out_include_dir = "include/version123",
-    static_libraries = ["hello.lib"],
+    out_static_libs = ["hello.lib"],
 )
 
 cc_binary(
@@ -120,7 +120,7 @@ cmake(
     lib_source = ":srcs",
     out_include_dir = "include",
     # the name of the static library != <name>.a, put it explicitly
-    static_libraries = ["libhello.a"],
+    out_static_libs = ["libhello.a"],
 )
 
 cc_binary(

--- a/examples/cmake_defines/BUILD.bazel
+++ b/examples/cmake_defines/BUILD.bazel
@@ -3,7 +3,7 @@ load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake")
 cmake(
     name = "lib_a",
     lib_source = ":lib_a_sources",
-    static_libraries = select({
+    out_static_libs = select({
         "//:windows": ["lib_a.lib"],
         "//conditions:default": ["liblib_a.a"],
     }),
@@ -14,7 +14,7 @@ cmake(
     name = "lib_b",
     defines = ["FOO"],
     lib_source = ":lib_b_sources",
-    static_libraries = select({
+    out_static_libs = select({
         "//:windows": ["lib_b.lib"],
         "//conditions:default": ["liblib_b.a"],
     }),

--- a/examples/cmake_hello_world_lib/binary/BUILD.bazel
+++ b/examples/cmake_hello_world_lib/binary/BUILD.bazel
@@ -11,16 +11,16 @@ filegroup(
 
 cmake(
     name = "libhello",
-    binaries = select({
-        "//:windows": ["hello.exe"],
-        "//conditions:default": ["hello"],
-    }),
     # Probably this variable should be set by default.
     # Apparently, it needs to be set for shared libraries on Mac OS
     cache_entries = {
         "CMAKE_MACOSX_RPATH": "True",
     },
     lib_source = ":srcs",
+    out_binaries = select({
+        "//:windows": ["hello.exe"],
+        "//conditions:default": ["hello"],
+    }),
 )
 
 filegroup(

--- a/examples/cmake_hello_world_lib/shared/BUILD.bazel
+++ b/examples/cmake_hello_world_lib/shared/BUILD.bazel
@@ -18,7 +18,7 @@ cmake(
         "CMAKE_MACOSX_RPATH": "True",
     },
     lib_source = ":srcs",
-    shared_libraries = select({
+    out_shared_libs = select({
         "//:macos": ["libhello.dylib"],
         "//:windows": ["libhello.dll"],
         "//conditions:default": ["libhello.so"],

--- a/examples/cmake_hello_world_lib/static/BUILD.bazel
+++ b/examples/cmake_hello_world_lib/static/BUILD.bazel
@@ -26,7 +26,7 @@ cmake(
     make_commands = ["MSBuild.exe INSTALL.vcxproj"],
     # pass include/version123 to C/C++ provider as include directory
     out_include_dir = "include/version123",
-    static_libraries = ["hello.lib"],
+    out_static_libs = ["hello.lib"],
     # TODO: Update to `exec_compatible_with`
     tags = ["manual"],
 )
@@ -41,7 +41,7 @@ cmake(
     ],
     # pass include/version123 to C/C++ provider as include directory
     out_include_dir = "include/version123",
-    static_libraries = ["hello.lib"],
+    out_static_libs = ["hello.lib"],
     # TODO: Update to `exec_compatible_with`
     tags = ["manual"],
 )
@@ -56,7 +56,7 @@ cmake(
     ],
     # pass include/version123 to C/C++ provider as include directory
     out_include_dir = "include/version123",
-    static_libraries = ["hello.lib"],
+    out_static_libs = ["hello.lib"],
     # TODO: Update to `exec_compatible_with`
     tags = ["manual"],
 )
@@ -126,7 +126,7 @@ cmake(
     lib_source = ":srcs",
     out_include_dir = "include",
     # the name of the static library != <name>.a, put it explicitly
-    static_libraries = ["libhello.a"],
+    out_static_libs = ["libhello.a"],
 )
 
 cc_binary(

--- a/examples/cmake_hello_world_variant/BUILD.bazel
+++ b/examples/cmake_hello_world_variant/BUILD.bazel
@@ -2,17 +2,17 @@ load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake")
 
 cmake(
     name = "hello_world",
-    binaries = select({
-        "//:macos": ["CMakeHelloWorld"],
-        "//:windows": ["CMakeHelloWorld.exe"],
-        "//conditions:default": ["CMakeHelloWorld"],
-    }),
     cmake_options = ["-GNinja"],
     lib_source = "@cmake_hello_world_variant_src//:all",
     make_commands = [
         "ninja",
         "ninja install",
     ],
+    out_binaries = select({
+        "//:macos": ["CMakeHelloWorld"],
+        "//:windows": ["CMakeHelloWorld.exe"],
+        "//conditions:default": ["CMakeHelloWorld"],
+    }),
 )
 
 filegroup(

--- a/examples/cmake_with_bazel_transitive/BUILD.bazel
+++ b/examples/cmake_with_bazel_transitive/BUILD.bazel
@@ -18,7 +18,7 @@ cmake(
         "ninja",
         "ninja install",
     ],
-    static_libraries = ["libb.a"],
+    out_static_libs = ["libb.a"],
     # This library is with public visibility, we can reuse it here.
     deps = ["//cmake_synthetic/liba:lib_a_bazel"],
 )

--- a/examples/cmake_with_data/BUILD.bazel
+++ b/examples/cmake_with_data/BUILD.bazel
@@ -27,7 +27,7 @@ cmake(
             "make install",
         ],
     }),
-    static_libraries = select({
+    out_static_libs = select({
         "@bazel_tools//src/conditions:windows": ["lib_a.lib"],
         "//conditions:default": ["lib_a.a"],
     }),

--- a/examples/configure_use_malloc/BUILD.bazel
+++ b/examples/configure_use_malloc/BUILD.bazel
@@ -9,7 +9,7 @@ configure_make(
         "--disable-libunwind",
     ],
     lib_source = "@gperftools//:all",
-    static_libraries = ["libtcmalloc_and_profiler.a"],
+    out_static_libs = ["libtcmalloc_and_profiler.a"],
 )
 
 # This currently gives an error:

--- a/examples/make_simple/BUILD.bazel
+++ b/examples/make_simple/BUILD.bazel
@@ -7,7 +7,7 @@ make(
         "CLANG_WRAPPER": "$(execpath //make_simple/code:clang_wrapper.sh)",
     },
     lib_source = "//make_simple/code:srcs",
-    static_libraries = ["liba.a"],
+    out_static_libs = ["liba.a"],
     tools_deps = ["//make_simple/code:clang_wrapper.sh"],
 )
 

--- a/examples/ninja_simple/BUILD.bazel
+++ b/examples/ninja_simple/BUILD.bazel
@@ -4,7 +4,7 @@ load("@rules_foreign_cc//tools/build_defs:ninja.bzl", "ninja")
 ninja(
     name = "ninja_lib",
     lib_source = "//ninja_simple/code:srcs",
-    static_libraries = ["liba.a"],
+    out_static_libs = ["liba.a"],
     targets = [
         "",
         "install",

--- a/examples/third_party/bison/BUILD.bison.bazel
+++ b/examples/third_party/bison/BUILD.bison.bazel
@@ -10,10 +10,10 @@ filegroup(
 # I tested and this builds for me on MAC and Linux, did not check Windows thouigh
 configure_make(
     name = "bison",
-    binaries = [
+    lib_source = ":all_srcs",
+    out_binaries = [
         "bison",
         "yacc",
     ],
-    lib_source = ":all_srcs",
-    static_libraries = ["liby.a"],
+    out_static_libs = ["liby.a"],
 )

--- a/examples/third_party/cares/BUILD.cares.bazel
+++ b/examples/third_party/cares/BUILD.cares.bazel
@@ -21,7 +21,7 @@ cmake(
         "ninja",
         "ninja install",
     ],
-    static_libraries = select({
+    out_static_libs = select({
         "@platforms//os:windows": ["cares.lib"],
         "//conditions:default": ["libcares.a"],
     }),

--- a/examples/third_party/curl/BUILD.curl.bazel
+++ b/examples/third_party/curl/BUILD.curl.bazel
@@ -45,7 +45,7 @@ cmake(
             "make install",
         ],
     }),
-    static_libraries = select({
+    out_static_libs = select({
         "@platforms//os:windows": ["libcurl.lib"],
         "//conditions:default": ["libcurl.a"],
     }),

--- a/examples/third_party/gn/BUILD.gn.bazel
+++ b/examples/third_party/gn/BUILD.gn.bazel
@@ -19,12 +19,16 @@ config_setting(
 
 ninja(
     name = "gn",
-    binaries = select({
+    directory = "out",
+    lib_source = "//:srcs",
+    out_binaries = select({
         ":windows": ["gn.exe"],
         "//conditions:default": ["gn"],
     }),
-    directory = "out",
-    lib_source = "//:srcs",
+    out_static_libs = select({
+        ":windows": ["gn_lib.lib"],
+        "//conditions:default": ["gn_lib.a"],
+    }),
     # gn has no install step, manually grab the artifacts
     postfix_script = select({
         ":windows": " && ".join([
@@ -35,10 +39,6 @@ ninja(
             "cp out/gn_lib.a $$INSTALLDIR$$/lib",
             "cp out/gn $$INSTALLDIR$$/bin",
         ]),
-    }),
-    static_libraries = select({
-        ":windows": ["gn_lib.lib"],
-        "//conditions:default": ["gn_lib.a"],
     }),
 )
 

--- a/examples/third_party/iconv/BUILD.iconv.bazel
+++ b/examples/third_party/iconv/BUILD.iconv.bazel
@@ -21,7 +21,7 @@ configure_make(
     ],
     lib_source = "@iconv//:all",
     make_commands = ["make install-lib"],
-    static_libraries = [
+    out_static_libs = [
         "libiconv.a",
     ],
     visibility = ["//visibility:public"],

--- a/examples/third_party/libgit2/BUILD.libgit2.bazel
+++ b/examples/third_party/libgit2/BUILD.libgit2.bazel
@@ -30,7 +30,7 @@ cmake(
         "//conditions:default": _CACHE_ENTRIES,
     }),
     lib_source = ":all_srcs",
-    static_libraries = select({
+    out_static_libs = select({
         # TODO: I'm guessing at this name. Needs to be checked on windows.
         "@platforms//os:windows": ["git2.lib"],
         "//conditions:default": ["libgit2.a"],

--- a/examples/third_party/libpng/BUILD.libpng.bazel
+++ b/examples/third_party/libpng/BUILD.libpng.bazel
@@ -14,6 +14,6 @@ cmake(
     },
     lib_source = "//:all_srcs",
     out_include_dir = "include/libpng16",
-    static_libraries = ["libpng16.a"],
+    out_static_libs = ["libpng16.a"],
     deps = ["@zlib"],
 )

--- a/examples/third_party/libssh2/BUILD.libssh2.bazel
+++ b/examples/third_party/libssh2/BUILD.libssh2.bazel
@@ -24,7 +24,7 @@ cmake(
         "//conditions:default": _CACHE_ENTRIES,
     }),
     lib_source = ":all_srcs",
-    static_libraries = select({
+    out_static_libs = select({
         # TODO: I'm guessing at this name. Needs to be checked on windows.
         "@platforms//os:windows": ["ssh2.lib"],
         "//conditions:default": ["libssh2.a"],

--- a/examples/third_party/openssl/BUILD.openssl.bazel
+++ b/examples/third_party/openssl/BUILD.openssl.bazel
@@ -41,7 +41,7 @@ configure_make(
         "make build_libs",
         "make install_dev",
     ],
-    static_libraries = [
+    out_static_libs = [
         "libcrypto.a",
         "libssl.a",
     ],

--- a/examples/third_party/pcre/BUILD.pcre.bazel
+++ b/examples/third_party/pcre/BUILD.pcre.bazel
@@ -15,7 +15,7 @@ cmake(
         "CMAKE_C_FLAGS": "${CMAKE_C_FLAGS:-} -fPIC",
     },
     lib_source = ":all_srcs",
-    static_libraries = ["libpcre.a"],
+    out_static_libs = ["libpcre.a"],
 )
 
 filegroup(

--- a/examples/third_party/zlib/BUILD.zlib.bazel
+++ b/examples/third_party/zlib/BUILD.zlib.bazel
@@ -24,7 +24,7 @@ cmake(
             "make install",
         ],
     }),
-    static_libraries = select({
+    out_static_libs = select({
         "@platforms//os:windows": ["zlibstatic.lib"],
         "//conditions:default": ["libz.a"],
     }),


### PR DESCRIPTION
This clears up some confusion I've seen users run into by renaming some attributes

| old                 | new                |
| ------------------- | ------------------ |
| binaries            | out_binaries       |
| headers_only        | out_headers_only   |
| interface_libraries | out_interface_libs |
| shared_libraries    | out_shared_libs    |
| static_libraries    | out_static_libs    |



Note that the old attributes are still supported for a short while longer so users can comfortably transition.