### PR TITLE
Use touch not cp -p to preserve timestamps

### DIFF
--- a/foreign_cc/private/shell_toolchain/toolchains/impl/default_commands.bzl
+++ b/foreign_cc/private/shell_toolchain/toolchains/impl/default_commands.bzl
@@ -61,7 +61,10 @@ fi
     )
 
 def copy_dir_contents_to_dir(source, target):
-    return """cp -L -p -r --no-target-directory "{}" "{}" """.format(source, target)
+    return """cp -L -r --no-target-directory "{source}" "{target}" && find {target} -type f -exec touch -r "{source}" "{{}}" \\;""".format(
+        source=source,
+        target=target,
+    )
 
 def symlink_contents_to_dir(source, target):
     text = """\

--- a/foreign_cc/private/shell_toolchain/toolchains/impl/linux_commands.bzl
+++ b/foreign_cc/private/shell_toolchain/toolchains/impl/linux_commands.bzl
@@ -61,7 +61,10 @@ fi
     )
 
 def copy_dir_contents_to_dir(source, target):
-    return """cp -L -p -r --no-target-directory "{}" "{}" """.format(source, target)
+    return """cp -L -r --no-target-directory "{source}" "{target}" && find {target} -type f -exec touch -r "{source}" "{{}}" \\;""".format(
+        source=source,
+        target=target,
+    )
 
 def symlink_contents_to_dir(source, target):
     text = """\

--- a/foreign_cc/private/shell_toolchain/toolchains/impl/windows_commands.bzl
+++ b/foreign_cc/private/shell_toolchain/toolchains/impl/windows_commands.bzl
@@ -61,7 +61,10 @@ fi
     )
 
 def copy_dir_contents_to_dir(source, target):
-    return """cp -L -p -r --no-target-directory "{}" "{}" """.format(source, target)
+    return """cp -L -r --no-target-directory "{source}" "{target}" && find {target} -type f -exec touch -r "{source}" "{{}}" \\;""".format(
+        source=source,
+        target=target,
+    )
 
 def symlink_contents_to_dir(source, target):
     text = """\


### PR DESCRIPTION
If the file being copied is owned by a different user than the build
action, which may be the case for some remote execution platforms,
`cp -p` fails with `EPERM` whereas `touch -r` won't.