### PR TITLE
Update `configure_options` to be passed before the `--prefix` arg

### DIFF
--- a/foreign_cc/private/configure_script.bzl
+++ b/foreign_cc/private/configure_script.bzl
@@ -70,7 +70,7 @@ def create_configure_script(
             options = " ".join(autoreconf_options),
         ).lstrip())
 
-    script.append("{env_vars} {prefix}\"{configure}\" --prefix=$$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$ {user_options}".format(
+    script.append("{env_vars} {prefix}\"{configure}\" {user_options} --prefix=$$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$".format(
         env_vars = _get_env_vars(workspace_name, tools, flags, env_vars, deps, inputs),
         prefix = configure_prefix,
         configure = configure_path,


### PR DESCRIPTION
Some projects (like [openssl](https://github.com/openssl/openssl)) have order specific variables. This allows the attribute to enforce that order.