### PR TITLE
Revert "Include `libtool` and `.nice` files when replacing sandbox paths (#644)"

### DIFF
--- a/foreign_cc/private/framework/toolchains/linux_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/linux_commands.bzl
@@ -68,7 +68,7 @@ if [ -d "$1" ]; then
   SAVEIFS=$IFS
   IFS=$'\n'
   # Find all real files. Symlinks are assumed to be relative to something within the directory we're seaching and thus ignored
-  local files=$(find -P $1 \\( -type f -and \\( -name "libtool" -or -name "*.pc" -or -name "*.lai" -or -name "*.la" -or -name "*-config" -or -name "*.nice" -or -name "*.mk" -or -name "*.cmake" \\) \\))
+  local files=$(find -P $1 \\( -type f -and \\( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.mk" -or -name "*.cmake" \\) \\))
   IFS=$SAVEIFS
   for file in ${files[@]}; do
     sed -i 's@'"$2"'@'"$3"'@g' "${file}"
@@ -114,9 +114,8 @@ mkdir -p "$target"
 if [[ -f "$1" ]]; then
   # In order to be able to use `replace_in_files`, we ensure that we create copies of specfieid
   # files so updating them is possible.
-  local input_basename="$(basename "$1")"
-  if [[ "$input_basename" == "libtool" || "$1" == *.pc || "$1" == *.la || "$1" == *.lai || "$1" == *-config || "$1" == *.nice || "$1" == *.mk || "$1" == *.cmake ]]; then
-    local dest="$target/$input_basename"
+  if [[ "$1" == *.pc || "$1" == *.la || "$1" == *-config || "$1" == *.mk || "$1" == *.cmake ]]; then
+    dest="$target/$(basename $1)"
     cp "$1" "$dest" && chmod +w "$dest" && touch -r "$1" "$dest"
   else
     ln -s -f -t "$target" "$1"

--- a/foreign_cc/private/framework/toolchains/macos_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/macos_commands.bzl
@@ -68,7 +68,7 @@ if [ -d "$1" ]; then
   SAVEIFS=$IFS
   IFS=$'\n'
   # Find all real files. Symlinks are assumed to be relative to something within the directory we're seaching and thus ignored
-  local files=$(find -P -f $1 \\( -type f -and \\( -name "libtool" -or -name "*.pc" -or -name "*.lai" -or -name "*.la" -or -name "*-config" -or -name "*.nice" -or -name "*.mk" -or -name "*.cmake" \\) \\))
+  local files=$(find -P -f $1 \\( -type f -and \\( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.mk" -or -name "*.cmake" \\) \\))
   IFS=$SAVEIFS
   for file in ${files[@]}; do
     sed -i '' -e 's@'"$2"'@'"$3"'@g' "${file}"
@@ -138,9 +138,8 @@ mkdir -p "$target"
 if [[ -f "$1" ]]; then
   # In order to be able to use `replace_in_files`, we ensure that we create copies of specfieid
   # files so updating them is possible.
-  local input_basename="$(basename "$1")"
-  if [[ "$input_basename" == "libtool" || "$1" == *.pc || "$1" == *.la || "$1" == *.lai || "$1" == *-config || "$1" == *.nice || "$1" == *.mk || "$1" == *.cmake ]]; then
-    local dest="$target/$input_basename"
+  if [[ "$1" == *.pc || "$1" == *.la || "$1" == *-config || "$1" == *.mk || "$1" == *.cmake ]]; then
+    dest="$target/$(basename $1)"
     cp "$1" "$dest" && chmod +w "$dest" && touch -r "$1" "$dest"
   else
     ln -s -f "$1" "$target"

--- a/foreign_cc/private/framework/toolchains/windows_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/windows_commands.bzl
@@ -115,9 +115,8 @@ mkdir -p "$target"
 if [[ -f "$1" ]]; then
   # In order to be able to use `replace_in_files`, we ensure that we create copies of specfieid
   # files so updating them is possible.
-  local input_basename="$(basename "$1")"
-  if [[ "$input_basename" == "libtool" || "$1" == *.pc || "$1" == *.la || "$1" == *.lai || "$1" == *-config || "$1" == *.nice || "$1" == *.mk || "$1" == *.cmake ]]; then
-    local dest="$target/$input_basename"
+  if [[ "$1" == *.pc || "$1" == *.la || "$1" == *-config || "$1" == *.mk || "$1" == *.cmake ]]; then
+    dest="$target/$(basename $1)"
     cp "$1" "$dest" && chmod +w "$dest" && touch -r "$1" "$dest"
   else
     ln -s -f -t "$target" "$1"

--- a/test/expected/inner_fun_text.txt
+++ b/test/expected/inner_fun_text.txt
@@ -23,9 +23,8 @@ mkdir -p "$target"
 if [[ -f "$1" ]]; then
 # In order to be able to use `replace_in_files`, we ensure that we create copies of specfieid
 # files so updating them is possible.
-local input_basename="$(basename "$1")"
-if [[ "$input_basename" == "libtool" || "$1" == *.pc || "$1" == *.la || "$1" == *.lai || "$1" == *-config || "$1" == *.nice || "$1" == *.mk || "$1" == *.cmake ]]; then
-local dest="$target/$input_basename"
+if [[ "$1" == *.pc || "$1" == *.la || "$1" == *-config || "$1" == *.mk || "$1" == *.cmake ]]; then
+dest="$target/$(basename $1)"
 cp "$1" "$dest" && chmod +w "$dest" && touch -r "$1" "$dest"
 else
 ln -s -f -t "$target" "$1"

--- a/test/expected/inner_fun_text_macos.txt
+++ b/test/expected/inner_fun_text_macos.txt
@@ -23,9 +23,8 @@ mkdir -p "$target"
 if [[ -f "$1" ]]; then
 # In order to be able to use `replace_in_files`, we ensure that we create copies of specfieid
 # files so updating them is possible.
-local input_basename="$(basename "$1")"
-if [[ "$input_basename" == "libtool" || "$1" == *.pc || "$1" == *.la || "$1" == *.lai || "$1" == *-config || "$1" == *.nice || "$1" == *.mk || "$1" == *.cmake ]]; then
-local dest="$target/$input_basename"
+if [[ "$1" == *.pc || "$1" == *.la || "$1" == *-config || "$1" == *.mk || "$1" == *.cmake ]]; then
+dest="$target/$(basename $1)"
 cp "$1" "$dest" && chmod +w "$dest" && touch -r "$1" "$dest"
 else
 ln -s -f "$1" "$target"


### PR DESCRIPTION
This reverts commit 08598910609153bb82c7e3a91dbf7ae3d17a0575. (#644)