### PR TITLE
Moved `workspace_definitions.bzl` to `foreign_cc/repositories.bzl` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ http_archive(
    url = "https://github.com/bazelbuild/rules_foreign_cc/archive/0.1.0.zip",
 )
 
-load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
+load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 
 # This sets up some common toolchains for building targets. For more details, please see
 # https://github.com/bazelbuild/rules_foreign_cc/tree/main/docs#rules_foreign_cc_dependencies

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,7 +1,7 @@
 workspace(name = "rules_foreign_cc")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
+load("//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 
 rules_foreign_cc_dependencies()
 

--- a/docs/WORKSPACE.bazel
+++ b/docs/WORKSPACE.bazel
@@ -5,7 +5,7 @@ local_repository(
     path = "..",
 )
 
-load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
+load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 
 rules_foreign_cc_dependencies()
 

--- a/docs/docs.bzl
+++ b/docs/docs.bzl
@@ -1,6 +1,5 @@
 """A module exporting symbols for Stardoc generation."""
 
-load("@rules_foreign_cc//:workspace_definitions.bzl", _rules_foreign_cc_dependencies = "rules_foreign_cc_dependencies")
 load(
     "@rules_foreign_cc//foreign_cc:defs.bzl",
     _boost_build = "boost_build",
@@ -14,6 +13,7 @@ load(
     _ForeignCcArtifact = "ForeignCcArtifact",
     _ForeignCcDeps = "ForeignCcDeps",
 )
+load("@rules_foreign_cc//foreign_cc:repositories.bzl", _rules_foreign_cc_dependencies = "rules_foreign_cc_dependencies")
 load("@rules_foreign_cc//foreign_cc/built_tools:cmake_build.bzl", _cmake_tool = "cmake_tool")
 load("@rules_foreign_cc//foreign_cc/built_tools:make_build.bzl", _make_tool = "make_tool")
 load("@rules_foreign_cc//foreign_cc/built_tools:ninja_build.bzl", _ninja_tool = "ninja_tool")

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -16,7 +16,7 @@ http_archive(
     ],
 )
 
-load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
+load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 
 # Don't use preinstalled tools to ensure builds are as hermetic as possible
 rules_foreign_cc_dependencies(register_preinstalled_tools = False)

--- a/examples/cmake_crosstool/WORKSPACE
+++ b/examples/cmake_crosstool/WORKSPACE
@@ -12,7 +12,7 @@ local_repository(
     path = "../..",
 )
 
-load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
+load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 
 rules_foreign_cc_dependencies()
 

--- a/examples/configure_use_malloc/WORKSPACE
+++ b/examples/configure_use_malloc/WORKSPACE
@@ -7,7 +7,7 @@ local_repository(
     path = "../..",
 )
 
-load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
+load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 
 rules_foreign_cc_dependencies()
 

--- a/examples/third_party/WORKSPACE.bazel
+++ b/examples/third_party/WORKSPACE.bazel
@@ -5,7 +5,7 @@ local_repository(
     path = "../..",
 )
 
-load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
+load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 
 rules_foreign_cc_dependencies(register_preinstalled_tools = False)
 

--- a/examples/toolchains_examples/WORKSPACE.bazel
+++ b/examples/toolchains_examples/WORKSPACE.bazel
@@ -5,7 +5,7 @@ local_repository(
     path = "../..",
 )
 
-load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
+load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 load(":additional_toolchains.bzl", "ADD_TOOLCHAIN_MAPPINGS")
 
 # We are registering additional shell toolchain implementation for fancy_platform.

--- a/foreign_cc/repositories.bzl
+++ b/foreign_cc/repositories.bzl
@@ -1,0 +1,89 @@
+"""A module for defining WORKSPACE dependencies required for rules_foreign_cc"""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load(
+    "//foreign_cc/private/shell_toolchain/toolchains:ws_defs.bzl",
+    shell_toolchain_workspace_initalization = "workspace_part",
+)
+load("//toolchains:toolchains.bzl", "built_toolchains", "prebuilt_toolchains", "preinstalled_toolchains")
+
+# buildifier: disable=unnamed-macro
+def rules_foreign_cc_dependencies(
+        native_tools_toolchains = [],
+        register_default_tools = True,
+        cmake_version = "3.19.6",
+        make_version = "4.3",
+        ninja_version = "1.10.2",
+        register_preinstalled_tools = True,
+        register_built_tools = True,
+        additional_shell_toolchain_mappings = [],
+        additional_shell_toolchain_package = None):
+    """Call this function from the WORKSPACE file to initialize rules_foreign_cc \
+    dependencies and let neccesary code generation happen \
+    (Code generation is needed to support different variants of the C++ Starlark API.).
+
+    Args:
+        native_tools_toolchains: pass the toolchains for toolchain types
+            '@rules_foreign_cc//toolchains:cmake_toolchain' and
+            '@rules_foreign_cc//toolchains:ninja_toolchain' with the needed platform constraints.
+            If you do not pass anything, registered default toolchains will be selected (see below).
+
+        register_default_tools: If True, the cmake and ninja toolchains, calling corresponding
+            preinstalled binaries by name (cmake, ninja) will be registered after
+            'native_tools_toolchains' without any platform constraints. The default is True.
+
+        cmake_version: The target version of the cmake toolchain if `register_default_tools`
+            or `register_built_tools` is set to `True`.
+
+        make_version: The target version of the default make toolchain if `register_built_tools`
+            is set to `True`.
+
+        ninja_version: The target version of the ninja toolchain if `register_default_tools`
+            or `register_built_tools` is set to `True`.
+
+        register_preinstalled_tools: If true, toolchains will be registered for the native built tools
+            installed on the exec host
+
+        register_built_tools: If true, toolchains that build the tools from source are registered
+
+        additional_shell_toolchain_mappings: Mappings of the shell toolchain functions to
+            execution and target platforms constraints. Similar to what defined in
+            @rules_foreign_cc//foreign_cc/private/shell_toolchain/toolchains:toolchain_mappings.bzl
+            in the TOOLCHAIN_MAPPINGS list. Please refer to example in @rules_foreign_cc//toolchain_examples.
+
+        additional_shell_toolchain_package: A package under which additional toolchains, referencing
+            the generated data for the passed additonal_shell_toolchain_mappings, will be defined.
+            This value is needed since register_toolchains() is called for these toolchains.
+            Please refer to example in @rules_foreign_cc//toolchain_examples.
+    """
+
+    shell_toolchain_workspace_initalization(
+        additional_shell_toolchain_mappings,
+        additional_shell_toolchain_package,
+    )
+
+    native.register_toolchains(*native_tools_toolchains)
+
+    if register_default_tools:
+        prebuilt_toolchains(cmake_version, ninja_version)
+
+    if register_built_tools:
+        built_toolchains(
+            cmake_version = cmake_version,
+            make_version = make_version,
+            ninja_version = ninja_version,
+        )
+
+    if register_preinstalled_tools:
+        preinstalled_toolchains()
+
+    maybe(
+        http_archive,
+        name = "bazel_skylib",
+        sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
+        ],
+    )

