### PR TITLE
Added support for replacing sandbox paths in build artifacts

### DIFF
--- a/examples/third_party/apr/BUILD.apr.bazel
+++ b/examples/third_party/apr/BUILD.apr.bazel
@@ -1,0 +1,21 @@
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
+
+filegroup(
+    name = "all_srcs",
+    srcs = glob(["**"]),
+)
+
+configure_make(
+    name = "apr",
+    configure_env_vars = select({
+        "@platforms//os:macos": {"AR": ""},
+        "//conditions:default": {},
+    }),
+    configure_in_place = True,
+    configure_options = [
+        "--disable-shared",
+    ],
+    lib_source = ":all_srcs",
+    out_static_libs = ["libapr-1.a"],
+    visibility = ["//visibility:public"],
+)

--- a/examples/third_party/apr/BUILD.bazel
+++ b/examples/third_party/apr/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+
+exports_files(
+    [
+        "BUILD.apr.bazel",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+build_test(
+    name = "apr_build_test",
+    targets = [
+        "@apr//:apr",
+    ],
+    visibility = ["//:__pkg__"],
+)

--- a/examples/third_party/apr/apr_repositories.bzl
+++ b/examples/third_party/apr/apr_repositories.bzl
@@ -1,0 +1,22 @@
+"""A module defining the third party dependency apr"""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+def apr_repositories():
+    maybe(
+        http_archive,
+        name = "apr",
+        build_file = Label("//apr:BUILD.apr.bazel"),
+        patches = [
+            # https://bz.apache.org/bugzilla/show_bug.cgi?id=50146
+            Label("//apr:macos_iovec.patch"),
+            #https://bz.apache.org/bugzilla/show_bug.cgi?id=64753
+            Label("//apr:macos_pid_t.patch"),
+        ],
+        sha256 = "48e9dbf45ae3fdc7b491259ffb6ccf7d63049ffacbc1c0977cced095e4c2d5a2",
+        strip_prefix = "apr-1.7.0",
+        urls = [
+            "https://www-eu.apache.org/dist/apr/apr-1.7.0.tar.gz",
+        ],
+    )

--- a/examples/third_party/apr/macos_iovec.patch
+++ b/examples/third_party/apr/macos_iovec.patch
@@ -1,0 +1,97 @@
+diff -ruN configure configure
+--- configure	2019-04-01 19:56:23.000000000 +0200
++++ configure	2019-04-01 19:56:23.000000000 +0200
+@@ -24475,6 +24475,7 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ #include <stdio.h>
++$ac_includes_default
+ #include <sys/types.h>
+ #ifdef WIN32
+ #define binmode "b"
+@@ -24485,7 +24486,7 @@
+ {
+   FILE *f=fopen("conftestval", "w" binmode);
+   if (!f) exit(1);
+-  fprintf(f, "%d\n", sizeof(pid_t));
++  fprintf(f, "%zd\n", sizeof(pid_t));
+   exit(0);
+ }
+ _ACEOF
+@@ -24800,6 +24801,7 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ #include <stdio.h>
++$ac_includes_default
+ #include <sys/types.h>
+ #ifdef WIN32
+ #define binmode "b"
+@@ -24810,7 +24812,7 @@
+ {
+   FILE *f=fopen("conftestval", "w" binmode);
+   if (!f) exit(1);
+-  fprintf(f, "%d\n", sizeof(ssize_t));
++  fprintf(f, "%zd\n", sizeof(ssize_t));
+   exit(0);
+ }
+ _ACEOF
+@@ -24863,6 +24865,7 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ #include <stdio.h>
++$ac_includes_default
+ #include <stddef.h>
+ #ifdef WIN32
+ #define binmode "b"
+@@ -24873,7 +24876,7 @@
+ {
+   FILE *f=fopen("conftestval", "w" binmode);
+   if (!f) exit(1);
+-  fprintf(f, "%d\n", sizeof(size_t));
++  fprintf(f, "%zd\n", sizeof(size_t));
+   exit(0);
+ }
+ _ACEOF
+@@ -24927,6 +24930,7 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ #include <stdio.h>
++$ac_includes_default
+ #include <sys/types.h>
+ #ifdef WIN32
+ #define binmode "b"
+@@ -24937,7 +24941,7 @@
+ {
+   FILE *f=fopen("conftestval", "w" binmode);
+   if (!f) exit(1);
+-  fprintf(f, "%d\n", sizeof(off_t));
++  fprintf(f, "%zd\n", sizeof(off_t));
+   exit(0);
+ }
+ _ACEOF
+@@ -25308,7 +25312,7 @@
+ {
+   FILE *f=fopen("conftestval", "w" binmode);
+   if (!f) exit(1);
+-  fprintf(f, "%d\n", sizeof(ino_t));
++  fprintf(f, "%zd\n", sizeof(ino_t));
+   exit(0);
+ }
+ _ACEOF
+@@ -25584,6 +25588,7 @@
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ #include <stdio.h>
++$ac_includes_default
+ #include <sys/types.h>
+ #include <sys/uio.h>
+ #ifdef WIN32
+@@ -25595,7 +25600,7 @@
+ {
+   FILE *f=fopen("conftestval", "w" binmode);
+   if (!f) exit(1);
+-  fprintf(f, "%d\n", sizeof(struct iovec));
++  fprintf(f, "%zd\n", sizeof(struct iovec));
+   exit(0);
+ }
+ _ACEOF

--- a/examples/third_party/apr/macos_pid_t.patch
+++ b/examples/third_party/apr/macos_pid_t.patch
@@ -1,0 +1,12 @@
+diff -ruN configure configure
+--- configure	2019-04-01 19:56:23.000000000 +0200
++++ configure	2019-04-01 19:56:23.000000000 +0200
+@@ -24517,7 +24518,7 @@
+ elif test "$ac_cv_sizeof_pid_t" = "$ac_cv_sizeof_long_long"; then
+     pid_t_fmt='#define APR_PID_T_FMT APR_INT64_T_FMT'
+ else
+-    pid_t_fmt='#error Can not determine the proper size for pid_t'
++    pid_t_fmt='#define APR_PID_T_FMT "d"'
+ fi
+ 
+ # Basically, we have tried to figure out the correct format strings

--- a/examples/third_party/apr_util/BUILD.apr_util.bazel
+++ b/examples/third_party/apr_util/BUILD.apr_util.bazel
@@ -1,0 +1,22 @@
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
+
+filegroup(
+    name = "all_srcs",
+    srcs = glob(["**"]),
+)
+
+configure_make(
+    name = "apr_util",
+    configure_env_vars = select({
+        "@platforms//os:macos": {"AR": ""},
+        "//conditions:default": {},
+    }),
+    configure_in_place = True,
+    configure_options = [
+        "--with-apr=$EXT_BUILD_DEPS/apr",
+    ],
+    lib_source = ":all_srcs",
+    out_static_libs = ["libaprutil-1.a"],
+    visibility = ["//visibility:public"],
+    deps = ["@apr"],
+)

--- a/examples/third_party/apr_util/BUILD.bazel
+++ b/examples/third_party/apr_util/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+
+exports_files(
+    [
+        "BUILD.apr_util.bazel",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+build_test(
+    name = "apr_util_build_test",
+    targets = [
+        "@apr_util//:apr_util",
+    ],
+    visibility = ["//:__pkg__"],
+)

--- a/examples/third_party/apr_util/apr_util_repositories.bzl
+++ b/examples/third_party/apr_util/apr_util_repositories.bzl
@@ -1,0 +1,17 @@
+"""A module defining the third party dependency apr"""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+def apr_util_repositories():
+    maybe(
+        http_archive,
+        name = "apr_util",
+        build_file = Label("//apr_util:BUILD.apr_util.bazel"),
+        sha256 = "b65e40713da57d004123b6319828be7f1273fbc6490e145874ee1177e112c459",
+        strip_prefix = "apr-util-1.6.1",
+        urls = [
+            "https://mirror.bazel.build/www-us.apache.org/dist//apr/apr-util-1.6.1.tar.gz",
+            "https://www-us.apache.org/dist//apr/apr-util-1.6.1.tar.gz",
+        ],
+    )

--- a/examples/third_party/repositories.bzl
+++ b/examples/third_party/repositories.bzl
@@ -2,6 +2,8 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("//apr:apr_repositories.bzl", "apr_repositories")
+load("//apr_util:apr_util_repositories.bzl", "apr_util_repositories")
 load("//bison:bison_repositories.bzl", "bison_repositories")
 load("//cares:cares_repositories.bzl", "cares_repositories")
 load("//curl:curl_repositories.bzl", "curl_repositories")
@@ -14,11 +16,15 @@ load("//libpng:libpng_repositories.bzl", "libpng_repositories")
 load("//libssh2:libssh2_repositories.bzl", "libssh2_repositories")
 load("//openssl:openssl_repositories.bzl", "openssl_repositories")
 load("//pcre:pcre_repositories.bzl", "pcre_repositories")
+load("//sqlite:sqlite_repositories.bzl", "sqlite_repositories")
+load("//subversion:subversion_repositories.bzl", "subversion_repositories")
 load("//zlib:zlib_repositories.bzl", "zlib_repositories")
 
+# buildifier: disable=unnamed-macro
 def repositories():
     """Load all repositories needed for the targets of rules_foreign_cc_examples_third_party"""
-
+    apr_repositories()
+    apr_util_repositories()
     bison_repositories()
     cares_repositories()
     curl_repositories()
@@ -31,6 +37,8 @@ def repositories():
     libssh2_repositories()
     openssl_repositories()
     pcre_repositories()
+    sqlite_repositories()
+    subversion_repositories()
     zlib_repositories()
 
     maybe(

--- a/examples/third_party/sqlite/BUILD.bazel
+++ b/examples/third_party/sqlite/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+
+exports_files(
+    [
+        "BUILD.sqlite.bazel",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+build_test(
+    name = "sqlite_build_test",
+    targets = [
+        "@sqlite//:sqlite",
+    ],
+    visibility = ["//:__pkg__"],
+)

--- a/examples/third_party/sqlite/BUILD.sqlite.bazel
+++ b/examples/third_party/sqlite/BUILD.sqlite.bazel
@@ -1,0 +1,17 @@
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
+
+filegroup(
+    name = "all_srcs",
+    srcs = glob(["**"]),
+)
+
+configure_make(
+    name = "sqlite",
+    configure_env_vars = select({
+        "@platforms//os:macos": {"AR": ""},
+        "//conditions:default": {},
+    }),
+    lib_source = ":all_srcs",
+    out_static_libs = ["libsqlite3.a"],
+    visibility = ["//visibility:public"],
+)

--- a/examples/third_party/sqlite/sqlite_repositories.bzl
+++ b/examples/third_party/sqlite/sqlite_repositories.bzl
@@ -1,0 +1,14 @@
+"""A module defining the third party dependency sqlite"""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+def sqlite_repositories():
+    maybe(
+        http_archive,
+        name = "sqlite",
+        build_file = Label("//sqlite:BUILD.sqlite.bazel"),
+        sha256 = "f52b72a5c319c3e516ed7a92e123139a6e87af08a2dc43d7757724f6132e6db0",
+        strip_prefix = "sqlite-autoconf-3350500",
+        urls = ["https://www.sqlite.org/2021/sqlite-autoconf-3350500.tar.gz"],
+    )

--- a/examples/third_party/subversion/BUILD.bazel
+++ b/examples/third_party/subversion/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+
+exports_files(
+    [
+        "BUILD.subversion.bazel",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+build_test(
+    name = "subversion_build_test",
+    targets = [
+        "@subversion//:subversion",
+    ],
+    visibility = ["//:__pkg__"],
+)

--- a/examples/third_party/subversion/BUILD.subversion.bazel
+++ b/examples/third_party/subversion/BUILD.subversion.bazel
@@ -1,0 +1,48 @@
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
+
+filegroup(
+    name = "all_srcs",
+    srcs = glob(["**"]),
+)
+
+CONFIGURE_ENV_VARS = {
+    "CFLAGS": "-Dredacted='\\\"redacted\\\"'",
+    "CXXFLAGS": "-Dredacted='\\\"redacted\\\"'",
+}
+
+configure_make(
+    name = "subversion",
+    configure_env_vars = select({
+        "@platforms//os:macos": dicts.add(
+            {"AR": ""},
+            CONFIGURE_ENV_VARS,
+        ),
+        "//conditions:default": CONFIGURE_ENV_VARS,
+    }),
+    configure_options = [
+        "--enable-all-static",
+        "--without-boost",
+        "--with-apr=$EXT_BUILD_DEPS/apr",
+        "--with-apr-util=$EXT_BUILD_DEPS/apr_util",
+        "--with-zlib=$EXT_BUILD_DEPS/zlib",
+        "--with-lz4=internal",
+        "--with-utf8proc=internal",
+    ],
+    lib_source = ":all_srcs",
+    out_binaries = [
+        "svn",
+        "svnversion",
+    ],
+    targets = [
+        "bin",
+        "install",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@apr",
+        "@apr_util",
+        "@sqlite",
+        "@zlib",
+    ],
+)

--- a/examples/third_party/subversion/subversion_repositories.bzl
+++ b/examples/third_party/subversion/subversion_repositories.bzl
@@ -1,0 +1,16 @@
+"""A module defining the third party dependency subversion"""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+def subversion_repositories():
+    maybe(
+        http_archive,
+        name = "subversion",
+        build_file = Label("//subversion:BUILD.subversion.bazel"),
+        sha256 = "dee2796abaa1f5351e6cc2a60b1917beb8238af548b20d3e1ec22760ab2f0cad",
+        strip_prefix = "subversion-1.14.1",
+        urls = [
+            "https://downloads.apache.org/subversion/subversion-1.14.1.tar.gz",
+        ],
+    )

--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -405,6 +405,7 @@ def cc_external_rule_impl(ctx, attrs):
         # for the results which are in $INSTALLDIR (with placeholder)
         "##replace_absolute_paths## $$INSTALLDIR$$ $$BUILD_TMPDIR$$",
         "##replace_absolute_paths## $$INSTALLDIR$$ $$EXT_BUILD_DEPS$$",
+        "##replace_sandbox_paths## $$INSTALLDIR$$ $$EXT_BUILD_ROOT$$",
         installdir_copy.script,
         "cd $$EXT_BUILD_ROOT$$",
     ] + [

--- a/foreign_cc/private/framework/toolchains/commands.bzl
+++ b/foreign_cc/private/framework/toolchains/commands.bzl
@@ -90,6 +90,13 @@ PLATFORM_COMMANDS = {
         ],
         doc = "Defines a function with 'text' as the function body.",
     ),
+    "define_sandbox_paths": _command_info(
+        arguments = [
+            _argument_info(name = "dir_", data_type = type(""), doc = "Directory where to replace"),
+            _argument_info(name = "abs_path", data_type = type(""), doc = "Absolute path value"),
+        ],
+        doc = "Replaces sandbox path placeholder inside 'dir_' with a provided value 'abs_path'",
+    ),
     "disable_tracing": _command_info(
         arguments = [],
         doc = "Disable script tracing. eg: `set +x`",
@@ -176,6 +183,13 @@ PLATFORM_COMMANDS = {
             _argument_info(name = "to_", data_type = type(""), doc = "Replace target"),
         ],
         doc = "Replaces all occurrences of 'from_' to 'to_' recursively in the directory 'dir'.",
+    ),
+    "replace_sandbox_paths": _command_info(
+        arguments = [
+            _argument_info(name = "dir_", data_type = type(""), doc = "Directory where to replace"),
+            _argument_info(name = "abs_path", data_type = type(""), doc = "Absolute path value"),
+        ],
+        doc = "Replaces sandbox path 'abs_path' inside 'dir_' with a placeholder value",
     ),
     "replace_symlink": _command_info(
         arguments = [

--- a/foreign_cc/private/framework/toolchains/linux_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/linux_commands.bzl
@@ -2,8 +2,6 @@
 
 load(":commands.bzl", "FunctionAndCallInfo")
 
-_REPLACE_VALUE = "\\${EXT_BUILD_DEPS}"
-
 def shebang():
     return "#!/usr/bin/env bash"
 
@@ -71,10 +69,14 @@ if [ -d "$1" ]; then
   local files=$(find -P $1 \\( -type f -and \\( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.mk" -or -name "*.cmake" \\) \\))
   IFS=$SAVEIFS
   for file in ${files[@]}; do
+    local backup=$(mktemp)
+    touch -r "${file}" "${backup}"
     sed -i 's@'"$2"'@'"$3"'@g' "${file}"
     if [[ "$?" -ne "0" ]]; then
       exit 1
     fi
+    touch -r "${backup}" "${file}"
+    rm "${backup}"
   done
 fi
 """,
@@ -206,14 +208,28 @@ fi""".format(dir_ = dir_)
 def define_absolute_paths(dir_, abs_path):
     return "##replace_in_files## {dir_} {REPLACE_VALUE} {abs_path}".format(
         dir_ = dir_,
-        REPLACE_VALUE = _REPLACE_VALUE,
+        REPLACE_VALUE = "\\${EXT_BUILD_DEPS}",
         abs_path = abs_path,
     )
 
 def replace_absolute_paths(dir_, abs_path):
     return "##replace_in_files## {dir_} {abs_path} {REPLACE_VALUE}".format(
         dir_ = dir_,
-        REPLACE_VALUE = _REPLACE_VALUE,
+        REPLACE_VALUE = "\\${EXT_BUILD_DEPS}",
+        abs_path = abs_path,
+    )
+
+def define_sandbox_paths(dir_, abs_path):
+    return "##replace_in_files## {dir_} {REPLACE_VALUE} {abs_path}".format(
+        dir_ = dir_,
+        REPLACE_VALUE = "\\${EXT_BUILD_ROOT}",
+        abs_path = abs_path,
+    )
+
+def replace_sandbox_paths(dir_, abs_path):
+    return "##replace_in_files## {dir_} {abs_path} {REPLACE_VALUE}".format(
+        dir_ = dir_,
+        REPLACE_VALUE = "\\${EXT_BUILD_ROOT}",
         abs_path = abs_path,
     )
 

--- a/foreign_cc/private/framework/toolchains/macos_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/macos_commands.bzl
@@ -2,8 +2,6 @@
 
 load(":commands.bzl", "FunctionAndCallInfo")
 
-_REPLACE_VALUE = "\\${EXT_BUILD_DEPS}"
-
 def shebang():
     return "#!/usr/bin/env bash"
 
@@ -71,12 +69,15 @@ if [ -d "$1" ]; then
   local files=$(find -P -f $1 \\( -type f -and \\( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.mk" -or -name "*.cmake" \\) \\))
   IFS=$SAVEIFS
   for file in ${files[@]}; do
+    local backup=$(mktemp)
+    touch -r "${file}" "${backup}"
     sed -i '' -e 's@'"$2"'@'"$3"'@g' "${file}"
     if [[ "$?" -ne "0" ]]; then
       exit 1
     fi
+    touch -r "${backup}" "${file}"
+    rm "${backup}"
   done
-  
 fi
 """,
     )
@@ -230,14 +231,28 @@ fi""".format(dir_ = dir_)
 def define_absolute_paths(dir_, abs_path):
     return "##replace_in_files## {dir_} {REPLACE_VALUE} {abs_path}".format(
         dir_ = dir_,
-        REPLACE_VALUE = _REPLACE_VALUE,
+        REPLACE_VALUE = "\\${EXT_BUILD_DEPS}",
         abs_path = abs_path,
     )
 
 def replace_absolute_paths(dir_, abs_path):
     return "##replace_in_files## {dir_} {abs_path} {REPLACE_VALUE}".format(
         dir_ = dir_,
-        REPLACE_VALUE = _REPLACE_VALUE,
+        REPLACE_VALUE = "\\${EXT_BUILD_DEPS}",
+        abs_path = abs_path,
+    )
+
+def define_sandbox_paths(dir_, abs_path):
+    return "##replace_in_files## {dir_} {REPLACE_VALUE} {abs_path}".format(
+        dir_ = dir_,
+        REPLACE_VALUE = "\\${EXT_BUILD_ROOT}",
+        abs_path = abs_path,
+    )
+
+def replace_sandbox_paths(dir_, abs_path):
+    return "##replace_in_files## {dir_} {abs_path} {REPLACE_VALUE}".format(
+        dir_ = dir_,
+        REPLACE_VALUE = "\\${EXT_BUILD_ROOT}",
         abs_path = abs_path,
     )
 

--- a/foreign_cc/private/framework/toolchains/windows_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/windows_commands.bzl
@@ -2,8 +2,6 @@
 
 load(":commands.bzl", "FunctionAndCallInfo")
 
-_REPLACE_VALUE = "\\${EXT_BUILD_DEPS}"
-
 def shebang():
     return "#!/usr/bin/env bash"
 
@@ -72,10 +70,14 @@ if [ -d "$1" ]; then
   local files=$($REAL_FIND -P $1 -type f  \\( -type f -and \\( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.mk" -or -name "*.cmake" \\) \\))
   IFS=$SAVEIFS
   for file in ${files[@]}; do
+    local backup=$(mktemp)
+    touch -r "${file}" "${backup}"
     sed -i 's@'"$2"'@'"$3"'@g' "${file}"
     if [[ "$?" -ne "0" ]]; then
       exit 1
     fi
+    touch -r "${backup}" "${file}"
+    rm "${backup}"
   done
 fi
 """,
@@ -217,14 +219,28 @@ fi""".format(dir_ = dir_)
 def define_absolute_paths(dir_, abs_path):
     return "##replace_in_files## {dir_} {REPLACE_VALUE} {abs_path}".format(
         dir_ = dir_,
-        REPLACE_VALUE = _REPLACE_VALUE,
+        REPLACE_VALUE = "\\${EXT_BUILD_DEPS}",
         abs_path = abs_path,
     )
 
 def replace_absolute_paths(dir_, abs_path):
     return "##replace_in_files## {dir_} {abs_path} {REPLACE_VALUE}".format(
         dir_ = dir_,
-        REPLACE_VALUE = _REPLACE_VALUE,
+        REPLACE_VALUE = "\\${EXT_BUILD_DEPS}",
+        abs_path = abs_path,
+    )
+
+def define_sandbox_paths(dir_, abs_path):
+    return "##replace_in_files## {dir_} {REPLACE_VALUE} {abs_path}".format(
+        dir_ = dir_,
+        REPLACE_VALUE = "\\${EXT_BUILD_ROOT}",
+        abs_path = abs_path,
+    )
+
+def replace_sandbox_paths(dir_, abs_path):
+    return "##replace_in_files## {dir_} {abs_path} {REPLACE_VALUE}".format(
+        dir_ = dir_,
+        REPLACE_VALUE = "\\${EXT_BUILD_ROOT}",
         abs_path = abs_path,
     )
 

--- a/foreign_cc/private/make_script.bzl
+++ b/foreign_cc/private/make_script.bzl
@@ -40,6 +40,9 @@ def pkgconfig_script(ext_build_dirs):
             script.append("##increment_pkg_config_path## $$EXT_BUILD_DEPS$$/" + ext_dir.basename)
         script.append("echo \"PKG_CONFIG_PATH=$${PKG_CONFIG_PATH:-}$$\"")
 
-    script.append("##define_absolute_paths## $$EXT_BUILD_DEPS$$ $$EXT_BUILD_DEPS$$")
+    script.extend([
+        "##define_absolute_paths## $$EXT_BUILD_DEPS$$ $$EXT_BUILD_DEPS$$",
+        "##define_sandbox_paths## $$EXT_BUILD_DEPS$$ $$EXT_BUILD_ROOT$$",
+    ])
 
     return script


### PR DESCRIPTION
This change expands on the `define_absolute_paths` and `replace_absolute_paths` functionality which replace absolute paths to files within `EXT_BUILD_DEPS` with that environment variable to be expanded at a later time and introduces `define_sandbox_paths` and `replace_sandbox_paths` which more generally replaces absolute paths to the exec root with `${EXT_BUILD_ROOT}`. In both cases, these variables are update at the beginning of each build and are otherwise invisible to foreign build systems.