### PR TITLE
Fixed silent failures replacing sandbox paths in outputs

### DIFF
--- a/foreign_cc/private/framework/toolchains/linux_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/linux_commands.bzl
@@ -112,7 +112,14 @@ def symlink_to_dir(source, target):
 local target="$2"
 mkdir -p "$target"
 if [[ -f "$1" ]]; then
-  ln -s -f -t "$target" "$1"
+  # In order to be able to use `replace_in_files`, we ensure that we create copies of specfieid
+  # files so updating them is possible.
+  if [[ "$1" == *.pc || "$1" == *.la || "$1" == *-config || "$1" == *.mk || "$1" == *.cmake ]]; then
+    dest="$target/$(basename $1)"
+    cp "$1" "$dest" && chmod +w "$dest" && touch -r "$1" "$dest"
+  else
+    ln -s -f -t "$target" "$1"
+  fi
 elif [[ -L "$1" && ! -d "$1" ]]; then
   cp -a "$1" "$2"
 elif [[ -d "$1" ]]; then

--- a/foreign_cc/private/framework/toolchains/linux_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/linux_commands.bzl
@@ -65,7 +65,17 @@ def replace_in_files(dir, from_, to_):
     return FunctionAndCallInfo(
         text = """\
 if [ -d "$1" ]; then
-  find -L $1 -type f   \\( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.cmake" \\)   -exec sed -i 's@'"$2"'@'"$3"'@g' {} ';'
+  SAVEIFS=$IFS
+  IFS=$'\n'
+  # Find all real files. Symlinks are assumed to be relative to something within the directory we're seaching and thus ignored
+  local files=$(find -P $1 \\( -type f -and \\( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.mk" -or -name "*.cmake" \\) \\))
+  IFS=$SAVEIFS
+  for file in ${files[@]}; do
+    sed -i 's@'"$2"'@'"$3"'@g' "${file}"
+    if [[ "$?" -ne "0" ]]; then
+      exit 1
+    fi
+  done
 fi
 """,
     )

--- a/foreign_cc/private/framework/toolchains/macos_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/macos_commands.bzl
@@ -136,7 +136,14 @@ def symlink_to_dir(source, target):
 local target="$2"
 mkdir -p "$target"
 if [[ -f "$1" ]]; then
-  ln -s -f "$1" "$target"
+  # In order to be able to use `replace_in_files`, we ensure that we create copies of specfieid
+  # files so updating them is possible.
+  if [[ "$1" == *.pc || "$1" == *.la || "$1" == *-config || "$1" == *.mk || "$1" == *.cmake ]]; then
+    dest="$target/$(basename $1)"
+    cp "$1" "$dest" && chmod +w "$dest" && touch -r "$1" "$dest"
+  else
+    ln -s -f "$1" "$target"
+  fi
 elif [[ -L "$1" && ! -d "$1" ]]; then
   cp -a "$1" "$2"
 elif [[ -d "$1" ]]; then

--- a/foreign_cc/private/framework/toolchains/macos_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/macos_commands.bzl
@@ -65,7 +65,18 @@ def replace_in_files(dir, from_, to_):
     return FunctionAndCallInfo(
         text = """\
 if [ -d "$1" ]; then
-    find -L -f $1 \\( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.cmake" \\)     -exec sed -i '' -e 's@'"$2"'@'"$3"'@g' {} ';'
+  SAVEIFS=$IFS
+  IFS=$'\n'
+  # Find all real files. Symlinks are assumed to be relative to something within the directory we're seaching and thus ignored
+  local files=$(find -P -f $1 \\( -type f -and \\( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.mk" -or -name "*.cmake" \\) \\))
+  IFS=$SAVEIFS
+  for file in ${files[@]}; do
+    sed -i '' -e 's@'"$2"'@'"$3"'@g' "${file}"
+    if [[ "$?" -ne "0" ]]; then
+      exit 1
+    fi
+  done
+  
 fi
 """,
     )

