### PR TITLE
Renamed `cmake_external` to `cmake`

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,9 @@ http_archive(
 And in the `BUILD.bazel` file, put:
 
 ```python
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake")
 
-cmake_external(
+cmake(
     name = "pcre",
     cache_entries = {
         "CMAKE_C_FLAGS": "-fPIC",
@@ -171,7 +171,7 @@ Example usage (see full example in `./examples/cmake_hello_world_lib`):
 Example assumes that MS Visual Studio and Ninja are installed on the host machine, and Ninja bin directory is added to PATH.
 
 ```python
-cmake_external(
+cmake(
     # expect to find ./lib/hello.lib as the result of the build
     name = "hello",
     # This option can be omitted
@@ -181,7 +181,7 @@ cmake_external(
     make_commands = ["MSBuild.exe INSTALL.vcxproj"],
 )
 
-cmake_external(
+cmake(
     name = "hello_ninja",
     # expect to find ./lib/hello.lib as the result of the build
     lib_name = "hello",
@@ -195,7 +195,7 @@ cmake_external(
     ],
 )
 
-cmake_external(
+cmake(
     name = "hello_nmake",
     # explicitly specify the generator
     cmake_options = ["-G \"NMake Makefiles\""],

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Rules Foreign CC
 
 - [boost_build](#boost_build)
-- [cmake_external](#cmake_external)
+- [cmake](#cmake)
 - [cmake_tool](#cmake_tool)
 - [ConfigureParameters](#ConfigureParameters)
 - [configure_make](#configure_make)
@@ -61,16 +61,16 @@ Rule for building Boost. Invokes bootstrap.sh and then b2 install.
 | <a id="boost_build-user_options"></a>user_options |  any additional flags to pass to b2   | List of strings | optional | [] |
 
 
-<a id="#cmake_external"></a>
+<a id="#cmake"></a>
 
-## cmake_external
+## cmake
 
 <pre>
-cmake_external(<a href="#cmake_external-name">name</a>, <a href="#cmake_external-additional_inputs">additional_inputs</a>, <a href="#cmake_external-additional_tools">additional_tools</a>, <a href="#cmake_external-alwayslink">alwayslink</a>, <a href="#cmake_external-binaries">binaries</a>, <a href="#cmake_external-cache_entries">cache_entries</a>,
-               <a href="#cmake_external-cmake_options">cmake_options</a>, <a href="#cmake_external-data">data</a>, <a href="#cmake_external-defines">defines</a>, <a href="#cmake_external-deps">deps</a>, <a href="#cmake_external-env">env</a>, <a href="#cmake_external-env_vars">env_vars</a>, <a href="#cmake_external-generate_crosstool_file">generate_crosstool_file</a>,
-               <a href="#cmake_external-headers_only">headers_only</a>, <a href="#cmake_external-install_prefix">install_prefix</a>, <a href="#cmake_external-interface_libraries">interface_libraries</a>, <a href="#cmake_external-lib_name">lib_name</a>, <a href="#cmake_external-lib_source">lib_source</a>, <a href="#cmake_external-linkopts">linkopts</a>,
-               <a href="#cmake_external-make_commands">make_commands</a>, <a href="#cmake_external-out_bin_dir">out_bin_dir</a>, <a href="#cmake_external-out_include_dir">out_include_dir</a>, <a href="#cmake_external-out_lib_dir">out_lib_dir</a>, <a href="#cmake_external-postfix_script">postfix_script</a>,
-               <a href="#cmake_external-shared_libraries">shared_libraries</a>, <a href="#cmake_external-static_libraries">static_libraries</a>, <a href="#cmake_external-tools_deps">tools_deps</a>, <a href="#cmake_external-working_directory">working_directory</a>)
+cmake(<a href="#cmake-name">name</a>, <a href="#cmake-additional_inputs">additional_inputs</a>, <a href="#cmake-additional_tools">additional_tools</a>, <a href="#cmake-alwayslink">alwayslink</a>, <a href="#cmake-binaries">binaries</a>, <a href="#cmake-cache_entries">cache_entries</a>, <a href="#cmake-cmake_options">cmake_options</a>,
+      <a href="#cmake-data">data</a>, <a href="#cmake-defines">defines</a>, <a href="#cmake-deps">deps</a>, <a href="#cmake-env">env</a>, <a href="#cmake-env_vars">env_vars</a>, <a href="#cmake-generate_crosstool_file">generate_crosstool_file</a>, <a href="#cmake-headers_only">headers_only</a>, <a href="#cmake-install_prefix">install_prefix</a>,
+      <a href="#cmake-interface_libraries">interface_libraries</a>, <a href="#cmake-lib_name">lib_name</a>, <a href="#cmake-lib_source">lib_source</a>, <a href="#cmake-linkopts">linkopts</a>, <a href="#cmake-make_commands">make_commands</a>, <a href="#cmake-out_bin_dir">out_bin_dir</a>,
+      <a href="#cmake-out_include_dir">out_include_dir</a>, <a href="#cmake-out_lib_dir">out_lib_dir</a>, <a href="#cmake-postfix_script">postfix_script</a>, <a href="#cmake-shared_libraries">shared_libraries</a>, <a href="#cmake-static_libraries">static_libraries</a>, <a href="#cmake-tools_deps">tools_deps</a>,
+      <a href="#cmake-working_directory">working_directory</a>)
 </pre>
 
 Rule for building external library with CMake.
@@ -80,34 +80,34 @@ Rule for building external library with CMake.
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="cmake_external-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| <a id="cmake_external-additional_inputs"></a>additional_inputs |  Optional additional inputs to be declared as needed for the shell script action.Not used by the shell script part in cc_external_rule_impl.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="cmake_external-additional_tools"></a>additional_tools |  Optional additional tools needed for the building. Not used by the shell script part in cc_external_rule_impl.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="cmake_external-alwayslink"></a>alwayslink |  Optional. if true, link all the object files from the static library, even if they are not used.   | Boolean | optional | False |
-| <a id="cmake_external-binaries"></a>binaries |  Optional names of the resulting binaries.   | List of strings | optional | [] |
-| <a id="cmake_external-cache_entries"></a>cache_entries |  CMake cache entries to initialize (they will be passed with -Dkey=value) Values, defined by the toolchain, will be joined with the values, passed here. (Toolchain values come first)   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
-| <a id="cmake_external-cmake_options"></a>cmake_options |  Other CMake options   | List of strings | optional | [] |
-| <a id="cmake_external-data"></a>data |  Files needed by this rule at runtime. May list file or rule targets. Generally allows any target.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="cmake_external-defines"></a>defines |  Optional compilation definitions to be passed to the dependencies of this library. They are NOT passed to the compiler, you should duplicate them in the configuration options.   | List of strings | optional | [] |
-| <a id="cmake_external-deps"></a>deps |  Optional dependencies to be copied into the directory structure. Typically those directly required for the external building of the library/binaries. (i.e. those that the external buidl system will be looking for and paths to which are provided by the calling rule)   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="cmake_external-env"></a>env |  Environment variables to set during the build. $(execpath) macros may be used to point at files which are listed as data deps, tools_deps, or additional_tools, but unlike with other rules, these will be replaced with absolute paths to those files, because the build does not run in the exec root. No other macros are supported.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
-| <a id="cmake_external-env_vars"></a>env_vars |  CMake environment variable values to join with toolchain-defined. For example, additional CXXFLAGS.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
-| <a id="cmake_external-generate_crosstool_file"></a>generate_crosstool_file |  When True, CMake crosstool file will be generated from the toolchain values, provided cache-entries and env_vars (some values will still be passed as -Dkey=value and environment variables). If CMAKE_TOOLCHAIN_FILE cache entry is passed, specified crosstool file will be used When using this option to cross-compile, it is required to specify CMAKE_SYSTEM_NAME in the cache_entries   | Boolean | optional | True |
-| <a id="cmake_external-headers_only"></a>headers_only |  Flag variable to indicate that the library produces only headers   | Boolean | optional | False |
-| <a id="cmake_external-install_prefix"></a>install_prefix |  Relative install prefix to be passed to CMake in -DCMAKE_INSTALL_PREFIX   | String | optional | "" |
-| <a id="cmake_external-interface_libraries"></a>interface_libraries |  Optional names of the resulting interface libraries.   | List of strings | optional | [] |
-| <a id="cmake_external-lib_name"></a>lib_name |  Library name. Defines the name of the install directory and the name of the static library, if no output files parameters are defined (any of static_libraries, shared_libraries, interface_libraries, binaries_names) Optional. If not defined, defaults to the target's name.   | String | optional | "" |
-| <a id="cmake_external-lib_source"></a>lib_source |  Label with source code to build. Typically a filegroup for the source of remote repository. Mandatory.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
-| <a id="cmake_external-linkopts"></a>linkopts |  Optional link options to be passed up to the dependencies of this library   | List of strings | optional | [] |
-| <a id="cmake_external-make_commands"></a>make_commands |  Optinal make commands, defaults to ["make", "make install"]   | List of strings | optional | ["make", "make install"] |
-| <a id="cmake_external-out_bin_dir"></a>out_bin_dir |  Optional name of the output subdirectory with the binary files, defaults to 'bin'.   | String | optional | "bin" |
-| <a id="cmake_external-out_include_dir"></a>out_include_dir |  Optional name of the output subdirectory with the header files, defaults to 'include'.   | String | optional | "include" |
-| <a id="cmake_external-out_lib_dir"></a>out_lib_dir |  Optional name of the output subdirectory with the library files, defaults to 'lib'.   | String | optional | "lib" |
-| <a id="cmake_external-postfix_script"></a>postfix_script |  Optional part of the shell script to be added after the make commands   | String | optional | "" |
-| <a id="cmake_external-shared_libraries"></a>shared_libraries |  Optional names of the resulting shared libraries.   | List of strings | optional | [] |
-| <a id="cmake_external-static_libraries"></a>static_libraries |  Optional names of the resulting static libraries.   | List of strings | optional | [] |
-| <a id="cmake_external-tools_deps"></a>tools_deps |  Optional tools to be copied into the directory structure. Similar to deps, those directly required for the external building of the library/binaries.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="cmake_external-working_directory"></a>working_directory |  Working directory, with the main CMakeLists.txt (otherwise, the top directory of the lib_source label files is used.)   | String | optional | "" |
+| <a id="cmake-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="cmake-additional_inputs"></a>additional_inputs |  Optional additional inputs to be declared as needed for the shell script action.Not used by the shell script part in cc_external_rule_impl.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="cmake-additional_tools"></a>additional_tools |  Optional additional tools needed for the building. Not used by the shell script part in cc_external_rule_impl.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="cmake-alwayslink"></a>alwayslink |  Optional. if true, link all the object files from the static library, even if they are not used.   | Boolean | optional | False |
+| <a id="cmake-binaries"></a>binaries |  Optional names of the resulting binaries.   | List of strings | optional | [] |
+| <a id="cmake-cache_entries"></a>cache_entries |  CMake cache entries to initialize (they will be passed with -Dkey=value) Values, defined by the toolchain, will be joined with the values, passed here. (Toolchain values come first)   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
+| <a id="cmake-cmake_options"></a>cmake_options |  Other CMake options   | List of strings | optional | [] |
+| <a id="cmake-data"></a>data |  Files needed by this rule at runtime. May list file or rule targets. Generally allows any target.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="cmake-defines"></a>defines |  Optional compilation definitions to be passed to the dependencies of this library. They are NOT passed to the compiler, you should duplicate them in the configuration options.   | List of strings | optional | [] |
+| <a id="cmake-deps"></a>deps |  Optional dependencies to be copied into the directory structure. Typically those directly required for the external building of the library/binaries. (i.e. those that the external buidl system will be looking for and paths to which are provided by the calling rule)   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="cmake-env"></a>env |  Environment variables to set during the build. $(execpath) macros may be used to point at files which are listed as data deps, tools_deps, or additional_tools, but unlike with other rules, these will be replaced with absolute paths to those files, because the build does not run in the exec root. No other macros are supported.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
+| <a id="cmake-env_vars"></a>env_vars |  CMake environment variable values to join with toolchain-defined. For example, additional CXXFLAGS.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
+| <a id="cmake-generate_crosstool_file"></a>generate_crosstool_file |  When True, CMake crosstool file will be generated from the toolchain values, provided cache-entries and env_vars (some values will still be passed as -Dkey=value and environment variables). If CMAKE_TOOLCHAIN_FILE cache entry is passed, specified crosstool file will be used When using this option to cross-compile, it is required to specify CMAKE_SYSTEM_NAME in the cache_entries   | Boolean | optional | True |
+| <a id="cmake-headers_only"></a>headers_only |  Flag variable to indicate that the library produces only headers   | Boolean | optional | False |
+| <a id="cmake-install_prefix"></a>install_prefix |  Relative install prefix to be passed to CMake in -DCMAKE_INSTALL_PREFIX   | String | optional | "" |
+| <a id="cmake-interface_libraries"></a>interface_libraries |  Optional names of the resulting interface libraries.   | List of strings | optional | [] |
+| <a id="cmake-lib_name"></a>lib_name |  Library name. Defines the name of the install directory and the name of the static library, if no output files parameters are defined (any of static_libraries, shared_libraries, interface_libraries, binaries_names) Optional. If not defined, defaults to the target's name.   | String | optional | "" |
+| <a id="cmake-lib_source"></a>lib_source |  Label with source code to build. Typically a filegroup for the source of remote repository. Mandatory.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| <a id="cmake-linkopts"></a>linkopts |  Optional link options to be passed up to the dependencies of this library   | List of strings | optional | [] |
+| <a id="cmake-make_commands"></a>make_commands |  Optinal make commands, defaults to ["make", "make install"]   | List of strings | optional | ["make", "make install"] |
+| <a id="cmake-out_bin_dir"></a>out_bin_dir |  Optional name of the output subdirectory with the binary files, defaults to 'bin'.   | String | optional | "bin" |
+| <a id="cmake-out_include_dir"></a>out_include_dir |  Optional name of the output subdirectory with the header files, defaults to 'include'.   | String | optional | "include" |
+| <a id="cmake-out_lib_dir"></a>out_lib_dir |  Optional name of the output subdirectory with the library files, defaults to 'lib'.   | String | optional | "lib" |
+| <a id="cmake-postfix_script"></a>postfix_script |  Optional part of the shell script to be added after the make commands   | String | optional | "" |
+| <a id="cmake-shared_libraries"></a>shared_libraries |  Optional names of the resulting shared libraries.   | List of strings | optional | [] |
+| <a id="cmake-static_libraries"></a>static_libraries |  Optional names of the resulting static libraries.   | List of strings | optional | [] |
+| <a id="cmake-tools_deps"></a>tools_deps |  Optional tools to be copied into the directory structure. Similar to deps, those directly required for the external building of the library/binaries.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="cmake-working_directory"></a>working_directory |  Working directory, with the main CMakeLists.txt (otherwise, the top directory of the lib_source label files is used.)   | String | optional | "" |
 
 
 <a id="#cmake_tool"></a>

--- a/docs/docs.bzl
+++ b/docs/docs.bzl
@@ -5,7 +5,7 @@ load("@rules_foreign_cc//for_workspace:cmake_build.bzl", _cmake_tool = "cmake_to
 load("@rules_foreign_cc//for_workspace:make_build.bzl", _make_tool = "make_tool")
 load("@rules_foreign_cc//for_workspace:ninja_build.bzl", _ninja_tool = "ninja_tool")
 load("@rules_foreign_cc//tools/build_defs:boost_build.bzl", _boost_build = "boost_build")
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", _cmake_external = "cmake_external")
+load("@rules_foreign_cc//tools/build_defs:cmake.bzl", _cmake = "cmake")
 load("@rules_foreign_cc//tools/build_defs:configure.bzl", _configure_make = "configure_make")
 load(
     "@rules_foreign_cc//tools/build_defs:framework.bzl",
@@ -25,7 +25,7 @@ load(
 
 # Rules Foreign CC symbols
 boost_build = _boost_build
-cmake_external = _cmake_external
+cmake = _cmake
 cmake_tool = _cmake_tool
 configure_make = _configure_make
 make = _make

--- a/examples/cmake_android/BUILD.bazel
+++ b/examples/cmake_android/BUILD.bazel
@@ -1,8 +1,8 @@
 load("@rules_android//android:rules.bzl", "android_binary", "android_library")
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake")
 
-cmake_external(
+cmake(
     name = "libhello",
     lib_source = "//cmake_hello_world_lib/static:srcs",
     out_include_dir = "include/version123",

--- a/examples/cmake_crosstool/BUILD.bazel
+++ b/examples/cmake_crosstool/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake")
 
 filegroup(
     name = "srcs",
@@ -12,7 +12,7 @@ cc_library(
     srcs = ["hello.cc"],
 )
 
-cmake_external(
+cmake(
     name = "hello_cmake",
     lib_source = "//static:srcs",
     out_include_dir = "include/version123",

--- a/examples/cmake_crosstool/static/BUILD.bazel
+++ b/examples/cmake_crosstool/static/BUILD.bazel
@@ -2,7 +2,7 @@
 # for test only
 
 load("@rules_cc//cc:defs.bzl", "cc_binary")
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake")
 
 filegroup(
     name = "srcs",
@@ -14,14 +14,14 @@ exports_files([
     "hello_client.c",
 ])
 
-cmake_external(
+cmake(
     name = "libhello",
     lib_source = ":srcs",
     # pass include/version123 to C/C++ provider as include directory
     out_include_dir = "include/version123",
 )
 
-cmake_external(
+cmake(
     name = "libhello_win",
     cmake_options = ["-G \"Visual Studio 15 2017\" -A x64"],
     lib_name = "libhello",
@@ -32,7 +32,7 @@ cmake_external(
     static_libraries = ["hello.lib"],
 )
 
-cmake_external(
+cmake(
     name = "libhello_win_ninja",
     cmake_options = ["-GNinja"],
     lib_source = ":srcs",
@@ -45,7 +45,7 @@ cmake_external(
     static_libraries = ["hello.lib"],
 )
 
-cmake_external(
+cmake(
     name = "libhello_win_nmake",
     cmake_options = ["-G \"NMake Makefiles\""],
     lib_source = ":srcs",
@@ -115,7 +115,7 @@ sh_test(
     visibility = ["//:__pkg__"],
 )
 
-cmake_external(
+cmake(
     name = "libhello123",
     lib_source = ":srcs",
     out_include_dir = "include",

--- a/examples/cmake_defines/BUILD.bazel
+++ b/examples/cmake_defines/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake")
 
-cmake_external(
+cmake(
     name = "lib_a",
     lib_source = ":lib_a_sources",
     static_libraries = select({
@@ -10,7 +10,7 @@ cmake_external(
     deps = [":lib_b"],
 )
 
-cmake_external(
+cmake(
     name = "lib_b",
     defines = ["FOO"],
     lib_source = ":lib_b_sources",

--- a/examples/cmake_hello_world_lib/binary/BUILD.bazel
+++ b/examples/cmake_hello_world_lib/binary/BUILD.bazel
@@ -1,7 +1,7 @@
 # example code is taken from https://github.com/Akagi201/learning-cmake/tree/master/hello-world-lib
 # for test only
 load("@bazel_tools//tools/build_rules:test_rules.bzl", "file_test")
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake")
 
 filegroup(
     name = "srcs",
@@ -9,7 +9,7 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-cmake_external(
+cmake(
     name = "libhello",
     binaries = select({
         "//:windows": ["hello.exe"],

--- a/examples/cmake_hello_world_lib/shared/BUILD.bazel
+++ b/examples/cmake_hello_world_lib/shared/BUILD.bazel
@@ -2,7 +2,7 @@
 # for test only
 
 load("@rules_cc//cc:defs.bzl", "cc_test")
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake")
 
 filegroup(
     name = "srcs",
@@ -10,7 +10,7 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-cmake_external(
+cmake(
     name = "libhello",
     # Probably this variable should be set by default.
     # Apparently, it needs to be set for shared libraries on Mac OS

--- a/examples/cmake_hello_world_lib/static/BUILD.bazel
+++ b/examples/cmake_hello_world_lib/static/BUILD.bazel
@@ -2,7 +2,7 @@
 # for test only
 
 load("@rules_cc//cc:defs.bzl", "cc_binary")
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake")
 
 filegroup(
     name = "srcs",
@@ -10,7 +10,7 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-cmake_external(
+cmake(
     name = "libhello",
     lib_source = ":srcs",
     # pass include/version123 to C/C++ provider as include directory
@@ -18,7 +18,7 @@ cmake_external(
     tags = ["manual"],
 )
 
-cmake_external(
+cmake(
     name = "libhello_win",
     cmake_options = ["-G \"Visual Studio 15 2017\" -A x64"],
     lib_name = "libhello",
@@ -31,7 +31,7 @@ cmake_external(
     tags = ["manual"],
 )
 
-cmake_external(
+cmake(
     name = "libhello_win_ninja",
     cmake_options = ["-GNinja"],
     lib_source = ":srcs",
@@ -46,7 +46,7 @@ cmake_external(
     tags = ["manual"],
 )
 
-cmake_external(
+cmake(
     name = "libhello_win_nmake",
     cmake_options = ["-G \"NMake Makefiles\""],
     lib_source = ":srcs",
@@ -121,7 +121,7 @@ sh_test(
     deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
-cmake_external(
+cmake(
     name = "libhello123",
     lib_source = ":srcs",
     out_include_dir = "include",

--- a/examples/cmake_hello_world_variant/BUILD.bazel
+++ b/examples/cmake_hello_world_variant/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake")
 
-cmake_external(
+cmake(
     name = "hello_world",
     binaries = select({
         "//:macos": ["CMakeHelloWorld"],

--- a/examples/cmake_synthetic/BUILD.bazel
+++ b/examples/cmake_synthetic/BUILD.bazel
@@ -1,8 +1,8 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_cc//cc:defs.bzl", "cc_test")
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake")
 
-cmake_external(
+cmake(
     name = "liba",
     cmake_options = ["-GNinja"],
     # Demonstrate non-alphanumeric name
@@ -15,7 +15,7 @@ cmake_external(
     postfix_script = "cp $$INSTALLDIR$$/lib/liba.a $$INSTALLDIR$$/lib/liba++.a",
 )
 
-cmake_external(
+cmake(
     name = "libb",
     cmake_options = ["-GNinja"],
     lib_source = "//cmake_synthetic/libb:b_srcs",
@@ -26,7 +26,7 @@ cmake_external(
     deps = [":liba"],
 )
 
-cmake_external(
+cmake(
     name = "lib_with_duplicate_transitive_bazel_deps",
     cache_entries = {
         "LIBA_DIR": "$$EXT_BUILD_DEPS$$",

--- a/examples/cmake_with_bazel_transitive/BUILD.bazel
+++ b/examples/cmake_with_bazel_transitive/BUILD.bazel
@@ -1,8 +1,8 @@
 load("@rules_cc//cc:defs.bzl", "cc_test")
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake")
 
 # Example of the cmake_external target built with Bazel-built dependency
-cmake_external(
+cmake(
     name = "cmake_libb",
     cache_entries = {
         # CMake's find_package wants to find cmake config for liba,

--- a/examples/cmake_with_data/BUILD.bazel
+++ b/examples/cmake_with_data/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@rules_cc//cc:defs.bzl", "cc_test")
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake")
 
-cmake_external(
+cmake(
     name = "cmake_with_data",
     cache_entries = select({
         "@bazel_tools//src/conditions:windows": {

--- a/examples/cmake_working_dir/BUILD.bazel
+++ b/examples/cmake_working_dir/BUILD.bazel
@@ -1,12 +1,12 @@
 load("@rules_cc//cc:defs.bzl", "cc_test")
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake")
 
 filegroup(
     name = "sources",
     srcs = glob(["source_root/**"]),
 )
 
-cmake_external(
+cmake(
     name = "liba",
     lib_source = ":sources",
     # This demonstrates the usage of the working directory:

--- a/examples/third_party/cares/BUILD.cares.bazel
+++ b/examples/third_party/cares/BUILD.cares.bazel
@@ -1,4 +1,4 @@
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -7,7 +7,7 @@ filegroup(
     srcs = glob(["**"]),
 )
 
-cmake_external(
+cmake(
     name = "cares",
     cache_entries = {
         "CARES_SHARED": "no",

--- a/examples/third_party/curl/BUILD.curl.bazel
+++ b/examples/third_party/curl/BUILD.curl.bazel
@@ -1,4 +1,4 @@
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake")
 
 filegroup(
     name = "all_srcs",
@@ -22,7 +22,7 @@ _LINUX_CACHE_ENTRIES = dict(_CACHE_ENTRIES.items() + {
     "CMAKE_C_FLAGS": "-fPIC",
 }.items())
 
-cmake_external(
+cmake(
     name = "curl",
     cache_entries = select({
         "@platforms//os:linux": _LINUX_CACHE_ENTRIES,

--- a/examples/third_party/libgit2/BUILD.libgit2.bazel
+++ b/examples/third_party/libgit2/BUILD.libgit2.bazel
@@ -1,4 +1,4 @@
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake")
 
 filegroup(
     name = "all_srcs",
@@ -23,7 +23,7 @@ _LINUX_CACHE_ENTRIES = dict(_CACHE_ENTRIES.items() + {
     "REGEX_BACKEND": "pcre",
 }.items())
 
-cmake_external(
+cmake(
     name = "libgit2",
     cache_entries = select({
         "@platforms//os:linux": _LINUX_CACHE_ENTRIES,

--- a/examples/third_party/libpng/BUILD.libpng.bazel
+++ b/examples/third_party/libpng/BUILD.libpng.bazel
@@ -1,4 +1,4 @@
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -7,7 +7,7 @@ filegroup(
     srcs = glob(["**"]),
 )
 
-cmake_external(
+cmake(
     name = "libpng",
     cache_entries = {
         "ZLIB_ROOT": "$EXT_BUILD_DEPS/libz",

--- a/examples/third_party/libssh2/BUILD.libssh2.bazel
+++ b/examples/third_party/libssh2/BUILD.libssh2.bazel
@@ -1,4 +1,4 @@
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake")
 
 filegroup(
     name = "all_srcs",
@@ -17,7 +17,7 @@ _LINUX_CACHE_ENTRIES = dict(_CACHE_ENTRIES.items() + {
     "CMAKE_C_FLAGS": "${CMAKE_C_FLAGS:-} -fPIC",
 }.items())
 
-cmake_external(
+cmake(
     name = "libssh2",
     cache_entries = select({
         "@platforms//os:linux": _LINUX_CACHE_ENTRIES,

--- a/examples/third_party/pcre/BUILD.pcre.bazel
+++ b/examples/third_party/pcre/BUILD.pcre.bazel
@@ -1,6 +1,6 @@
 """pcre is only expected to be used on Linux systems"""
 
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -9,7 +9,7 @@ filegroup(
     srcs = glob(["**"]),
 )
 
-cmake_external(
+cmake(
     name = "pcre",
     cache_entries = {
         "CMAKE_C_FLAGS": "${CMAKE_C_FLAGS:-} -fPIC",

--- a/examples/third_party/zlib/BUILD.zlib.bazel
+++ b/examples/third_party/zlib/BUILD.zlib.bazel
@@ -1,4 +1,4 @@
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -7,7 +7,7 @@ filegroup(
     srcs = glob(["**"]),
 )
 
-cmake_external(
+cmake(
     name = "zlib",
     cmake_options = select({
         "@platforms//os:windows": ["-GNinja"],

--- a/tools/build_defs/cmake.bzl
+++ b/tools/build_defs/cmake.bzl
@@ -25,7 +25,7 @@ load(
 )
 load(":cmake_script.bzl", "create_cmake_script")
 
-def _cmake_external(ctx):
+def _cmake_impl(ctx):
     cmake_data = get_cmake_data(ctx)
     make_data = get_make_data(ctx)
 
@@ -148,12 +148,12 @@ def _attrs():
     })
     return attrs
 
-cmake_external = rule(
+cmake = rule(
     doc = "Rule for building external library with CMake.",
     attrs = _attrs(),
     fragments = ["cpp"],
     output_to_genfiles = True,
-    implementation = _cmake_external,
+    implementation = _cmake_impl,
     toolchains = [
         "@rules_foreign_cc//tools/build_defs:cmake_toolchain",
         "@rules_foreign_cc//tools/build_defs:ninja_toolchain",
@@ -162,3 +162,8 @@ cmake_external = rule(
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
 )
+
+# This is an alias to the underlying rule and is
+# kept around for legacy compaitiblity. This should
+# not be removed without sufficent warning.
+cmake_external = cmake


### PR DESCRIPTION
This makes the naming conventions of the rules more consistent.

Note that the previous name of `cmake_external` continues to work.