### PR TITLE
Restrict use of `use_default_shell_env` to windows.

### DIFF
--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -277,7 +277,7 @@ def _env_prelude(ctx, lib_name, data_dependencies, target_root):
     # Add all user defined variables
     attr_env = dict()
     for key, value in getattr(ctx.attr, "env", {}).items():
-        # Ensure the values of the environemnt variables have absolute paths
+        # Ensure the values of the environment variables have absolute paths
         attr_env.update({key: ctx.expand_location(value.replace("$(execpath ", "$EXT_BUILD_ROOT/$(execpath "), data_dependencies)})
     env_snippet.extend(["export {}={}".format(key, val) for key, val in attr_env.items()])
 

--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -261,8 +261,7 @@ def _env_prelude(ctx, lib_name, data_dependencies, target_root):
         "export EXT_BUILD_DEPS=$$INSTALLDIR$$.ext_build_deps",
     ]
 
-    # Start with the default shell env to capture `--action_env` args
-    env = dict(ctx.configuration.default_shell_env)
+    env = dict()
 
     # Add all environment variables from the cc_toolchain
     cc_env = _correct_path_variable(get_env_vars(ctx))
@@ -273,6 +272,9 @@ def _env_prelude(ctx, lib_name, data_dependencies, target_root):
     # environment variables to tools for the current cc_toolchain in use.
     if "win" in os_name(ctx):
         env_snippet.extend(["export {}=\"{}\"".format(key, cc_env[key]) for key in cc_env])
+
+    # Capture `action_env` and allow it to take precedence over cc env
+    env.update(ctx.configuration.default_shell_env)
 
     # Add all user defined variables
     attr_env = dict()


### PR DESCRIPTION
The primary intent of this change is to have a more structured way of controlling the environment. The way it's currently implemented adds support for [--action_env](https://docs.bazel.build/versions/master/command-line-reference.html#flag--action_env) to MacOS platforms and adds a centralized place in code to manage environment variables.