### PR TITLE
Generate cmake crosstool file as a declared output

### DIFF
--- a/foreign_cc/boost_build.bzl
+++ b/foreign_cc/boost_build.bzl
@@ -22,11 +22,14 @@ def _create_configure_script(configureParameters):
     ctx = configureParameters.ctx
     root = detect_root(ctx.attr.lib_source)
 
-    return "\n".join([
-        "cd $INSTALLDIR",
-        "##copy_dir_contents_to_dir## $$EXT_BUILD_ROOT$$/{}/. .".format(root),
-        "./bootstrap.sh {}".format(" ".join(ctx.attr.bootstrap_options)),
-    ])
+    return struct(
+	commands = [
+            "cd $INSTALLDIR",
+            "##copy_dir_contents_to_dir## $$EXT_BUILD_ROOT$$/{}/. .".format(root),
+            "./bootstrap.sh {}".format(" ".join(ctx.attr.bootstrap_options)),
+        ],
+	files = [],
+    )
 
 def _attrs():
     attrs = dict(CC_EXTERNAL_RULE_ATTRIBUTES)

--- a/foreign_cc/cmake.bzl
+++ b/foreign_cc/cmake.bzl
@@ -73,8 +73,9 @@ def _create_configure_script(configureParameters):
     flags = get_flags_info(ctx, "<TARGET>")
     no_toolchain_file = ctx.attr.cache_entries.get("CMAKE_TOOLCHAIN_FILE") or not ctx.attr.generate_crosstool_file
 
-    define_install_prefix = "export INSTALL_PREFIX=\"" + _get_install_prefix(ctx) + "\"\n"
+    define_install_prefix = "export INSTALL_PREFIX=\"" + _get_install_prefix(ctx) + "\""
     configure_script = create_cmake_script(
+        ctx,
         workspace_name = ctx.workspace_name,
         cmake_path = configureParameters.attrs.cmake_path,
         tools = tools,
@@ -88,7 +89,10 @@ def _create_configure_script(configureParameters):
         include_dirs = inputs.include_dirs,
         is_debug_mode = is_debug_mode(ctx),
     )
-    return define_install_prefix + configure_script
+    return struct(
+        commands = [define_install_prefix] + configure_script.commands,
+        files = configure_script.files
+    )
 
 def _get_install_prefix(ctx):
     if ctx.attr.install_prefix:

--- a/foreign_cc/configure.bzl
+++ b/foreign_cc/configure.bzl
@@ -44,7 +44,7 @@ def _create_configure_script(configureParameters):
     tools = get_tools_info(ctx)
     flags = get_flags_info(ctx)
 
-    define_install_prefix = "export INSTALL_PREFIX=\"" + _get_install_prefix(ctx) + "\"\n"
+    define_install_prefix = "export INSTALL_PREFIX=\"" + _get_install_prefix(ctx) + "\""
 
     configure = create_configure_script(
         workspace_name = ctx.workspace_name,
@@ -71,7 +71,11 @@ def _create_configure_script(configureParameters):
         autogen_options = ctx.attr.autogen_options,
         autogen_env_vars = ctx.attr.autogen_env_vars,
     )
-    return "\n".join([define_install_prefix, configure])
+
+    return struct(
+        commands = [define_install_prefix] + configure.commands,
+        files = configure.files,
+    )
 
 def _get_install_prefix(ctx):
     if ctx.attr.install_prefix:

--- a/foreign_cc/ninja.bzl
+++ b/foreign_cc/ninja.bzl
@@ -77,7 +77,10 @@ def _create_ninja_script(configureParameters):
             target = target,
         ))
 
-    return "\n".join(script)
+    return struct(
+        commands = script,
+        files = [],
+    )
 
 def _attrs():
     """Modifies the common set of attributes used by rules_foreign_cc and sets Ninja specific attrs

--- a/foreign_cc/private/configure_script.bzl
+++ b/foreign_cc/private/configure_script.bzl
@@ -66,7 +66,10 @@ def create_configure_script(
         configure = configure_path,
         user_options = " ".join(user_options),
     ))
-    return "\n".join(script)
+    return struct(
+        commands = script,
+        files = []
+    )
 
 def _get_autogen_env_vars(autogen_env_vars):
     # Make a copy if necessary so we can set NOCONFIGURE.

--- a/foreign_cc/private/make_script.bzl
+++ b/foreign_cc/private/make_script.bzl
@@ -21,7 +21,10 @@ def create_make_script(
 
     script.append("##symlink_contents_to_dir## $$EXT_BUILD_ROOT$$/{} $$BUILD_TMPDIR$$".format(root))
     script.extend(make_commands)
-    return "\n".join(script)
+    return struct(
+        commands = script,
+        files = [],
+    )
 
 # buildifier: disable=function-docstring-args
 # buildifier: disable=function-docstring-return

--- a/test/cmake_text_tests.bzl
+++ b/test/cmake_text_tests.bzl
@@ -240,6 +240,7 @@ def _merge_flag_values_no_toolchain_file_test(ctx):
     }
 
     script = create_cmake_script(
+        ctx,
         "ws",
         "cmake",
         tools,
@@ -252,7 +253,7 @@ def _merge_flag_values_no_toolchain_file_test(ctx):
         [],
     )
     expected = """CC="/usr/bin/gcc" CXX="/usr/bin/gcc" CXXFLAGS="foo=\\"bar\\" -Fbat" cmake -DCMAKE_AR="/usr/bin/ar" -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$EXT_BUILD_DEPS" -DCMAKE_RANLIB=""  $EXT_BUILD_ROOT/external/test_rule"""
