### PR TITLE
Fixed cmake build and target arguments

### DIFF
--- a/.bazelci/config.yaml
+++ b/.bazelci/config.yaml
@@ -48,6 +48,7 @@ tasks:
       - "-//cmake_defines/..."
       - "-//cmake_hello_world_lib/..."
       - "-//cmake_with_data/..."
+      - "-//cmake_with_target/..."
       - "-//cmake_working_dir/..."
       - "-//configure_with_bazel_transitive/..."
       - "-//make_simple/..."

--- a/examples/cmake_with_target/BUILD.bazel
+++ b/examples/cmake_with_target/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
+
+filegroup(
+    name = "srcs",
+    srcs = glob(["src/**"]),
+    visibility = ["//visibility:public"],
+)
+
+# Building all targets with the `srcs` CMake project will fail.
+# this example demonstrates how users can avoid unnecessary targets
+cmake(
+    name = "cmake_with_target",
+    build_args = [
+        "--verbose",
+        "--",  # <- Pass remaining options to the native tool.
+        "-j 1",
+    ],
+    install_args = ["--component working"],
+    lib_source = ":srcs",
+    out_static_libs = select({
+        "@platforms//os:windows": [
+            "working_a.lib",
+            "working_b.lib"
+        ],
+        "//conditions:default": [
+            "libworking_a.a",
+            "libworking_b.a",
+        ],
+    }),
+    targets = [
+        "working_a",
+        "working_b",
+    ],
+)

--- a/examples/cmake_with_target/src/CMakeLists.txt
+++ b/examples/cmake_with_target/src/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.18.1)
+
+project(cmake_with_target_example)
+
+set(LIB_SRC lib.cpp lib.h)
+
+add_library(working_a STATIC ${LIB_SRC})
+target_compile_definitions(working_a PRIVATE TRIGGER_ERROR=0)
+
+add_library(working_b STATIC ${LIB_SRC})
+target_compile_definitions(working_b PRIVATE TRIGGER_ERROR=0)
+
+add_library(broken STATIC ${LIB_SRC})
+target_compile_definitions(broken PRIVATE TRIGGER_ERROR=1)
+
+install(TARGETS working_a working_b COMPONENT working ARCHIVE DESTINATION lib)
+install(TARGETS broken COMPONENT broken ARCHIVE DESTINATION lib)
+install(FILES lib.h DESTINATION include)

--- a/examples/cmake_with_target/src/lib.cpp
+++ b/examples/cmake_with_target/src/lib.cpp
@@ -1,0 +1,16 @@
+#include "lib.h"
+
+#include <iostream>
+
+#ifndef TRIGGER_ERROR
+#error This value must be defined
+#endif
+
+#if TRIGGER_ERROR
+#error This error intentionally prevents this library from compiling
+#endif
+
+void hello_world()
+{
+    std::cout << "Hello world!" << std::endl;
+}

--- a/examples/cmake_with_target/src/lib.h
+++ b/examples/cmake_with_target/src/lib.h
@@ -1,0 +1,6 @@
+#ifndef LIB_H_
+#define LIB_H_
+
+void hello_world();
+
+#endif

--- a/foreign_cc/cmake.bzl
+++ b/foreign_cc/cmake.bzl
@@ -89,9 +89,14 @@ def _create_configure_script(configureParameters):
         # Generate commands for all the targets, ensuring there's
         # always at least 1 call to the default target.
         for target in ctx.attr.targets or [""]:
+
+            # There's no need to use the `--target` argument for an empty/"all" target
+            if target:
+                target = "--target '{}'".format(target)
+
             # Note that even though directory is always passed, the
             # following arguments can take precedence.
-            cmake_commands.append("{cmake} --build {dir} --config {config} {args} {target}".format(
+            cmake_commands.append("{cmake} --build {dir} --config {config} {target} {args}".format(
                 cmake = attrs.cmake_path,
                 dir = ".",
                 args = build_args,


### PR DESCRIPTION
Targets can now be properly passed to the CMake build command and arguments are now appropriately the last thing to be passed to provide the most flexibility.