### PR TITLE
Added a common framework for built tools

### DIFF
--- a/foreign_cc/built_tools/private/BUILD.bazel
+++ b/foreign_cc/built_tools/private/BUILD.bazel
@@ -4,7 +4,4 @@ bzl_library(
     name = "bzl_srcs",
     srcs = glob(["**/*.bzl"]),
     visibility = ["//:__subpackages__"],
-    deps = [
-        "//foreign_cc/built_tools/private:bzl_srcs",
-    ],
 )

--- a/foreign_cc/built_tools/private/built_tools_framework.bzl
+++ b/foreign_cc/built_tools/private/built_tools_framework.bzl
@@ -1,0 +1,93 @@
+"""A module defining a common framework for "built_tools" rules"""
+
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("//foreign_cc/private:detect_root.bzl", "detect_root")
+load("//foreign_cc/private:framework.bzl", "wrap_outputs")
+load("//foreign_cc/private:shell_script_helper.bzl", "convert_shell_script")
+
+# Common attributes for all built_tool rules
+FOREIGN_CC_BUILT_TOOLS_ATTRS = {
+    "srcs": attr.label(
+        doc = "The target containing the build tool's sources",
+        mandatory = True,
+    ),
+    "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
+}
+
+# Common host fragments for all built_tool rules
+FOREIGN_CC_BUILT_TOOLS_HOST_FRAGMENTS = [
+    "cpp",
+]
+
+def built_tool_rule_impl(ctx, script_lines, out_dir, mnemonic):
+    """Framework function for bootstrapping C/C++ build tools.
+
+    This macro should be shared by all "built-tool" rules defined in rules_foreign_cc.
+    Any rule implementing this function should ensure that the appropriate artifacts
+    are placed in a directory represented by the `INSTALLDIR` environment variable.
+
+    Args:
+        ctx (ctx): The current rule's context object
+        script_lines (list): A list of lines of a bash script for building the build tool
+        out_dir (File): The output directory of the build tool
+        mnemonic (str): The mnemonic of the build action
+
+    Returns:
+        list: A list of providers
+    """
+
+    root = detect_root(ctx.attr.srcs)
+
+    script = [
+        # TODO: The script prelude should be used but for some reason it fails
+        # on RBE builds.
+        # "##script_prelude##",
+        "export EXT_BUILD_ROOT=##pwd##",
+        "export INSTALLDIR=$$EXT_BUILD_ROOT$$/{}".format(out_dir.path),
+        "export BUILD_TMPDIR=$$INSTALLDIR$$.build_tmpdir",
+        "##mkdirs## $$BUILD_TMPDIR$$",
+        "##copy_dir_contents_to_dir## ./{} $$BUILD_TMPDIR$$".format(root),
+        "cd $$BUILD_TMPDIR$$",
+    ]
+
+    script.append("set -x")
+    script.extend(script_lines)
+    script.append("set +x")
+
+    script_text = "\n".join([
+        "#!/usr/bin/env bash",
+        convert_shell_script(ctx, script),
+        "",
+    ])
+
+    lib_name = ctx.attr.name
+
+    wrapped_outputs = wrap_outputs(ctx, lib_name, mnemonic, script_text)
+    cc_toolchain = find_cpp_toolchain(ctx)
+
+    tools = depset(
+        [wrapped_outputs.wrapper_script_file, wrapped_outputs.script_file],
+        transitive = [cc_toolchain.all_files],
+    )
+
+    # The use of `run_shell` here is intended to ensure bash is correctly setup on windows
+    # environments. This should not be replaced with `run` until a cross platform implementation
+    # is found that guarantees bash exists or appropriately errors out.
+    ctx.actions.run_shell(
+        mnemonic = mnemonic,
+        inputs = ctx.attr.srcs.files,
+        outputs = [out_dir, wrapped_outputs.log_file],
+        tools = tools,
+        use_default_shell_env = True,
+        command = wrapped_outputs.wrapper_script_file.path,
+        execution_requirements = {"block-network": ""},
+    )
+
+    return [
+        DefaultInfo(files = depset([out_dir])),
+        OutputGroupInfo(
+            log_file = depset([wrapped_outputs.log_file]),
+            script_file = depset([wrapped_outputs.script_file]),
+            wrapper_script_file = depset([wrapped_outputs.wrapper_script_file]),
+        ),
+    ]

--- a/toolchains/BUILD.bazel
+++ b/toolchains/BUILD.bazel
@@ -67,7 +67,7 @@ native_tool_toolchain(
 
 make_tool(
     name = "make_tool",
-    make_srcs = "@gnumake_src//:all_srcs",
+    srcs = "@gnumake_src//:all_srcs",
     tags = ["manual"],
 )
 
@@ -84,7 +84,7 @@ native_tool_toolchain(
 
 cmake_tool(
     name = "cmake_tool",
-    cmake_srcs = "@cmake_src//:all_srcs",
+    srcs = "@cmake_src//:all_srcs",
     tags = ["manual"],
 )
 
@@ -101,7 +101,7 @@ native_tool_toolchain(
 
 ninja_tool(
     name = "ninja_tool",
-    ninja_srcs = "@ninja_build_src//:all_srcs",
+    srcs = "@ninja_build_src//:all_srcs",
     tags = ["manual"],
 )
 


### PR DESCRIPTION
To prevent massive text dumps when building "built tool" toolchains, all built tool rules now share a common framework similar to the other rules in `//foreign_cc:defs.bzl`.

Some notable changes:
- each built tool rule has had it's `*_srcs` attribute renamed to `srcs`. So for `ninja_tool`, `ninja_srcs` must now be passed to `srcs`.
- While this isn't a change, built tool rules will not fail if the tool fails to build or install for whatever reason. https://github.com/bazelbuild/rules_foreign_cc/pull/548 is a PR for addressing this issue.