### PR TITLE
Build OpenSSL using MSVC toolchain on Windows

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -16,6 +16,13 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
+config_setting(
+    name = "msvc_compiler",
+    flag_values = {
+        "@bazel_tools//tools/cpp:compiler": "msvc-cl",
+    },
+)
+
 test_suite(
     name = "third_party_examples_linux_tests",
     tags = ["manual"],

--- a/examples/third_party/BUILD.bazel
+++ b/examples/third_party/BUILD.bazel
@@ -15,7 +15,7 @@ test_suite(
         "//libjpeg_turbo:libjpeg_turbo_build_test",
         "//libpng:test_libpng",
         "//libssh2:libssh2_build_test",
-        "//openssl:openssl_build_test",
+        "//openssl:openssl_test_suite",
         "//pcre:pcre_build_test",
         "//python:python_tests",
         "//sqlite:sqlite_build_test",
@@ -40,7 +40,7 @@ test_suite(
         "//libjpeg_turbo:libjpeg_turbo_build_test",
         "//libpng:test_libpng",
         "//libssh2:libssh2_build_test",
-        "//openssl:openssl_build_test",
+        "//openssl:openssl_test_suite",
         "//pcre:pcre_build_test",
         "//python:python_tests",
         # Missing a new enough automake to build
@@ -64,7 +64,7 @@ test_suite(
         "//libjpeg_turbo:libjpeg_turbo_build_test",
         "//libpng:test_libpng",
         "//libssh2:libssh2_build_test",
-        "//openssl:openssl_build_test",
+        "//openssl:openssl_test_suite",
         "//pcre:pcre_build_test",
         "//python:python_tests",
         "//sqlite:sqlite_build_test",
@@ -77,7 +77,7 @@ test_suite(
     tags = ["manual"],
     tests = [
         "//curl:curl_build_test",
-        "//openssl:openssl_build_test",
+        "//openssl:openssl_test_suite",
         # TODO: Add more windows tests
     ],
 )

--- a/examples/third_party/BUILD.bazel
+++ b/examples/third_party/BUILD.bazel
@@ -8,7 +8,7 @@ test_suite(
         "//apr_util:apr_util_build_test",
         "//bison:bison_build_test",
         "//cares:test_c_ares",
-        "//curl:curl_build_test",
+        "//curl:curl_test_suite",
         "//gn:gn_launch_test",
         "//gperftools:test",
         "//libgit2:libgit2_build_test",
@@ -32,7 +32,7 @@ test_suite(
         # Missing a new enough m4 to build
         # "//bison:bison_build_test",
         "//cares:test_c_ares",
-        "//curl:curl_build_test",
+        "//curl:curl_test_suite",
         # Attempts to access git sha during configure of build so fails
         # "//gn:gn_launch_test",
         "//gperftools:test",
@@ -56,7 +56,7 @@ test_suite(
         "//apr:apr_build_test",
         "//apr_util:apr_util_build_test",
         "//cares:test_c_ares",
-        "//curl:curl_build_test",
+        "//curl:curl_test_suite",
         "//gn:gn_launch_test",
         "//gperftools:test",
         "//iconv:iconv_build_test",
@@ -76,7 +76,7 @@ test_suite(
     name = "windows_tests",
     tags = ["manual"],
     tests = [
-        "//curl:curl_build_test",
+        "//curl:curl_test_suite",
         "//openssl:openssl_test_suite",
         # TODO: Add more windows tests
     ],

--- a/examples/third_party/BUILD.bazel
+++ b/examples/third_party/BUILD.bazel
@@ -77,6 +77,7 @@ test_suite(
     tags = ["manual"],
     tests = [
         "//curl:curl_build_test",
+        "//openssl:openssl_build_test",
         # TODO: Add more windows tests
     ],
 )

--- a/examples/third_party/curl/BUILD.bazel
+++ b/examples/third_party/curl/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@rules_cc//cc:defs.bzl", "cc_test")
 
 exports_files(
     [
@@ -7,10 +8,42 @@ exports_files(
     visibility = ["//visibility:public"],
 )
 
+cc_test(
+    name = "curl_test",
+    srcs = ["curl_test.cc"],
+    defines = select({
+        "@rules_foreign_cc_examples//:msvc_compiler": ["CURL_STATICLIB"],
+        "//conditions:default": [],
+    }),
+    linkopts = select({
+        "@platforms//os:linux": ["-ldl"],
+        "@rules_foreign_cc_examples//:msvc_compiler": [
+            "crypt32.lib",
+            "ws2_32.lib",
+            "advapi32.lib",
+            "user32.lib",
+        ],
+        "//conditions:default": [],
+    }),
+    deps = [
+        "@curl",
+        "@openssl",
+    ],
+)
+
 build_test(
-    name = "curl_build_test",
+    name = "build_test",
     targets = [
         "@curl//:curl",
+    ],
+    visibility = ["//:__pkg__"],
+)
+
+test_suite(
+    name = "curl_test_suite",
+    tests = [
+        ":build_test",
+        ":curl_test",
     ],
     visibility = ["//:__pkg__"],
 )

--- a/examples/third_party/curl/BUILD.curl.bazel
+++ b/examples/third_party/curl/BUILD.curl.bazel
@@ -10,8 +10,10 @@ _CACHE_ENTRIES = {
     "BUILD_SHARED_LIBS": "off",
     "CMAKE_BUILD_TYPE": "RELEASE",
     "CMAKE_PREFIX_PATH": "$$EXT_BUILD_DEPS$$/openssl",
+    "CMAKE_USE_OPENSSL": "on",
     # TODO: ldap should likely be enabled
     "CURL_DISABLE_LDAP": "on",
+    "OPENSSL_ROOT_DIR": "$$EXT_BUILD_DEPS$$/openssl",
 }
 
 _MACOS_CACHE_ENTRIES = dict(_CACHE_ENTRIES.items() + {
@@ -36,17 +38,19 @@ cmake(
     }),
     generate_crosstool_file = False,
     lib_source = ":all_srcs",
+    linkopts = select({
+        "@platforms//os:linux": [
+            "-lpthread",
+        ],
+        "//conditions:default": [],
+    }),
     out_static_libs = select({
         "@platforms//os:windows": ["libcurl.lib"],
         "//conditions:default": ["libcurl.a"],
     }),
     visibility = ["//visibility:public"],
     deps = [
-        "@zlib//:zlib",
-    ] + select({
-        "@platforms//os:windows": [],
-        "//conditions:default": [
-            "@openssl//:openssl",
-        ],
-    }),
+        "@openssl",
+        "@zlib",
+    ],
 )

--- a/examples/third_party/curl/curl_test.cc
+++ b/examples/third_party/curl/curl_test.cc
@@ -1,0 +1,17 @@
+#include <curl/curl.h>
+
+#include <cassert>
+#include <string>
+
+// Use (void) to silent unused warnings.
+#define assertm(exp, msg) assert(((void)msg, exp))
+
+int main(int argc, char* argv[])
+{
+    curl_version_info_data* data = curl_version_info(CURLVERSION_NOW);
+
+    assertm(std::string(data->version) == std::string("7.74.0"), "The version of curl does not match the expected version");
+    assertm(std::string(data->ssl_version) == std::string("OpenSSL/1.1.1h"), "The version of openssl does not match the expected version");
+
+    return 0;
+}

--- a/examples/third_party/openssl/BUILD.bazel
+++ b/examples/third_party/openssl/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@rules_cc//cc:defs.bzl", "cc_test")
 
 exports_files(
     [
@@ -7,10 +8,32 @@ exports_files(
     visibility = ["//visibility:public"],
 )
 
+cc_test(
+    name = "openssl_test",
+    srcs = ["openssl_test.cc"],
+    linkopts = select({
+        "@rules_foreign_cc_examples//:msvc_compiler": [
+            "advapi32.lib",
+            "user32.lib",
+        ],
+        "//conditions:default": [],
+    }),
+    deps = ["@openssl"],
+)
+
 build_test(
-    name = "openssl_build_test",
+    name = "build_test",
     targets = [
         "@openssl//:openssl",
+    ],
+    visibility = ["//:__pkg__"],
+)
+
+test_suite(
+    name = "openssl_test_suite",
+    tests = [
+        ":build_test",
+        ":openssl_test",
     ],
     visibility = ["//:__pkg__"],
 )

--- a/examples/third_party/openssl/BUILD.nasm.bazel
+++ b/examples/third_party/openssl/BUILD.nasm.bazel
@@ -1,0 +1,14 @@
+load("@bazel_skylib//rules:select_file.bzl", "select_file")
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_srcs",
+    srcs = glob(["**"]),
+)
+
+select_file(
+    name = "nasm",
+    srcs = ":all_srcs",
+    subpath = "nasm.exe",
+)

--- a/examples/third_party/openssl/BUILD.openssl.bazel
+++ b/examples/third_party/openssl/BUILD.openssl.bazel
@@ -2,7 +2,7 @@
 https://github.com/bazelbuild/rules_foreign_cc/issues/337
 """
 
-load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make", "configure_make_variant")
 
 # Read https://wiki.openssl.org/index.php/Compilation_and_Installation
 
@@ -15,37 +15,74 @@ CONFIGURE_OPTIONS = [
     "no-comp",
     "no-idea",
     "no-weak-ssl-ciphers",
+    "no-shared",
 ]
 
-configure_make(
+LIB_NAME = "openssl"
+
+MAKE_TARGETS = [
+    "build_libs",
+    "install_dev",
+]
+
+alias(
     name = "openssl",
+    actual = select({
+        "@rules_foreign_cc_examples//:msvc_compiler": "openssl_msvc",
+        "//conditions:default": "openssl_default",
+    }),
+    visibility = ["//visibility:public"],
+)
+
+configure_make_variant(
+    name = "openssl_msvc",
+    build_data = [
+        "@nasm//:nasm",
+        "@perl//:perl",
+    ],
+    configure_command = "Configure",
+    configure_in_place = True,
+    configure_options = CONFIGURE_OPTIONS + [
+        "VC-WIN64A",
+        # Unset Microsoft Assembler (MASM) flags set by built-in MSVC toolchain,
+        # as NASM is unsed to build OpenSSL rather than MASM
+        "ASFLAGS=\" \"",
+    ],
+    configure_prefix = "$PERL",
+    env = {
+        # The Zi flag must be set otherwise OpenSSL fails to build due to missing .pdb files
+        "CFLAGS": "-Zi",
+        "PATH": "$(dirname $(execpath @nasm//:nasm)):$PATH",
+        "PERL": "$(execpath @perl//:perl)",
+    },
+    lib_name = LIB_NAME,
+    lib_source = ":all_srcs",
+    out_static_libs = [
+        "libssl.lib",
+        "libcrypto.lib",
+    ],
+    targets = MAKE_TARGETS,
+    toolchain = "@rules_foreign_cc//toolchains:preinstalled_nmake_toolchain",
+)
+
+configure_make(
+    name = "openssl_default",
     configure_command = "config",
     configure_in_place = True,
-    configure_options = select({
-        "@platforms//os:macos": [
-            "ARFLAGS=r",
-            "no-afalgeng",
-            "no-asm",
-            "no-shared",
-        ] + CONFIGURE_OPTIONS,
-        "//conditions:default": [
-            "no-shared",
-        ] + CONFIGURE_OPTIONS,
-    }),
+    configure_options = CONFIGURE_OPTIONS,
     env = select({
         "@platforms//os:macos": {"AR": ""},
         "//conditions:default": {},
     }),
+    lib_name = LIB_NAME,
     lib_source = ":all_srcs",
+    # Note that for Linux builds, libssl must come before libcrypto on the linker command-line.
+    # As such, libssl must be listed before libcrypto
     out_static_libs = [
-        "libcrypto.a",
         "libssl.a",
+        "libcrypto.a",
     ],
-    targets = [
-        "build_libs",
-        "install_dev",
-    ],
-    visibility = ["//visibility:public"],
+    targets = MAKE_TARGETS,
 )
 
 filegroup(

--- a/examples/third_party/openssl/BUILD.perl.bazel
+++ b/examples/third_party/openssl/BUILD.perl.bazel
@@ -1,0 +1,14 @@
+load("@bazel_skylib//rules:select_file.bzl", "select_file")
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_srcs",
+    srcs = glob(["**"]),
+)
+
+select_file(
+    name = "perl",
+    srcs = ":all_srcs",
+    subpath = "perl/bin/perl.exe",
+)

--- a/examples/third_party/openssl/openssl_repositories.bzl
+++ b/examples/third_party/openssl/openssl_repositories.bzl
@@ -15,3 +15,24 @@ def openssl_repositories():
             "https://github.com/openssl/openssl/archive/OpenSSL_1_1_1h.tar.gz",
         ],
     )
+
+    maybe(
+        http_archive,
+        name = "nasm",
+        build_file = Label("//openssl:BUILD.nasm.bazel"),
+        sha256 = "f5c93c146f52b4f1664fa3ce6579f961a910e869ab0dae431bd871bdd2584ef2",
+        strip_prefix = "nasm-2.15.05",
+        urls = [
+            "https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/win64/nasm-2.15.05-win64.zip",
+        ],
+    )
+
+    maybe(
+        http_archive,
+        name = "perl",
+        build_file = Label("//openssl:BUILD.perl.bazel"),
+        sha256 = "aeb973da474f14210d3e1a1f942dcf779e2ae7e71e4c535e6c53ebabe632cc98",
+        urls = [
+            "https://strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-64bit.zip",
+        ],
+    )

--- a/examples/third_party/openssl/openssl_test.cc
+++ b/examples/third_party/openssl/openssl_test.cc
@@ -1,0 +1,53 @@
+#include <openssl/sha.h>
+
+#include <cassert>
+#include <iomanip>
+#include <sstream>
+#include <string>
+
+// Use (void) to silent unused warnings.
+#define assertm(exp, msg) assert(((void)msg, exp))
+
+// From https://stackoverflow.com/a/2262447/7768383
+bool simpleSHA256(const void* input, unsigned long length, unsigned char* md)
+{
+    SHA256_CTX context;
+    if (!SHA256_Init(&context))
+        return false;
+
+    if (!SHA256_Update(&context, (unsigned char*)input, length))
+        return false;
+
+    if (!SHA256_Final(md, &context))
+        return false;
+
+    return true;
+}
+
+// Convert an byte array into a string
+std::string fromByteArray(const unsigned char* data, unsigned long length)
+{
+    std::stringstream shastr;
+    shastr << std::hex << std::setfill('0');
+    for (unsigned long i = 0; i < length; ++i)
+    {
+        shastr << std::setw(2) << static_cast<int>(data[i]);
+    }
+
+    return shastr.str();
+}
+
+std::string MESSAGE = "hello world";
+std::string MESSAGE_HASH = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
+
+int main(int argc, char* argv[])
+{
+    unsigned char md[SHA256_DIGEST_LENGTH] = {};
+
+    assertm(simpleSHA256(static_cast<const void*>(MESSAGE.data()), MESSAGE.size(), md), "Failed to generate hash");
+    std::string hash = fromByteArray(md, SHA256_DIGEST_LENGTH);
+
+    assertm(hash == MESSAGE_HASH, "Unexpected message hash");
+
+    return 0;
+}

--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -454,9 +454,9 @@ def cc_external_rule_impl(ctx, attrs):
         command = wrapped_outputs.wrapper_script_file.path,
         execution_requirements = execution_requirements,
         use_default_shell_env = True,
-        progress_message = "Foreign Cc - {configure_name}: Building {target_name}".format(
+        progress_message = "Foreign Cc - {configure_name}: Building {lib_name}".format(
             configure_name = attrs.configure_name,
-            target_name = ctx.attr.name,
+            lib_name = lib_name,
         ),
     )
 


### PR DESCRIPTION
This PR modifies rules_foreign_cc so that OpenSSL successfully builds using the MSVC toolchain on Windows.

Note that I started working on this branch before the recent commit on master whereby the `nmake` toolchain was added. I instead added an `nmake` attribute to the `configure_make()` rule. It would be good to get the reviewers' thoughts on which approach is best