### PR TITLE
Fixed libjpeg turbo example

### DIFF
--- a/examples/third_party/libjpeg_turbo/BUILD.libjpeg_turbo.bazel
+++ b/examples/third_party/libjpeg_turbo/BUILD.libjpeg_turbo.bazel
@@ -15,12 +15,15 @@ cmake(
     out_shared_libs = select({
         "@platforms//os:linux": [
             "libjpeg.so",
+            "libturbojpeg.so",
         ],
         "@platforms//os:macos": [
+            "libjpeg.dylib",
             "libturbojpeg.dylib",
         ],
         "@platforms//os:windows": [
             "libjpeg.dll",
+            "libturbojpeg.dll",
         ],
     }),
     visibility = ["//visibility:public"],


### PR DESCRIPTION
It helps if we actually return the correct library 😅

While `libjpeg` is being created, the target we're interested in is `libjpeg_turbo`.