### PR TITLE
Set progress message when building targets

### DIFF
--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -452,6 +452,10 @@ def cc_external_rule_impl(ctx, attrs):
         use_default_shell_env = "win" in os_name(ctx),
         # this is ignored if use_default_shell_env = True
         env = env,
+        progress_message = "Foreign Cc - {configure_name}: Building {target_name}".format(
+            configure_name = attrs.configure_name,
+            target_name = ctx.attr.name,
+        ),
     )
 
     # Gather runfiles transitively as per the documentation in:


### PR DESCRIPTION
This PR modifies the progress message that is printed to console when building targets using `rules_foreign_cc`. Previously, the progress message would be of the (somewhat confusing) form:

```
CcConfigureMakeRule external/openssl/openssl/include
```

This PR modifies the message to be of the form:

```
Building openssl (Foreign Cc - Configure)
```