### PR TITLE
Fix tool_prefix for CMake

### DIFF
--- a/foreign_cc/cmake.bzl
+++ b/foreign_cc/cmake.bzl
@@ -218,8 +218,6 @@ def _create_configure_script(configureParameters):
         for arg in ctx.attr.build_args
     ])
 
-    prefix = "{} ".format(ctx.expand_location(attrs.tool_prefix, data)) if attrs.tool_prefix else ""
-
     # Generate commands for all the targets, ensuring there's
     # always at least 1 call to the default target.
     for target in ctx.attr.targets or [""]:
@@ -229,8 +227,7 @@ def _create_configure_script(configureParameters):
 
         # Note that even though directory is always passed, the
         # following arguments can take precedence.
-        cmake_commands.append("{prefix}{cmake} --build {dir} --config {config} {target} {args}".format(
-            prefix = prefix,
+        cmake_commands.append("{cmake} --build {dir} --config {config} {target} {args}".format(
             cmake = attrs.cmake_path,
             dir = ".",
             args = build_args,
@@ -245,8 +242,7 @@ def _create_configure_script(configureParameters):
             for arg in ctx.attr.install_args
         ])
 
-        cmake_commands.append("{prefix}{cmake} --install {dir} --config {config} {args}".format(
-            prefix = prefix,
+        cmake_commands.append("{cmake} --install {dir} --config {config} {args}".format(
             cmake = attrs.cmake_path,
             dir = ".",
             args = install_args,
@@ -266,6 +262,7 @@ def _create_configure_script(configureParameters):
         user_env = getattr(ctx.attr, "env_vars", {}),
         options = attrs.generate_args,
         cmake_commands = cmake_commands,
+        cmake_prefix = ctx.expand_location(attrs.tool_prefix, data) if attrs.tool_prefix else "",
         include_dirs = inputs.include_dirs,
         is_debug_mode = is_debug_mode(ctx),
     )

--- a/foreign_cc/private/cmake_script.bzl
+++ b/foreign_cc/private/cmake_script.bzl
@@ -16,6 +16,7 @@ def create_cmake_script(
         options,
         cmake_commands,
         include_dirs = [],
+        cmake_prefix = None,
         is_debug_mode = True):
     """Constructs CMake script to be passed to cc_external_rule_impl.
 
@@ -33,6 +34,7 @@ def create_cmake_script(
         options: other CMake options specified by user
         cmake_commands: A list of cmake commands for building and installing targets
         include_dirs: Optional additional include directories. Defaults to [].
+        cmake_prefix: Optional prefix before the cmake command (without the trailing space).
         is_debug_mode: If the compilation mode is `debug`. Defaults to True.
 
     Returns:
@@ -91,7 +93,8 @@ def create_cmake_script(
     script.append("##enable_tracing##")
 
     # Configure the CMake generate command
-    script.append(" ".join([
+    cmake_prefixes = [cmake_prefix] if cmake_prefix else []
+    script.append(" ".join(cmake_prefixes + [
         cmake_path,
         str_cmake_cache_entries,
         " ".join(options),

--- a/test/cmake_text_tests.bzl
+++ b/test/cmake_text_tests.bzl
@@ -253,7 +253,7 @@ def _merge_flag_values_no_toolchain_file_test(ctx):
         user_env,
         [],
         cmake_commands = [],
-        cmake_prefix = "emcmake"
+        cmake_prefix = "emcmake",
     )
     expected = r"""export CC="/usr/bin/gcc"
 export CXX="/usr/bin/gcc"

--- a/test/cmake_text_tests.bzl
+++ b/test/cmake_text_tests.bzl
@@ -253,12 +253,13 @@ def _merge_flag_values_no_toolchain_file_test(ctx):
         user_env,
         [],
         cmake_commands = [],
+        cmake_prefix = "emcmake"
     )
     expected = r"""export CC="/usr/bin/gcc"
 export CXX="/usr/bin/gcc"
 export CXXFLAGS="foo=\\\"bar\\\" -Fbat"
 ##enable_tracing##
-cmake -DCMAKE_AR="/usr/bin/ar" -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$$EXT_BUILD_DEPS$$" -DCMAKE_RANLIB=""  -G 'Unix Makefiles' $$EXT_BUILD_ROOT$$/external/test_rule
+emcmake cmake -DCMAKE_AR="/usr/bin/ar" -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$$EXT_BUILD_DEPS$$" -DCMAKE_RANLIB=""  -G 'Unix Makefiles' $$EXT_BUILD_ROOT$$/external/test_rule
 ##disable_tracing##
 """
     asserts.equals(env, expected.splitlines(), script)


### PR DESCRIPTION
Set the prefix before the first CMake invocation (where all the extra flags are passed), and don't set the prefix for the `--build` and `--install` invocations of CMake.

Fixes #685.