### PR TITLE
Pass empty suffix to sed on macOS

### DIFF
--- a/foreign_cc/private/shell_toolchain/toolchains/impl/macos_commands.bzl
+++ b/foreign_cc/private/shell_toolchain/toolchains/impl/macos_commands.bzl
@@ -55,7 +55,7 @@ def replace_in_files(dir, from_, to_):
     return FunctionAndCall(
         text = """\
 if [ -d "$1" ]; then
-    find -L -f $1 \\( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.cmake" \\)     -exec sed -i -e 's@'"$2"'@'"$3"'@g' {} ';'
+    find -L -f $1 \\( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.cmake" \\)     -exec sed -i '' -e 's@'"$2"'@'"$3"'@g' {} ';'
 fi
 """,
     )


### PR DESCRIPTION
sed on macOS requires a suffix when using -i. Current usage will create temporary files with -e suffixes so pass an empty suffix to avoid creating the backup files on macOS.