### PR TITLE
Added a new `platform_info` target to the foreign_cc framework

### DIFF
--- a/foreign_cc/built_tools/make_build.bzl
+++ b/foreign_cc/built_tools/make_build.bzl
@@ -6,7 +6,7 @@ load(
     "FOREIGN_CC_BUILT_TOOLS_HOST_FRAGMENTS",
     "built_tool_rule_impl",
 )
-load("//foreign_cc/private/framework:helpers.bzl", "os_name")
+load("//foreign_cc/private/framework:platform.bzl", "os_name")
 
 def _make_tool_impl(ctx):
     script = [

--- a/foreign_cc/built_tools/ninja_build.bzl
+++ b/foreign_cc/built_tools/ninja_build.bzl
@@ -6,7 +6,7 @@ load(
     "FOREIGN_CC_BUILT_TOOLS_HOST_FRAGMENTS",
     "built_tool_rule_impl",
 )
-load("//foreign_cc/private/framework:helpers.bzl", "os_name")
+load("//foreign_cc/private/framework:platform.bzl", "os_name")
 
 def _ninja_tool_impl(ctx):
     script = [

--- a/foreign_cc/built_tools/private/built_tools_framework.bzl
+++ b/foreign_cc/built_tools/private/built_tools_framework.bzl
@@ -11,7 +11,14 @@ FOREIGN_CC_BUILT_TOOLS_ATTRS = {
         doc = "The target containing the build tool's sources",
         mandatory = True,
     ),
-    "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
+    "_cc_toolchain": attr.label(
+        default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+    ),
+    "_foreign_cc_framework_platform": attr.label(
+        doc = "Information about the execution platform",
+        cfg = "exec",
+        default = Label("@rules_foreign_cc//foreign_cc/private/framework:platform_info"),
+    ),
 }
 
 # Common host fragments for all built_tool rules

--- a/foreign_cc/cmake.bzl
+++ b/foreign_cc/cmake.bzl
@@ -16,7 +16,10 @@ load(
     "cc_external_rule_impl",
     "create_attrs",
 )
-load("//foreign_cc/private/framework:helpers.bzl", "os_name")
+load(
+    "//foreign_cc/private/framework:platform.bzl",
+    "os_name",
+)
 load(
     "//toolchains/native_tools:tool_access.bzl",
     "get_cmake_data",

--- a/foreign_cc/configure.bzl
+++ b/foreign_cc/configure.bzl
@@ -14,7 +14,7 @@ load(
     "cc_external_rule_impl",
     "create_attrs",
 )
-load("//foreign_cc/private/framework:helpers.bzl", "os_name")
+load("//foreign_cc/private/framework:platform.bzl", "os_name")
 load("//toolchains/native_tools:tool_access.bzl", "get_make_data")
 
 def _configure_make(ctx):

--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -10,10 +10,10 @@ load(
     "//foreign_cc/private/framework:helpers.bzl",
     "convert_shell_script",
     "create_function",
-    "os_name",
     "script_extension",
     "shebang",
 )
+load("//foreign_cc/private/framework:platform.bzl", "os_name")
 load(
     "//toolchains/native_tools:tool_access.bzl",
     "get_make_data",
@@ -191,6 +191,11 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
     # we need to declare this attribute to access cc_toolchain
     "_cc_toolchain": attr.label(
         default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+    ),
+    "_foreign_cc_framework_platform": attr.label(
+        doc = "Information about the execution platform",
+        cfg = "exec",
+        default = Label("@rules_foreign_cc//foreign_cc/private/framework:platform_info"),
     ),
 }
 

--- a/foreign_cc/private/framework/BUILD.bazel
+++ b/foreign_cc/private/framework/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load(":platform.bzl", "framework_platform_info")
 
 toolchain_type(
     name = "shell_toolchain",
@@ -11,3 +12,5 @@ bzl_library(
     visibility = ["//:__subpackages__"],
     deps = ["//foreign_cc/private/framework/toolchains:bzl_srcs"],
 )
+
+framework_platform_info()

--- a/foreign_cc/private/framework/helpers.bzl
+++ b/foreign_cc/private/framework/helpers.bzl
@@ -34,9 +34,6 @@ of the function bodies to populate the "prelude" part of the script.
 load("//foreign_cc/private/framework/toolchains:access.bzl", "call_shell", "create_context")
 load("//foreign_cc/private/framework/toolchains:commands.bzl", "PLATFORM_COMMANDS")
 
-def os_name(ctx):
-    return call_shell(create_context(ctx), "os_name")
-
 def script_extension(ctx):
     """A helper method for getting the script extension of the current foreign_cc framework toolchain
 

--- a/foreign_cc/private/framework/platform.bzl
+++ b/foreign_cc/private/framework/platform.bzl
@@ -1,0 +1,67 @@
+"""A helper module containing tools for detecting platform information"""
+
+ForeignCcPlatformInfo = provider(
+    doc = "A provider containing information about the current platform",
+    fields = {
+        "os": "The platform os",
+    },
+)
+
+def _framework_platform_info_impl(ctx):
+    """The implementation of `framework_platform_info`
+
+    Args:
+        ctx (ctx): The rule's context object
+
+    Returns:
+        list: A provider containing platform info
+    """
+    return [ForeignCcPlatformInfo(
+        os = ctx.attr.os,
+    )]
+
+_framework_platform_info = rule(
+    doc = "A rule defining platform information used by the foreign_cc framework",
+    implementation = _framework_platform_info_impl,
+    attrs = {
+        "os": attr.string(
+            doc = "The platform's operating system",
+        ),
+    },
+)
+
+def framework_platform_info(name = "platform_info"):
+    """Define a target contianing platform information used in the foreign_cc framework"""
+    _framework_platform_info(
+        name = name,
+        os = select({
+            "@platforms//os:android": "android",
+            "@platforms//os:freebsd": "freebsd",
+            "@platforms//os:ios": "ios",
+            "@platforms//os:linux": "linux",
+            "@platforms//os:macos": "macos",
+            "@platforms//os:none": "none",
+            "@platforms//os:openbsd": "openbsd",
+            "@platforms//os:qnx": "qnx",
+            "@platforms//os:tvos": "tvos",
+            "@platforms//os:watchos": "watchos",
+            "@platforms//os:windows": "windows",
+            "//conditions:default": "unknown",
+        }),
+        visibility = ["//visibility:public"],
+    )
+
+def os_name(ctx):
+    """A helper function for getting the operating system name from a `ForeignCcPlatformInfo` provider
+
+    Args:
+        ctx (ctx): The current rule's context object
+
+    Returns:
+        str: The string of the current platform
+    """
+    platform_info = getattr(ctx.attr, "_foreign_cc_framework_platform")
+    if not platform_info:
+        return "unknown"
+
+    return platform_info[ForeignCcPlatformInfo].os

--- a/foreign_cc/private/framework/platform.bzl
+++ b/foreign_cc/private/framework/platform.bzl
@@ -31,7 +31,7 @@ _framework_platform_info = rule(
 )
 
 def framework_platform_info(name = "platform_info"):
-    """Define a target contianing platform information used in the foreign_cc framework"""
+    """Define a target containing platform information used in the foreign_cc framework"""
     _framework_platform_info(
         name = name,
         os = select({

--- a/foreign_cc/private/framework/toolchains/commands.bzl
+++ b/foreign_cc/private/framework/toolchains/commands.bzl
@@ -145,10 +145,6 @@ PLATFORM_COMMANDS = {
         arguments = [_argument_info(name = "path", data_type = type(""), doc = "Path to directory")],
         doc = "Creates a directory and, if neccesary, it's parents",
     ),
-    "os_name": _command_info(
-        arguments = [],
-        doc = "Returns OS name",
-    ),
     "path": _command_info(
         arguments = [
             _argument_info(name = "expression", data_type = type(""), doc = "Path"),

--- a/foreign_cc/private/framework/toolchains/linux_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/linux_commands.bzl
@@ -4,9 +4,6 @@ load(":commands.bzl", "FunctionAndCallInfo")
 
 _REPLACE_VALUE = "\\${EXT_BUILD_DEPS}"
 
-def os_name():
-    return "linux"
-
 def shebang():
     return "#!/usr/bin/env bash"
 

--- a/foreign_cc/private/framework/toolchains/macos_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/macos_commands.bzl
@@ -4,9 +4,6 @@ load(":commands.bzl", "FunctionAndCallInfo")
 
 _REPLACE_VALUE = "\\${EXT_BUILD_DEPS}"
 
-def os_name():
-    return "macos"
-
 def shebang():
     return "#!/usr/bin/env bash"
 

--- a/foreign_cc/private/framework/toolchains/windows_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/windows_commands.bzl
@@ -4,9 +4,6 @@ load(":commands.bzl", "FunctionAndCallInfo")
 
 _REPLACE_VALUE = "\\${EXT_BUILD_DEPS}"
 
-def os_name():
-    return "windows"
-
 def shebang():
     return "#!/usr/bin/env bash"
 

--- a/test/convert_shell_script_test.bzl
+++ b/test/convert_shell_script_test.bzl
@@ -108,7 +108,6 @@ def _do_function_call_test(ctx):
 
     cases = {
         "##echo## \"\ntext\n\"": "echo1 \"\ntext\n\"",
-        "##os_name##": "Fuchsia",
         "##script_prelude##": "set -euo pipefail",
         "##symlink_contents_to_dir## 1 2": "1_2",
         "export ROOT=\"A B C\"": "export1 ROOT=\"A B C\"",


### PR DESCRIPTION
I don't think this is something that should live in the foreign_cc toolchain. Ideally this would be replaced by something provided by Bazel but until then I like having it separated