### PR TITLE
Add missing includes for std::runtime_error

### DIFF
--- a/examples/cmake_synthetic/test_libb.cpp
+++ b/examples/cmake_synthetic/test_libb.cpp
@@ -1,6 +1,7 @@
 #include "libb.h"
 
 #include <iostream>
+#include <stdexcept>
 #include <string>
 
 int main(int argc, char* argv[])

--- a/examples/cmake_with_bazel_transitive/test_libb.cpp
+++ b/examples/cmake_with_bazel_transitive/test_libb.cpp
@@ -1,6 +1,7 @@
 #include "libb.h"
 
 #include <iostream>
+#include <stdexcept>
 #include <string>
 
 int main(int argc, char* argv[])

--- a/examples/cmake_with_data/lib_a/src/lib_a.cpp
+++ b/examples/cmake_with_data/lib_a/src/lib_a.cpp
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <fstream>
 #include <iostream>
+#include <stdexcept>
 
 std::string hello_data(std::string path)
 {

--- a/examples/cmake_with_data/tests/test_cmake_with_data.cpp
+++ b/examples/cmake_with_data/tests/test_cmake_with_data.cpp
@@ -1,6 +1,7 @@
 #include "lib_a.h"
 
 #include <iostream>
+#include <stdexcept>
 #include <string>
 
 int main(int argc, char* argv[])

--- a/examples/cmake_with_data/tests/test_cmake_with_shared_lib.cpp
+++ b/examples/cmake_with_data/tests/test_cmake_with_shared_lib.cpp
@@ -1,5 +1,6 @@
 #include <fstream>
 #include <iostream>
+#include <stdexcept>
 #include <string>
 
 void test_opening_file(std::string path)

--- a/examples/cmake_working_dir/test_liba.cpp
+++ b/examples/cmake_working_dir/test_liba.cpp
@@ -1,6 +1,7 @@
 #include "liba.h"
 
 #include <iostream>
+#include <stdexcept>
 #include <string>
 
 int main(int argc, char* argv[])

--- a/examples/third_party/cares/c-ares-test.cpp
+++ b/examples/third_party/cares/c-ares-test.cpp
@@ -1,6 +1,7 @@
 #include "ares.h"
 
 #include <iostream>
+#include <stdexcept>
 #include <string.h>
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
The compilers in CI are reasonably old and aren't strict at requiring the correct headers included for classes defined in std. This adds the missing include headers that are needed to be standards compliant when using the exception `std::runtime_error`