### PR TITLE
Add missing environment to cc external rule actions

### DIFF
--- a/tools/build_defs/framework.bzl
+++ b/tools/build_defs/framework.bzl
@@ -297,7 +297,9 @@ def cc_external_rule_impl(ctx, attrs):
     outputs = _define_outputs(ctx, attrs, lib_name)
     out_cc_info = _define_out_cc_info(ctx, attrs, inputs, outputs)
 
-    cc_env = _correct_path_variable(get_env_vars(ctx))
+    cc_env = get_env_vars(ctx)
+    cc_env.update(ctx.configuration.default_shell_env)
+    cc_env = _correct_path_variable(cc_env)
     set_cc_envs = ""
     execution_os_name = os_name(ctx)
     if execution_os_name != "osx":


### PR DESCRIPTION
The environment used to execute actions is too strict, as it is actually restricting access to the toolchain during the call to configure scripts. This fixes it by updating the current env with the default one for shell actions.