### PR TITLE
Add incompatible_use_toolchain_transition = True 

### DIFF
--- a/foreign_cc/boost_build.bzl
+++ b/foreign_cc/boost_build.bzl
@@ -54,4 +54,7 @@ boost_build = rule(
         "@rules_foreign_cc//foreign_cc/private/shell_toolchain/toolchains:shell_commands",
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
+    # TODO: Remove once https://github.com/bazelbuild/bazel/issues/11584 is closed and the min supported
+    # version is updated to a release of Bazel containing the new default for this setting.
+    incompatible_use_toolchain_transition = True,
 )

--- a/foreign_cc/cmake.bzl
+++ b/foreign_cc/cmake.bzl
@@ -282,4 +282,7 @@ cmake = rule(
         "@rules_foreign_cc//foreign_cc/private/shell_toolchain/toolchains:shell_commands",
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
+    # TODO: Remove once https://github.com/bazelbuild/bazel/issues/11584 is closed and the min supported
+    # version is updated to a release of Bazel containing the new default for this setting.
+    incompatible_use_toolchain_transition = True,
 )

--- a/foreign_cc/configure.bzl
+++ b/foreign_cc/configure.bzl
@@ -214,4 +214,7 @@ configure_make = rule(
         "@rules_foreign_cc//foreign_cc/private/shell_toolchain/toolchains:shell_commands",
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
+    # TODO: Remove once https://github.com/bazelbuild/bazel/issues/11584 is closed and the min supported
+    # version is updated to a release of Bazel containing the new default for this setting.
+    incompatible_use_toolchain_transition = True,
 )

--- a/foreign_cc/make.bzl
+++ b/foreign_cc/make.bzl
@@ -99,4 +99,7 @@ make = rule(
         "@rules_foreign_cc//foreign_cc/private/shell_toolchain/toolchains:shell_commands",
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
+    # TODO: Remove once https://github.com/bazelbuild/bazel/issues/11584 is closed and the min supported
+    # version is updated to a release of Bazel containing the new default for this setting.
+    incompatible_use_toolchain_transition = True,
 )

--- a/foreign_cc/ninja.bzl
+++ b/foreign_cc/ninja.bzl
@@ -116,4 +116,7 @@ ninja = rule(
         "@rules_foreign_cc//foreign_cc/private/shell_toolchain/toolchains:shell_commands",
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
+    # TODO: Remove once https://github.com/bazelbuild/bazel/issues/11584 is closed and the min supported
+    # version is updated to a release of Bazel containing the new default for this setting.
+    incompatible_use_toolchain_transition = True,
 )


### PR DESCRIPTION
As per https://github.com/bazelbuild/bazel/issues/11584 add `incompatible_use_toolchain_transition` attribute to enable use of `exec` configuration