--- a/foreign_cc/private/framework/toolchains/windows_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/windows_commands.bzl
@@ -113,7 +113,14 @@ def symlink_to_dir(source, target):
 local target="$2"
 mkdir -p "$target"
 if [[ -f "$1" ]]; then
-  ln -s -f -t "$target" "$1"
+  # In order to be able to use `replace_in_files`, we ensure that we create copies of specfieid
+  # files so updating them is possible.
+  if [[ "$1" == *.pc || "$1" == *.la || "$1" == *-config || "$1" == *.mk || "$1" == *.cmake ]]; then
+    dest="$target/$(basename $1)"
+    cp "$1" "$dest" && chmod +w "$dest" && touch -r "$1" "$dest"
+  else
+    ln -s -f -t "$target" "$1"
+  fi
 elif [[ -L "$1" ]]; then
   local actual=$(readlink "$1")
   ##symlink_to_dir## "$actual" "$target"

--- a/test/expected/inner_fun_text.txt
+++ b/test/expected/inner_fun_text.txt
@@ -21,7 +21,14 @@ function symlink_to_dir() {
 local target="$2"
 mkdir -p "$target"
 if [[ -f "$1" ]]; then
+# In order to be able to use `replace_in_files`, we ensure that we create copies of specfieid
+# files so updating them is possible.
+if [[ "$1" == *.pc || "$1" == *.la || "$1" == *-config || "$1" == *.mk || "$1" == *.cmake ]]; then
+dest="$target/$(basename $1)"
+cp "$1" "$dest" && chmod +w "$dest" && touch -r "$1" "$dest"
+else
 ln -s -f -t "$target" "$1"
+fi
 elif [[ -L "$1" && ! -d "$1" ]]; then
 cp -a "$1" "$2"
 elif [[ -d "$1" ]]; then

--- a/test/expected/inner_fun_text_macos.txt
+++ b/test/expected/inner_fun_text_macos.txt
@@ -21,7 +21,14 @@ function symlink_to_dir() {
 local target="$2"
 mkdir -p "$target"
 if [[ -f "$1" ]]; then
+# In order to be able to use `replace_in_files`, we ensure that we create copies of specfieid
+# files so updating them is possible.
+if [[ "$1" == *.pc || "$1" == *.la || "$1" == *-config || "$1" == *.mk || "$1" == *.cmake ]]; then
+dest="$target/$(basename $1)"
+cp "$1" "$dest" && chmod +w "$dest" && touch -r "$1" "$dest"
+else
 ln -s -f "$1" "$target"
+fi
 elif [[ -L "$1" && ! -d "$1" ]]; then
 cp -a "$1" "$2"
 elif [[ -d "$1" ]]; then


### PR DESCRIPTION
In investigating build failures brought up in https://github.com/bazelbuild/rules_foreign_cc/pull/622 I uncovered some messages in the build logs:
```
sed: /private/var/tmp/_bazel_user/2d7cc63c99a1f0f43d4f45bc36f2be85/sandbox/darwin-sandbox/423/execroot/rules_foreign_cc_examples_third_party/bazel-out/host/bin/external/subversion/subversion.ext_build_deps/apr/lib/libapr-1.la: in-place editing only works for regular files
```

I found out that `sed` is unable to update paths that are symlinks. It requires a path to a real file.
We currently only have one use of `sed` and it's to update paths files which contain absolute paths to the current sandbox.
https://github.com/bazelbuild/rules_foreign_cc/blob/b8b88cd2d16035aa1639434eb808f4d67a34d5ae/foreign_cc/private/framework/toolchains/linux_commands.bzl#L68

This is not something that would likely be caught in CI because it's uncommon that we update an individual example. Updating an individual test which also has a dependency on another test would have created a situation where cached assets from a dependency were used to build the updated example. This build would fail as configuration files like the ones specified in the `find` command above would never have had these paths replaced and we'd attempt to access a file in an old sandbox. Thus leading to a failure as they're typically cleaned up after execution.

The fix here ensures that these configuration files are always copied into the build directory in a writable state and that `sed` is only ever given real files. `sed` errors will also be caught and cause build failures.