### PR TITLE
Add instructions for pre-commit buildifier hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: local
+    hooks:
+      - id: bazel-format
+        name: bazel format
+        description: Auto-formats starlark code
+        entry: buildifier --lint=off --mode=fix
+        files: '^(.*/)?(BUILD\.bazel|BUILD|WORKSPACE)$|\.BUILD$|\.bzl$'
+        language: system
+
+      - id: bazel-lint
+        name: bazel lint
+        description: Checks for code style violations in starlark code
+        # Keep the warnings argument in sync with .bazelci/presubmit.yml
+        entry: buildifier --lint=warn --mode=fix -v --warnings=all
+        files: '^(.*/)?(BUILD\.bazel|BUILD|WORKSPACE)$|\.BUILD$|\.bzl$'
+        language: system

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,19 @@
 We'd love to accept your patches and contributions to this project. There are
 just a few small guidelines you need to follow.
 
+## Formatting
+
+Starlark files should be formatted by buildifier.
+We suggest using a pre-commit hook to automate this.
+First [install pre-commit](https://pre-commit.com/#installation)
+Then run
+
+```shell
+pre-commit install
+```
+
+Otherwise the Buildkite CI will yell at you about formatting/linting violations.
+
 ## Contributor License Agreement
 
 Contributions to this project must be accompanied by a Contributor License


### PR DESCRIPTION
Note that https://github.com/bazelbuild/continuous-integration/issues/1161 means users will still be told to do this manually if they don't notice the CONTRIBUTING.md but can be fixed in the future