### PR TITLE
Update documentation to reflect minimum version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Documentation for all rules and providers are available [here](./docs/README.md)
 
 ## Bazel versions compatibility
 
-Works with Bazel after 3.4.0 without any flags.
+Works with Bazel after 3.7.0 without any flags.
 
 Note that the rules may be compatible with older versions of Bazel but support may break
 in future changes as these older versions are not tested.


### PR DESCRIPTION
Change f48ec05fed3170b8b32bbc4b6d8fd4175f8b8cff bumped up the minimum
bazel version to 3.7.0. This change reflects this in the
documentation.