-    asserts.equals(env, expected, script)
+    asserts.equals(env, [expected], script.commands)
 
     return unittest.end(env)
 
@@ -280,6 +281,7 @@ def _create_min_cmake_script_no_toolchain_file_test(ctx):
     }
 
     script = create_cmake_script(
+        ctx,
         "ws",
         "cmake",
         tools,
@@ -292,7 +294,7 @@ def _create_min_cmake_script_no_toolchain_file_test(ctx):
         ["-GNinja"],
     )
     expected = """CC="/usr/bin/gcc" CXX="/usr/bin/gcc" CFLAGS="-U_FORTIFY_SOURCE -fstack-protector -Wall" CXXFLAGS="-U_FORTIFY_SOURCE -fstack-protector -Wall" ASMFLAGS="-U_FORTIFY_SOURCE -fstack-protector -Wall" cmake -DCMAKE_AR="/usr/bin/ar" -DCMAKE_SHARED_LINKER_FLAGS="-shared -fuse-ld=gold" -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=gold -Wl -no-as-needed" -DNOFORTRAN="on" -DCMAKE_BUILD_TYPE="Debug" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$EXT_BUILD_DEPS;/abc/def" -DCMAKE_RANLIB="" -GNinja $EXT_BUILD_ROOT/external/test_rule"""
-    asserts.equals(env, expected, script)
+    asserts.equals(env, [expected], script.commands)
 
     return unittest.end(env)
 
@@ -323,6 +325,7 @@ def _create_min_cmake_script_wipe_toolchain_test(ctx):
     }
 
     script = create_cmake_script(
+        ctx,
         "ws",
         "cmake",
         tools,
@@ -335,7 +338,7 @@ def _create_min_cmake_script_wipe_toolchain_test(ctx):
         ["-GNinja"],
     )
     expected = """CC="/usr/bin/gcc" CXX="/usr/bin/gcc" CFLAGS="-U_FORTIFY_SOURCE -fstack-protector -Wall" CXXFLAGS="-U_FORTIFY_SOURCE -fstack-protector -Wall" ASMFLAGS="-U_FORTIFY_SOURCE -fstack-protector -Wall" cmake -DCMAKE_AR="/usr/bin/ar" -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=gold -Wl -no-as-needed" -DCMAKE_BUILD_TYPE="Debug" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$EXT_BUILD_DEPS;/abc/def" -DCMAKE_RANLIB="" -GNinja $EXT_BUILD_ROOT/external/test_rule"""
-    asserts.equals(env, expected, script)
+    asserts.equals(env, [expected], script.commands)
 
     return unittest.end(env)
 
@@ -362,6 +365,7 @@ def _create_min_cmake_script_toolchain_file_test(ctx):
     }
 
     script = create_cmake_script(
+        ctx,
         "ws",
         "cmake",
         tools,
@@ -373,19 +377,8 @@ def _create_min_cmake_script_toolchain_file_test(ctx):
         user_env,
         ["-GNinja"],
     )
-    expected = """cat > crosstool_bazel.cmake <<EOF
-set(CMAKE_AR "/usr/bin/ar" CACHE FILEPATH "Archiver")
-set(CMAKE_ASM_FLAGS_INIT "-U_FORTIFY_SOURCE -fstack-protector -Wall")
-set(CMAKE_CXX_COMPILER "/usr/bin/gcc")
-set(CMAKE_CXX_FLAGS_INIT "-U_FORTIFY_SOURCE -fstack-protector -Wall")
-set(CMAKE_C_COMPILER "/usr/bin/gcc")
-set(CMAKE_C_FLAGS_INIT "-U_FORTIFY_SOURCE -fstack-protector -Wall")
-set(CMAKE_EXE_LINKER_FLAGS_INIT "-fuse-ld=gold -Wl -no-as-needed")
-set(CMAKE_SHARED_LINKER_FLAGS_INIT "-shared -fuse-ld=gold")
-EOF
-
- cmake -DNOFORTRAN="on" -DCMAKE_TOOLCHAIN_FILE="crosstool_bazel.cmake" -DCMAKE_BUILD_TYPE="Debug" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$EXT_BUILD_DEPS" -DCMAKE_RANLIB=\"\" -GNinja $EXT_BUILD_ROOT/external/test_rule"""
-    asserts.equals(env, expected.splitlines(), script.splitlines())
+    expected = """ cmake -DNOFORTRAN="on" -DCMAKE_TOOLCHAIN_FILE="$$EXT_BUILD_ROOT$$/{}" -DCMAKE_BUILD_TYPE="Debug" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$EXT_BUILD_DEPS" -DCMAKE_RANLIB=\"\" -GNinja $EXT_BUILD_ROOT/external/test_rule""".format(script.files[0].path)
+    asserts.equals(env, expected.splitlines(), script.commands)
 
     return unittest.end(env)
 
