### PR TITLE
Added a `make_toolchain`, `nmake` for `msvc` windows platforms

### DIFF
--- a/foreign_cc/repositories.bzl
+++ b/foreign_cc/repositories.bzl
@@ -50,6 +50,12 @@ def rules_foreign_cc_dependencies(
     if register_default_tools:
         prebuilt_toolchains(cmake_version, ninja_version)
 
+        # `nmake` is a unique toolchin in that it's non-hermetic since it relies on the
+        # host environment but there does not appear to be any way to get `nmake` outside
+        # of installing Visual Studio. It is considered a default toolchain to add better
+        # support for MSVC Windows platforms.
+        native.register_toolchains(str(Label("//toolchains:preinstalled_nmake_toolchain")))
+
     if register_built_tools:
         built_toolchains(
             cmake_version = cmake_version,

--- a/toolchains/BUILD.bazel
+++ b/toolchains/BUILD.bazel
@@ -68,6 +68,21 @@ native_tool_toolchain(
     }),
 )
 
+toolchain(
+    name = "preinstalled_nmake_toolchain",
+    exec_compatible_with = [
+        "@platforms//os:windows",
+        "@bazel_tools//tools/cpp:msvc",
+    ],
+    toolchain = ":preinstalled_nmake",
+    toolchain_type = ":make_toolchain",
+)
+
+native_tool_toolchain(
+    name = "preinstalled_nmake",
+    path = "nmake.exe",
+)
+
 make_tool(
     name = "make_tool",
     srcs = "@gnumake_src//:all_srcs",

--- a/toolchains/toolchains.bzl
+++ b/toolchains/toolchains.bzl
@@ -13,7 +13,8 @@ prebuilt_toolchains = _prebuilt_toolchains
 def preinstalled_toolchains():
     """Register toolchains for various build tools expected to be installed on the exec host"""
     native.register_toolchains(
-        "@rules_foreign_cc//toolchains:preinstalled_cmake_toolchain",
-        "@rules_foreign_cc//toolchains:preinstalled_make_toolchain",
-        "@rules_foreign_cc//toolchains:preinstalled_ninja_toolchain",
+        str(Label("//toolchains:preinstalled_cmake_toolchain")),
+        str(Label("//toolchains:preinstalled_make_toolchain")),
+        str(Label("//toolchains:preinstalled_ninja_toolchain")),
+        str(Label("//toolchains:preinstalled_nmake_toolchain")),
     )


### PR DESCRIPTION
The introduction of the new `nmake` toolchain should not impact anyone unless they're using a custom platform which defines the `@bazel_tools//tools/cpp:msvc` constraint.