### PR TITLE
Replaced uses of `$var ` with `$$var$$`

### DIFF
--- a/foreign_cc/private/cmake_script.bzl
+++ b/foreign_cc/private/cmake_script.bzl
@@ -86,7 +86,7 @@ def create_cmake_script(
     # Add definitions for all environment variables
     script = set_env_vars
 
-    directory = "$EXT_BUILD_ROOT/" + root
+    directory = "$$EXT_BUILD_ROOT$$/" + root
 
     script.append("set -x")
 
@@ -123,7 +123,7 @@ def _wipe_empty_values(cache, keys_with_empty_values_in_user_cache):
 # From CMake documentation: ;-list of directories specifying installation prefixes to be searched...
 def _merge_prefix_path(user_cache, include_dirs):
     user_prefix = user_cache.get("CMAKE_PREFIX_PATH")
-    values = ["$EXT_BUILD_DEPS"] + include_dirs
+    values = ["$$EXT_BUILD_DEPS$$"] + include_dirs
     if user_prefix != None:
         # remove it, it is gonna be merged specifically
         user_cache.pop("CMAKE_PREFIX_PATH")
@@ -338,7 +338,7 @@ def _tail_if_starts_with(str, start):
 def _absolutize(workspace_name, text, force = False):
     if text.strip(" ").startswith("C:") or text.strip(" ").startswith("c:"):
         return text
-    return absolutize_path_in_str(workspace_name, "$EXT_BUILD_ROOT/", text, force)
+    return absolutize_path_in_str(workspace_name, "$$EXT_BUILD_ROOT$$/", text, force)
 
 def _join_flags_list(workspace_name, flags):
     return " ".join([_absolutize(workspace_name, flag) for flag in flags])

--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -317,8 +317,8 @@ def cc_external_rule_impl(ctx, attrs):
     define_variables = set_cc_envs + [
         "export EXT_BUILD_ROOT=##pwd##",
         "export INSTALLDIR=$$EXT_BUILD_ROOT$$/" + empty.file.dirname + "/" + lib_name,
-        "export BUILD_TMPDIR=$${INSTALLDIR}$$.build_tmpdir",
-        "export EXT_BUILD_DEPS=$${INSTALLDIR}$$.ext_build_deps",
+        "export BUILD_TMPDIR=$$INSTALLDIR$$.build_tmpdir",
+        "export EXT_BUILD_DEPS=$$INSTALLDIR$$.ext_build_deps",
     ] + [
         "export {key}={value}".format(
             key = key,

--- a/test/cmake_text_tests.bzl
+++ b/test/cmake_text_tests.bzl
@@ -12,12 +12,12 @@ def _absolutize_test(ctx):
     env = unittest.begin(ctx)
 
     cases = {
-        "-Lexternal/cmake/aaa": "-L$EXT_BUILD_ROOT/external/cmake/aaa",
+        "-Lexternal/cmake/aaa": "-L$$EXT_BUILD_ROOT$$/external/cmake/aaa",
         "/abs/a12": "/abs/a12",
         "abs/a12": "abs/a12",
-        "external/cmake/aaa": "$EXT_BUILD_ROOT/external/cmake/aaa",
-        "name=ws/cmake/aaa": "name=$EXT_BUILD_ROOT/ws/cmake/aaa",
-        "ws/cmake/aaa": "$EXT_BUILD_ROOT/ws/cmake/aaa",
+        "external/cmake/aaa": "$$EXT_BUILD_ROOT$$/external/cmake/aaa",
+        "name=ws/cmake/aaa": "name=$$EXT_BUILD_ROOT$$/ws/cmake/aaa",
+        "ws/cmake/aaa": "$$EXT_BUILD_ROOT$$/ws/cmake/aaa",
     }
 
     for case in cases:
@@ -94,11 +94,11 @@ def _fill_crossfile_from_toolchain_test(ctx):
     expected = {
         "CMAKE_AR": "/cxx_linker_static",
         "CMAKE_ASM_FLAGS_INIT": "assemble",
-        "CMAKE_CXX_COMPILER": "$EXT_BUILD_ROOT/external/cxx-value",
+        "CMAKE_CXX_COMPILER": "$$EXT_BUILD_ROOT$$/external/cxx-value",
         "CMAKE_CXX_COMPILER_EXTERNAL_TOOLCHAIN": "cxx-toolchain",
         # Quoted args are escaped when crossfile is written to a script in create_cmake_script
         "CMAKE_CXX_FLAGS_INIT": "--quoted=\"abc def\" --sysroot=/abc/sysroot --gcc_toolchain cxx-toolchain",
-        "CMAKE_CXX_LINK_EXECUTABLE": "$EXT_BUILD_ROOT/ws/cxx_linker_executable <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>",
+        "CMAKE_CXX_LINK_EXECUTABLE": "$$EXT_BUILD_ROOT$$/ws/cxx_linker_executable <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>",
         "CMAKE_C_COMPILER": "/some-cc-value",
         "CMAKE_C_COMPILER_EXTERNAL_TOOLCHAIN": "cc-toolchain",
         "CMAKE_C_FLAGS_INIT": "-cc-flag -gcc_toolchain cc-toolchain",
@@ -258,7 +258,7 @@ def _merge_flag_values_no_toolchain_file_test(ctx):
 export CXX="/usr/bin/gcc"
 export CXXFLAGS="foo=\\\"bar\\\" -Fbat"
 set -x
-cmake -DCMAKE_AR="/usr/bin/ar" -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$EXT_BUILD_DEPS" -DCMAKE_RANLIB=""  -G 'Unix Makefiles' $EXT_BUILD_ROOT/external/test_rule
+cmake -DCMAKE_AR="/usr/bin/ar" -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$$EXT_BUILD_DEPS$$" -DCMAKE_RANLIB=""  -G 'Unix Makefiles' $$EXT_BUILD_ROOT$$/external/test_rule
 set +x
 """
     asserts.equals(env, expected.splitlines(), script)
@@ -308,7 +308,7 @@ export CFLAGS="-U_FORTIFY_SOURCE -fstack-protector -Wall"
 export CXXFLAGS="-U_FORTIFY_SOURCE -fstack-protector -Wall"
 export ASMFLAGS="-U_FORTIFY_SOURCE -fstack-protector -Wall"
 set -x
-cmake -DCMAKE_AR="/usr/bin/ar" -DCMAKE_SHARED_LINKER_FLAGS="-shared -fuse-ld=gold" -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=gold -Wl -no-as-needed" -DNOFORTRAN="on" -DCMAKE_BUILD_TYPE="Debug" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$EXT_BUILD_DEPS;/abc/def" -DCMAKE_RANLIB="" --debug-output -Wdev -G 'Ninja' $EXT_BUILD_ROOT/external/test_rule
+cmake -DCMAKE_AR="/usr/bin/ar" -DCMAKE_SHARED_LINKER_FLAGS="-shared -fuse-ld=gold" -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=gold -Wl -no-as-needed" -DNOFORTRAN="on" -DCMAKE_BUILD_TYPE="Debug" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$$EXT_BUILD_DEPS$$;/abc/def" -DCMAKE_RANLIB="" --debug-output -Wdev -G 'Ninja' $$EXT_BUILD_ROOT$$/external/test_rule
 set +x
 """
     asserts.equals(env, expected.splitlines(), script)
@@ -361,7 +361,7 @@ export CFLAGS="-U_FORTIFY_SOURCE -fstack-protector -Wall"
 export CXXFLAGS="-U_FORTIFY_SOURCE -fstack-protector -Wall"
 export ASMFLAGS="-U_FORTIFY_SOURCE -fstack-protector -Wall"
 set -x
-cmake -DCMAKE_AR="/usr/bin/ar" -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=gold -Wl -no-as-needed" -DCMAKE_BUILD_TYPE="Debug" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$EXT_BUILD_DEPS;/abc/def" -DCMAKE_RANLIB="" --debug-output -Wdev -G 'Ninja' $EXT_BUILD_ROOT/external/test_rule
+cmake -DCMAKE_AR="/usr/bin/ar" -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=gold -Wl -no-as-needed" -DCMAKE_BUILD_TYPE="Debug" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$$EXT_BUILD_DEPS$$;/abc/def" -DCMAKE_RANLIB="" --debug-output -Wdev -G 'Ninja' $$EXT_BUILD_ROOT$$/external/test_rule
 set +x
 """
     asserts.equals(env, expected.splitlines(), script)
@@ -416,7 +416,7 @@ set(CMAKE_SHARED_LINKER_FLAGS_INIT "-shared -fuse-ld=gold")
 EOF
 
 set -x
-cmake -DNOFORTRAN="on" -DCMAKE_TOOLCHAIN_FILE="crosstool_bazel.cmake" -DCMAKE_BUILD_TYPE="Debug" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$EXT_BUILD_DEPS" -DCMAKE_RANLIB="" --debug-output -Wdev -G 'Ninja' $EXT_BUILD_ROOT/external/test_rule
+cmake -DNOFORTRAN="on" -DCMAKE_TOOLCHAIN_FILE="crosstool_bazel.cmake" -DCMAKE_BUILD_TYPE="Debug" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$$EXT_BUILD_DEPS$$" -DCMAKE_RANLIB="" --debug-output -Wdev -G 'Ninja' $$EXT_BUILD_ROOT$$/external/test_rule
 set +x
 """
     asserts.equals(env, expected.splitlines(), script)
@@ -480,7 +480,7 @@ export CXXFLAGS="--quoted=\\\"abc def\\\" --sysroot=/abc/sysroot --gcc_toolchain
 export ASMFLAGS="assemble assemble-user"
 export CUSTOM_ENV="YES"
 set -x
-cmake -DCMAKE_AR="/cxx_linker_static" -DCMAKE_CXX_LINK_EXECUTABLE="became" -DCMAKE_SHARED_LINKER_FLAGS="shared1 shared2" -DCMAKE_EXE_LINKER_FLAGS="executable" -DCMAKE_BUILD_TYPE="user_type" -DCUSTOM_CACHE="YES" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$EXT_BUILD_DEPS" -DCMAKE_RANLIB="" --debug-output -Wdev -G 'Ninja' $EXT_BUILD_ROOT/external/test_rule
+cmake -DCMAKE_AR="/cxx_linker_static" -DCMAKE_CXX_LINK_EXECUTABLE="became" -DCMAKE_SHARED_LINKER_FLAGS="shared1 shared2" -DCMAKE_EXE_LINKER_FLAGS="executable" -DCMAKE_BUILD_TYPE="user_type" -DCUSTOM_CACHE="YES" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$$EXT_BUILD_DEPS$$" -DCMAKE_RANLIB="" --debug-output -Wdev -G 'Ninja' $$EXT_BUILD_ROOT$$/external/test_rule
 set +x
 """
     asserts.equals(env, expected.splitlines(), script)
@@ -553,7 +553,7 @@ EOF
 
 export CUSTOM_ENV="YES"
 set -x
-cmake -DCUSTOM_CACHE="YES" -DCMAKE_TOOLCHAIN_FILE="crosstool_bazel.cmake" -DCMAKE_BUILD_TYPE="Debug" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$EXT_BUILD_DEPS" -DCMAKE_RANLIB="" --debug-output -Wdev -G 'Ninja' $EXT_BUILD_ROOT/external/test_rule
+cmake -DCUSTOM_CACHE="YES" -DCMAKE_TOOLCHAIN_FILE="crosstool_bazel.cmake" -DCMAKE_BUILD_TYPE="Debug" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$$EXT_BUILD_DEPS$$" -DCMAKE_RANLIB="" --debug-output -Wdev -G 'Ninja' $$EXT_BUILD_ROOT$$/external/test_rule
 set +x
 """
     asserts.equals(env, expected.splitlines(), script)


### PR DESCRIPTION
This moves more functionality into the framework so things like https://github.com/bazelbuild/rules_foreign_cc/issues/607 are more doable. Instead of relying on bash, we should use the foreign_cc framework to define functionality.