@@ -426,6 +419,7 @@ def _create_cmake_script_no_toolchain_file_test(ctx):
     }
 
     script = create_cmake_script(
+        ctx,
         "ws",
         "cmake",
         tools,
@@ -438,7 +432,7 @@ def _create_cmake_script_no_toolchain_file_test(ctx):
         ["-GNinja"],
     )
     expected = """CC="sink-cc-value" CXX="sink-cxx-value" CFLAGS="-cc-flag -gcc_toolchain cc-toolchain --from-env --additional-flag" CXXFLAGS="--quoted=\\"abc def\\" --sysroot=/abc/sysroot --gcc_toolchain cxx-toolchain" ASMFLAGS="assemble assemble-user" CUSTOM_ENV="YES" cmake -DCMAKE_AR="/cxx_linker_static" -DCMAKE_CXX_LINK_EXECUTABLE="became" -DCMAKE_SHARED_LINKER_FLAGS="shared1 shared2" -DCMAKE_EXE_LINKER_FLAGS="executable" -DCMAKE_BUILD_TYPE="user_type" -DCUSTOM_CACHE="YES" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$EXT_BUILD_DEPS" -DCMAKE_RANLIB="" -GNinja $EXT_BUILD_ROOT/external/test_rule"""
-    asserts.equals(env, expected, script)
+    asserts.equals(env, [expected], script.commands)
 
     return unittest.end(env)
 
@@ -478,6 +472,7 @@ def _create_cmake_script_toolchain_file_test(ctx):
     }
 
     script = create_cmake_script(
+        ctx,
         "ws",
         "cmake",
         tools,
@@ -489,23 +484,8 @@ def _create_cmake_script_toolchain_file_test(ctx):
         user_env,
         ["-GNinja"],
     )
-    expected = """cat > crosstool_bazel.cmake <<EOF
-set(CMAKE_AR "/cxx_linker_static" CACHE FILEPATH "Archiver")
-set(CMAKE_ASM_FLAGS_INIT "assemble assemble-user")
-set(CMAKE_CXX_COMPILER "sink-cxx-value")
-set(CMAKE_CXX_COMPILER_EXTERNAL_TOOLCHAIN "cxx-toolchain")
-set(CMAKE_CXX_FLAGS_INIT "--quoted=\\\"abc def\\\" --sysroot=/abc/sysroot --gcc_toolchain cxx-toolchain")
-set(CMAKE_CXX_LINK_EXECUTABLE "became")
-set(CMAKE_C_COMPILER "sink-cc-value")
-set(CMAKE_C_COMPILER_EXTERNAL_TOOLCHAIN "cc-toolchain")
-set(CMAKE_C_FLAGS_INIT "-cc-flag -gcc_toolchain cc-toolchain --from-env --additional-flag")
-set(CMAKE_EXE_LINKER_FLAGS_INIT "executable")
-set(CMAKE_SHARED_LINKER_FLAGS_INIT "shared1 shared2")
-set(CMAKE_SYSROOT "/abc/sysroot")
-EOF
-
-CUSTOM_ENV=\"YES\" cmake -DCUSTOM_CACHE=\"YES\" -DCMAKE_TOOLCHAIN_FILE=\"crosstool_bazel.cmake\" -DCMAKE_BUILD_TYPE=\"Debug\" -DCMAKE_INSTALL_PREFIX=\"test_rule\" -DCMAKE_PREFIX_PATH=\"$EXT_BUILD_DEPS\" -DCMAKE_RANLIB=\"\" -GNinja $EXT_BUILD_ROOT/external/test_rule"""
-    asserts.equals(env, expected.splitlines(), script.splitlines())
+    expected = """CUSTOM_ENV=\"YES\" cmake -DCUSTOM_CACHE=\"YES\" -DCMAKE_TOOLCHAIN_FILE=\"$$EXT_BUILD_ROOT$$/{}\" -DCMAKE_BUILD_TYPE=\"Debug\" -DCMAKE_INSTALL_PREFIX=\"test_rule\" -DCMAKE_PREFIX_PATH=\"$EXT_BUILD_DEPS\" -DCMAKE_RANLIB=\"\" -GNinja $EXT_BUILD_ROOT/external/test_rule""".format(script.files[0].path)
+    asserts.equals(env, expected.splitlines(), script.commands)
 
     return unittest.end(env)
 


### PR DESCRIPTION
Move cross tool to a declared output to reduce the chances of issues with shell escaping that generating this file via a heredoc creates.