### PR TITLE
Optimize methods in detect_root.bzl

### DIFF
--- a/foreign_cc/private/detect_root.bzl
+++ b/foreign_cc/private/detect_root.bzl
@@ -15,54 +15,16 @@ def detect_root(source):
     if len(sources) == 0:
         return ""
 
-    root = None
-    level = -1
-
     # find topmost directory
+    root = None
     for file in sources:
-        file_level = _get_level(file.path)
-
-        # If there is no level set or the current file's level
-        # is greather than what we have logged, update the root
-        if level == -1 or level > file_level:
-            root = file
-            level = file_level
+        if root == None or root.startswith(file.dirname):
+            root = file.dirname
 
     if not root:
         fail("No root source or directory was found")
 
-    if root.is_source:
-        return root.dirname
-
-    # Note this code path will never be hit due to a bug upstream Bazel
-    # https://github.com/bazelbuild/bazel/issues/12954
-
-    # If the root is not a source file, it must be a directory.
-    # Thus the path is returned
-    return root.path
-
-def _get_level(path):
-    """Determine the number of sub directories `path` is contained in
-
-    Args:
-        path (string): The target path
-
-    Returns:
-        int: The directory depth of `path`
-    """
-    normalized = path
-
-    # This for loop ensures there are no double `//` substrings.
-    # A for loop is used because there's not currently a `while`
-    # or a better mechanism for guaranteeing all `//` have been
-    # cleaned up.
-    for i in range(len(path)):
-        new_normalized = normalized.replace("//", "/")
-        if len(new_normalized) == len(normalized):
-            break
-        normalized = new_normalized
-
-    return normalized.count("/")
+    return root
 
 # buildifier: disable=function-docstring-header
 # buildifier: disable=function-docstring-args

--- a/foreign_cc/private/detect_root.bzl
+++ b/foreign_cc/private/detect_root.bzl
@@ -36,12 +36,6 @@ def filter_containing_dirs_from_inputs(input_files_list):
     The parent directories will be created for us in the execroot anyway,
     so we filter them out."""
 
-    # This puts directories in front of their children in list
-    sorted_list = sorted(input_files_list)
-    contains_map = {}
-    for input in input_files_list:
-        # If the immediate parent directory is already in the list, remove it
-        if contains_map.get(input.dirname):
-            contains_map.pop(input.dirname)
-        contains_map[input.path] = input
-    return contains_map.values()
+    populated_dirs = {f.dirname: None for f in input_files_list}
+    return [f for f in input_files_list if f.path not in populated_dirs]
+    

--- a/foreign_cc/private/detect_root.bzl
+++ b/foreign_cc/private/detect_root.bzl
@@ -15,8 +15,10 @@ def detect_root(source):
     if len(sources) == 0:
         return ""
 
-    # find topmost directory
     root = None
+
+    # Find topmost directory by searching for the file.dirname that is a
+    # prefix of all other files.
     for file in sources:
         if root == None or root.startswith(file.dirname):
             root = file.dirname
@@ -36,6 +38,7 @@ def filter_containing_dirs_from_inputs(input_files_list):
     The parent directories will be created for us in the execroot anyway,
     so we filter them out."""
 
+    # Find all the directories that have at least one file or dir inside them.
     populated_dirs = {f.dirname: None for f in input_files_list}
+    # Filter out any files which are members of populated_dirs.
     return [f for f in input_files_list if f.path not in populated_dirs]
-    


### PR DESCRIPTION
detect_root and filter_containing_dirs_from_inputs showed up on profiles of our builds as taking a long time (300+ ms). This change uses faster algorithms for detecting the root from a set of source files and eliminating duplicates.

The root is the shortest common dirname among all files. There is an implicit assumption that there is at least one file at the root, otherwise in a tree like the following, the wrong root will be detected, but the existing code also makes this assumption and it seems like it's required.
```
foo/bar/bar.c
foo/baz/baz.c
(Root should be foo, but will be detected as foo/bar)
```

filter_containing_dirs_from_inputs is made faster by avoiding the sort of a potentially large number of files by doing two passes, first to collect a set of directories that contain files, and second to create a list filtering out any directories in the set. (i.e. changes from n log n -> 2n)

This reduces the total time in analysis from 432ms to 134ms for our repository.
