### PR TITLE
Fixed incorrect tool paths for windows

### DIFF
--- a/.bazelci/config.yaml
+++ b/.bazelci/config.yaml
@@ -139,7 +139,7 @@ tasks:
       - //...
   min_supported_version:
     name: "Minimum Supported Version"
-    bazel: "3.4.0"
+    bazel: "3.7.0"
     platform: ubuntu1604
     build_targets:
       - "//..."
@@ -147,7 +147,7 @@ tasks:
       - "//..."
   min_supported_version_examples:
     name: "Minimum Supported Version Examples"
-    bazel: "3.4.0"
+    bazel: "3.7.0"
     platform: ubuntu1604
     working_directory: examples
     build_targets:

--- a/toolchains/BUILD.bazel
+++ b/toolchains/BUILD.bazel
@@ -62,7 +62,10 @@ toolchain(
 
 native_tool_toolchain(
     name = "preinstalled_make",
-    path = "make",
+    path = select({
+        "@platforms//os:windows": "make.exe",
+        "//conditions:default": "make",
+    }),
 )
 
 make_tool(
@@ -73,13 +76,19 @@ make_tool(
 
 native_tool_toolchain(
     name = "built_make",
-    path = "$(execpath :make_tool)/bin/make",
+    path = select({
+        "@platforms//os:windows": "$(execpath :make_tool)/bin/make.exe",
+        "//conditions:default": "$(execpath :make_tool)/bin/make",
+    }),
     target = ":make_tool",
 )
 
 native_tool_toolchain(
     name = "preinstalled_cmake",
-    path = "cmake",
+    path = select({
+        "@platforms//os:windows": "cmake.exe",
+        "//conditions:default": "cmake",
+    }),
 )
 
 cmake_tool(
@@ -90,13 +99,19 @@ cmake_tool(
 
 native_tool_toolchain(
     name = "built_cmake",
-    path = "$(execpath :cmake_tool)/bin/cmake",
+    path = select({
+        "@platforms//os:windows": "$(execpath :cmake_tool)/bin/cmake.exe",
+        "//conditions:default": "$(execpath :cmake_tool)/bin/cmake",
+    }),
     target = ":cmake_tool",
 )
 
 native_tool_toolchain(
     name = "preinstalled_ninja",
-    path = "ninja",
+    path = select({
+        "@platforms//os:windows": "ninja.exe",
+        "//conditions:default": "ninja",
+    }),
 )
 
 ninja_tool(
@@ -107,7 +122,10 @@ ninja_tool(
 
 native_tool_toolchain(
     name = "built_ninja",
-    path = "$(execpath :ninja_tool)/ninja",
+    path = select({
+        "@platforms//os:windows": "$(execpath :ninja_tool)/ninja.exe",
+        "//conditions:default": "$(execpath :ninja_tool)/ninja",
+    }),
     target = ":ninja_tool",
 )
 


### PR DESCRIPTION
Windows binaries all have the `.exe` extension so the path should reflect this

Additionally, the `ninja_tool` builds the binary in the root of the install directory, This should be corrected but for now this PR simply ensures the toolchain has the correct path to the ninja binary.

Finally, this PR raises the min tested Bazel version to `3.7.0`