### PR TITLE
Added `tool_prefix` attribute

### DIFF
--- a/examples/make_simple/BUILD.bazel
+++ b/examples/make_simple/BUILD.bazel
@@ -3,13 +3,13 @@ load("@rules_foreign_cc//foreign_cc:defs.bzl", "make")
 
 make(
     name = "make_lib",
+    build_data = ["//make_simple/code:clang_wrapper.sh"],
     env = {
         "CLANG_WRAPPER": "$(execpath //make_simple/code:clang_wrapper.sh)",
         "PREFIX": "$$INSTALLDIR$$",
     },
     lib_source = "//make_simple/code:srcs",
     out_static_libs = ["liba.a"],
-    tools_deps = ["//make_simple/code:clang_wrapper.sh"],
 )
 
 cc_test(

--- a/foreign_cc/cmake.bzl
+++ b/foreign_cc/cmake.bzl
@@ -205,14 +205,20 @@ def _create_configure_script(configureParameters):
 
     cmake_commands = []
 
-    data = ctx.attr.data + getattr(ctx.attr, "tools_deps", [])
     configuration = "Debug" if is_debug_mode(ctx) else "Release"
+
+    data = ctx.attr.data + ctx.attr.build_data
+
+    # TODO: The following attributes are deprecated. Remove
+    data += ctx.attr.tools_deps
 
     # Generate a list of arguments for cmake's build command
     build_args = " ".join([
         ctx.expand_location(arg, data)
         for arg in ctx.attr.build_args
     ])
+
+    prefix = "{} ".format(ctx.expand_location(attrs.tool_prefix, data)) if attrs.tool_prefix else ""
 
     # Generate commands for all the targets, ensuring there's
     # always at least 1 call to the default target.
@@ -223,7 +229,8 @@ def _create_configure_script(configureParameters):
 
         # Note that even though directory is always passed, the
         # following arguments can take precedence.
-        cmake_commands.append("{cmake} --build {dir} --config {config} {target} {args}".format(
+        cmake_commands.append("{prefix}{cmake} --build {dir} --config {config} {target} {args}".format(
+            prefix = prefix,
             cmake = attrs.cmake_path,
             dir = ".",
             args = build_args,
@@ -238,7 +245,8 @@ def _create_configure_script(configureParameters):
             for arg in ctx.attr.install_args
         ])
 
-        cmake_commands.append("{cmake} --install {dir} --config {config} {args}".format(
+        cmake_commands.append("{prefix}{cmake} --install {dir} --config {config} {args}".format(
+            prefix = prefix,
             cmake = attrs.cmake_path,
             dir = ".",
             args = install_args,

--- a/foreign_cc/cmake.bzl
+++ b/foreign_cc/cmake.bzl
@@ -158,7 +158,11 @@ load(
 def _cmake_impl(ctx):
     cmake_data = get_cmake_data(ctx)
 
-    tools_deps = ctx.attr.tools_deps + cmake_data.deps
+    tools_deps = cmake_data.deps
+
+    # TODO: `tool_deps` is deprecated. Remove
+    tools_deps += ctx.attr.tools_deps
+
     env = dict(ctx.attr.env)
 
     generator, generate_args = _get_generator_target(ctx)

--- a/foreign_cc/configure.bzl
+++ b/foreign_cc/configure.bzl
@@ -74,10 +74,13 @@ def _create_configure_script(configureParameters):
     ])
 
     make_commands = []
+    prefix = "{} ".format(ctx.expand_location(attrs.tool_prefix, data)) if attrs.tool_prefix else ""
+    configure_prefix = "{} ".format(ctx.expand_location(ctx.attr.configure_prefix, data)) if ctx.attr.configure_prefix else ""
 
     if not ctx.attr.make_commands:
         for target in ctx.attr.targets:
-            make_commands.append("{make} -C $$EXT_BUILD_ROOT$$/{root} {target} {args}".format(
+            make_commands.append("{prefix}{make} -C $$EXT_BUILD_ROOT$$/{root} {target} {args}".format(
+                prefix = prefix,
                 make = attrs.make_path,
                 root = root,
                 args = args,
@@ -94,6 +97,7 @@ def _create_configure_script(configureParameters):
         user_options = ctx.attr.configure_options,
         user_vars = dict(ctx.attr.configure_env_vars),
         is_debug = is_debug_mode(ctx),
+        configure_prefix = configure_prefix,
         configure_command = ctx.attr.configure_command,
         deps = ctx.attr.deps,
         inputs = inputs,
@@ -196,6 +200,9 @@ def _attrs():
         ),
         "configure_options": attr.string_list(
             doc = "Any options to be put on the 'configure' command line.",
+        ),
+        "configure_prefix": attr.string(
+            doc = "A prefix for the call to the `configure_command`.",
         ),
         "install_prefix": attr.string(
             doc = (

--- a/foreign_cc/make.bzl
+++ b/foreign_cc/make.bzl
@@ -43,7 +43,7 @@ def _create_make_script(configureParameters):
     tools = get_tools_info(ctx)
     flags = get_flags_info(ctx)
 
-    data = ctx.attr.data or list()
+    data = ctx.attr.data + ctx.attr.build_data
 
     # Generate a list of arguments for make
     args = " ".join([
@@ -52,8 +52,10 @@ def _create_make_script(configureParameters):
     ])
 
     make_commands = []
+    prefix = "{} ".format(ctx.expand_location(attrs.tool_prefix, data)) if attrs.tool_prefix else ""
     for target in ctx.attr.targets:
-        make_commands.append("{make} -C $$EXT_BUILD_ROOT$$/{root} {target} {args}".format(
+        make_commands.append("{prefix}{make} -C $$EXT_BUILD_ROOT$$/{root} {target} {args}".format(
+            prefix = prefix,
             make = attrs.make_path,
             root = root,
             args = args,

--- a/foreign_cc/private/configure_script.bzl
+++ b/foreign_cc/private/configure_script.bzl
@@ -13,6 +13,7 @@ def create_configure_script(
         user_options,
         user_vars,
         is_debug,
+        configure_prefix,
         configure_command,
         deps,
         inputs,
@@ -67,8 +68,9 @@ def create_configure_script(
             " ".join(autoreconf_options),
         ).lstrip())
 
-    script.append('{env_vars} "{configure}" --prefix=$$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$ {user_options}'.format(
+    script.append('{env_vars} {prefix}"{configure}" --prefix=$$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$ {user_options}'.format(
         env_vars = env_vars_string,
+        prefix = configure_prefix,
         configure = configure_path,
         user_options = " ".join(user_options),
     ))

--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -100,7 +100,7 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
     "env": attr.string_dict(
         doc = (
             "Environment variables to set during the build. " +
-            "`$(execpath)` macros may be used to point at files which are listed as `data`, `deps`, or `build_deps`, " +
+            "`$(execpath)` macros may be used to point at files which are listed as `data`, `deps`, or `build_data`, " +
             "but unlike with other rules, these will be replaced with absolute paths to those files, " +
             "because the build does not run in the exec root. " +
             "No other macros are supported."

--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -184,6 +184,10 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
         ),
         mandatory = False,
     ),
+    "tool_prefix": attr.string(
+        doc = "A prefix for build commands",
+        mandatory = False,
+    ),
     "tools_deps": attr.label_list(
         doc = "__deprecated__: Please use the `build_data` attribute.",
         mandatory = False,
@@ -457,7 +461,7 @@ def cc_external_rule_impl(ctx, attrs):
         runfiles = runfiles.merge(target[DefaultInfo].default_runfiles)
 
     # TODO: `additional_inputs` is deprecated, remove.
-    for legacy in [ctx.attr.additional_inputs]:
+    for legacy in ctx.attr.additional_inputs:
         runfiles = runfiles.merge(legacy[DefaultInfo].default_runfiles)
 
     externally_built = ForeignCcArtifactInfo(


### PR DESCRIPTION
This adds the `tool_prefix` and `build_data` attribute and deprecates `additional_tools`, `additional_inputs`, and `tool_deps`.

`tool_prefix` is expected to solve for issues brought up in https://github.com/bazelbuild/rules_foreign_cc/pull/671#issuecomment-858932271

Basically, some uses of build tools must be prefixed by things like `emcmake` and `emmake` for [emscripten](https://emscripten.org/). These toolchains should be provided as `build_data` and consumed in `tool_prefix` using [make variable expansion](https://docs.bazel.build/versions/main/be/make-variables.html#predefined_label_variables)