### PR TITLE
Update the macos `os_name` from `osx` to `macos`

### DIFF
--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -303,7 +303,7 @@ def cc_external_rule_impl(ctx, attrs):
     cc_env = _correct_path_variable(get_env_vars(ctx))
     set_cc_envs = ""
     execution_os_name = os_name(ctx)
-    if execution_os_name != "osx":
+    if execution_os_name != "macos":
         set_cc_envs = "\n".join(["export {}=\"{}\"".format(key, cc_env[key]) for key in cc_env])
 
     lib_header = "Bazel external C/C++ Rules. Building library '{}'".format(lib_name)
@@ -399,7 +399,7 @@ def cc_external_rule_impl(ctx, attrs):
         ),
         # TODO: Default to never using the default shell environment to make builds more hermetic. For now, every platform
         # but MacOS will take the default PATH passed by Bazel, not that from cc_toolchain.
-        use_default_shell_env = execution_os_name != "osx",
+        use_default_shell_env = execution_os_name != "macos",
         command = wrapped_outputs.wrapper_script_file.path,
         execution_requirements = execution_requirements,
         # this is ignored if use_default_shell_env = True

--- a/foreign_cc/private/shell_toolchain/toolchains/impl/macos_commands.bzl
+++ b/foreign_cc/private/shell_toolchain/toolchains/impl/macos_commands.bzl
@@ -4,7 +4,7 @@ load("@rules_foreign_cc//foreign_cc/private/shell_toolchain/toolchains:function_
 _REPLACE_VALUE = "\\${EXT_BUILD_DEPS}"
 
 def os_name():
-    return "osx"
+    return "macos"
 
 def pwd():
     return "$(pwd)"


### PR DESCRIPTION
We should be using the modern name. This also matches Bazel's [platform](https://github.com/bazelbuild/platforms/blob/ed46070dfc79646c573acede7c4f9257d3d8fe44/os/BUILD#L54-L63) definitions