### PR TITLE
Fixed naming convention issues in common providers

### DIFF
--- a/docs/docs.bzl
+++ b/docs/docs.bzl
@@ -10,8 +10,8 @@ load(
 )
 load(
     "@rules_foreign_cc//foreign_cc:providers.bzl",
-    _ForeignCcArtifact = "ForeignCcArtifact",
-    _ForeignCcDeps = "ForeignCcDeps",
+    _ForeignCcArtifactInfo = "ForeignCcArtifactInfo",
+    _ForeignCcDepsInfo = "ForeignCcDepsInfo",
 )
 load("@rules_foreign_cc//foreign_cc:repositories.bzl", _rules_foreign_cc_dependencies = "rules_foreign_cc_dependencies")
 load("@rules_foreign_cc//foreign_cc/built_tools:cmake_build.bzl", _cmake_tool = "cmake_tool")
@@ -35,11 +35,6 @@ ninja = _ninja
 ninja_tool = _ninja_tool
 rules_foreign_cc_dependencies = _rules_foreign_cc_dependencies
 
-# buildifier: disable=name-conventions
-ForeignCcArtifact = _ForeignCcArtifact
-
-# buildifier: disable=name-conventions
-ForeignCcDeps = _ForeignCcDeps
-
-# buildifier: disable=name-conventions
+ForeignCcArtifactInfo = _ForeignCcArtifactInfo
+ForeignCcDepsInfo = _ForeignCcDepsInfo
 ToolInfo = _ToolInfo

--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -5,7 +5,7 @@
 load("@bazel_skylib//lib:collections.bzl", "collections")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
-load("//foreign_cc:providers.bzl", "ForeignCcArtifact", "ForeignCcDeps")
+load("//foreign_cc:providers.bzl", "ForeignCcArtifactInfo", "ForeignCcDepsInfo")
 load("//foreign_cc/private:detect_root.bzl", "detect_root", "filter_containing_dirs_from_inputs")
 load(
     "//foreign_cc/private/framework:helpers.bzl",
@@ -435,7 +435,7 @@ def cc_external_rule_impl(ctx, attrs):
     for target in [ctx.attr.lib_source] + ctx.attr.additional_inputs + ctx.attr.deps + ctx.attr.data:
         runfiles = runfiles.merge(target[DefaultInfo].default_runfiles)
 
-    externally_built = ForeignCcArtifact(
+    externally_built = ForeignCcArtifactInfo(
         gen_dir = installdir_copy.file,
         bin_dir_name = attrs.out_bin_dir,
         lib_dir_name = attrs.out_lib_dir,
@@ -454,7 +454,7 @@ def cc_external_rule_impl(ctx, attrs):
             runfiles = runfiles,
         ),
         OutputGroupInfo(**output_groups),
-        ForeignCcDeps(artifacts = depset(
+        ForeignCcDepsInfo(artifacts = depset(
             [externally_built],
             transitive = _get_transitive_artifacts(attrs.deps),
         )),
@@ -791,7 +791,7 @@ def uniq_list_keep_order(list):
     return result
 
 def get_foreign_cc_dep(dep):
-    return dep[ForeignCcDeps] if ForeignCcDeps in dep else None
+    return dep[ForeignCcDepsInfo] if ForeignCcDepsInfo in dep else None
 
 # consider optimization here to do not iterate both collections
 def _get_headers(compilation_info):

--- a/foreign_cc/providers.bzl
+++ b/foreign_cc/providers.bzl
@@ -1,20 +1,20 @@
 """ A module containing all public facing providers """
 
-# buildifier: disable=name-conventions
-ForeignCcDeps = provider(
+ForeignCcDepsInfo = provider(
     doc = """Provider to pass transitive information about external libraries.""",
-    fields = {"artifacts": "Depset of ForeignCcArtifact"},
+    fields = {
+        "artifacts": "Depset of ForeignCcArtifactInfo",
+    },
 )
 
-# buildifier: disable=name-conventions
-ForeignCcArtifact = provider(
+ForeignCcArtifactInfo = provider(
     doc = """Groups information about the external library install directory,
 and relative bin, include and lib directories.
 
 Serves to pass transitive information about externally built artifacts up the dependency chain.
 
 Can not be used as a top-level provider.
-Instances of ForeignCcArtifact are incapsulated in a depset ForeignCcDeps#artifacts.""",
+Instances of ForeignCcArtifactInfo are encapsulated in a depset ForeignCcDepsInfo#artifacts.""",
     fields = {
         "bin_dir_name": "Bin directory, relative to install directory",
         "gen_dir": "Install directory",


### PR DESCRIPTION
This renames the following:
- `ForeignCcArtifact` -> `ForeignCcArtifactInfo`
- `ForeignCcDeps` -> `ForeignCcDepsInfo`