### PR TITLE
Add regression tests for python dependencies

### DIFF
--- a/examples/third_party/BUILD.bazel
+++ b/examples/third_party/BUILD.bazel
@@ -17,6 +17,7 @@ test_suite(
         "//libssh2:libssh2_build_test",
         "//openssl:openssl_build_test",
         "//pcre:pcre_build_test",
+        "//sqlite:sqlite_build_test",
     ],
 )
 
@@ -39,6 +40,8 @@ test_suite(
         "//libssh2:libssh2_build_test",
         "//openssl:openssl_build_test",
         "//pcre:pcre_build_test",
+        # Missing a new enough automake to build
+        #"//sqlite:sqlite_build_test",
     ],
 )
 
@@ -59,6 +62,7 @@ test_suite(
         "//libssh2:libssh2_build_test",
         "//openssl:openssl_build_test",
         "//pcre:pcre_build_test",
+        "//sqlite:sqlite_build_test",
     ],
 )
 

--- a/examples/third_party/BUILD.bazel
+++ b/examples/third_party/BUILD.bazel
@@ -4,6 +4,8 @@ test_suite(
     name = "linux_tests",
     tags = ["manual"],
     tests = [
+        "//apr:apr_build_test",
+        "//apr_util:apr_util_build_test",
         "//bison:bison_build_test",
         "//cares:test_c_ares",
         "//curl:curl_build_test",
@@ -22,6 +24,8 @@ test_suite(
     name = "linux_rbe_tests",
     tags = ["manual"],
     tests = [
+        "//apr:apr_build_test",
+        "//apr_util:apr_util_build_test",
         # Missing a new enough m4 to build
         # "//bison:bison_build_test",
         "//cares:test_c_ares",
@@ -42,6 +46,8 @@ test_suite(
     name = "macos_tests",
     tags = ["manual"],
     tests = [
+        "//apr:apr_build_test",
+        "//apr_util:apr_util_build_test",
         "//cares:test_c_ares",
         "//curl:curl_build_test",
         "//gn:gn_launch_test",

--- a/examples/third_party/BUILD.bazel
+++ b/examples/third_party/BUILD.bazel
@@ -18,6 +18,7 @@ test_suite(
         "//openssl:openssl_build_test",
         "//pcre:pcre_build_test",
         "//sqlite:sqlite_build_test",
+        "//subversion:subversion_build_test",
     ],
 )
 
@@ -42,6 +43,7 @@ test_suite(
         "//pcre:pcre_build_test",
         # Missing a new enough automake to build
         #"//sqlite:sqlite_build_test",
+        #"//subversion:subversion_build_test",
     ],
 )
 
@@ -63,6 +65,7 @@ test_suite(
         "//openssl:openssl_build_test",
         "//pcre:pcre_build_test",
         "//sqlite:sqlite_build_test",
+        "//subversion:subversion_build_test",
     ],
 )
 


### PR DESCRIPTION
This pull request adds regression tests for building dependencies of Python2 and Python3. This PR is a precursor to a PR which will provide the ability to build a hermetic Python2/3 toolchain using rules_foreign_cc