--- a/test/standard_cxx_flags_test/WORKSPACE
+++ b/test/standard_cxx_flags_test/WORKSPACE
@@ -7,7 +7,7 @@ local_repository(
     path = "../..",
 )
 
-load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
+load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 
 rules_foreign_cc_dependencies()
 

--- a/workspace_definitions.bzl
+++ b/workspace_definitions.bzl
@@ -1,91 +1,12 @@
-"""A module for defining WORKSPACE dependencies required for rules_foreign_cc"""
+"""Deprecated in favor of `//foreign_cc:repositories.bzl"""
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("//foreign_cc:repositories.bzl", _rules_foreign_cc_dependencies = "rules_foreign_cc_dependencies")
 
-# buildifier: disable=bzl-visibility
-load(
-    "//foreign_cc/private/shell_toolchain/toolchains:ws_defs.bzl",
-    shell_toolchain_workspace_initalization = "workspace_part",
+# buildifier: disable=print
+print(
+    "`@rules_foreign_cc//foreign_cc:repositories.bzl` has been replaced by " +
+    "`@rules_foreign_cc//foreign_cc:repositories.bzl`. Please use the " +
+    "updated source location",
 )
-load("//toolchains:toolchains.bzl", "built_toolchains", "prebuilt_toolchains", "preinstalled_toolchains")
 
-# buildifier: disable=unnamed-macro
-def rules_foreign_cc_dependencies(
-        native_tools_toolchains = [],
-        register_default_tools = True,
-        cmake_version = "3.19.6",
-        make_version = "4.3",
-        ninja_version = "1.10.2",
-        register_preinstalled_tools = True,
-        register_built_tools = True,
-        additional_shell_toolchain_mappings = [],
-        additional_shell_toolchain_package = None):
-    """Call this function from the WORKSPACE file to initialize rules_foreign_cc \
-    dependencies and let neccesary code generation happen \
-    (Code generation is needed to support different variants of the C++ Starlark API.).
-
-    Args:
-        native_tools_toolchains: pass the toolchains for toolchain types
-            '@rules_foreign_cc//toolchains:cmake_toolchain' and
-            '@rules_foreign_cc//toolchains:ninja_toolchain' with the needed platform constraints.
-            If you do not pass anything, registered default toolchains will be selected (see below).
-
-        register_default_tools: If True, the cmake and ninja toolchains, calling corresponding
-            preinstalled binaries by name (cmake, ninja) will be registered after
-            'native_tools_toolchains' without any platform constraints. The default is True.
-
-        cmake_version: The target version of the cmake toolchain if `register_default_tools`
-            or `register_built_tools` is set to `True`.
-
-        make_version: The target version of the default make toolchain if `register_built_tools`
-            is set to `True`.
-
-        ninja_version: The target version of the ninja toolchain if `register_default_tools`
-            or `register_built_tools` is set to `True`.
-
-        register_preinstalled_tools: If true, toolchains will be registered for the native built tools
-            installed on the exec host
-
-        register_built_tools: If true, toolchains that build the tools from source are registered
-
-        additional_shell_toolchain_mappings: Mappings of the shell toolchain functions to
-            execution and target platforms constraints. Similar to what defined in
-            @rules_foreign_cc//foreign_cc/private/shell_toolchain/toolchains:toolchain_mappings.bzl
-            in the TOOLCHAIN_MAPPINGS list. Please refer to example in @rules_foreign_cc//toolchain_examples.
-
-        additional_shell_toolchain_package: A package under which additional toolchains, referencing
-            the generated data for the passed additonal_shell_toolchain_mappings, will be defined.
-            This value is needed since register_toolchains() is called for these toolchains.
-            Please refer to example in @rules_foreign_cc//toolchain_examples.
-    """
-
-    shell_toolchain_workspace_initalization(
-        additional_shell_toolchain_mappings,
-        additional_shell_toolchain_package,
-    )
-
-    native.register_toolchains(*native_tools_toolchains)
-
-    if register_default_tools:
-        prebuilt_toolchains(cmake_version, ninja_version)
-
-    if register_built_tools:
-        built_toolchains(
-            cmake_version = cmake_version,
-            make_version = make_version,
-            ninja_version = ninja_version,
-        )
-
-    if register_preinstalled_tools:
-        preinstalled_toolchains()
-
-    maybe(
-        http_archive,
-        name = "bazel_skylib",
-        sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
-        urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
-            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
-        ],
-    )
+rules_foreign_cc_dependencies = _rules_foreign_cc_dependencies


### PR DESCRIPTION
This solves for some bzl visibility issues and brings the repo into alignment with other rules
- [rules_rust](https://bazelbuild.github.io/rules_rust/#setup)
- [rules_swift](https://github.com/bazelbuild/rules_swift#2-configure-your-workspace)