### PR TITLE
Remove ubuntu1604 from presubmit.yml

### DIFF
--- a/.bazelci/config.yaml
+++ b/.bazelci/config.yaml
@@ -170,7 +170,7 @@ tasks:
   min_supported_version:
     name: "Minimum Supported Version"
     bazel: "3.7.0"
-    platform: ubuntu1604
+    platform: ubuntu1804
     build_targets:
       - "//..."
     test_targets:
@@ -178,7 +178,7 @@ tasks:
   min_supported_version_examples:
     name: "Minimum Supported Version Examples"
     bazel: "3.7.0"
-    platform: ubuntu1604
+    platform: ubuntu1804
     working_directory: examples
     min_supported_targets: &min_supported_targets
       - "//..."


### PR DESCRIPTION
Ubuntu 16.04 is end-of-life, we're going to remove it from Bazel CI.