### PR TITLE
Convert MSVC flags by replacing slashes with dashes

### DIFF
--- a/foreign_cc/private/cc_toolchain_util.bzl
+++ b/foreign_cc/private/cc_toolchain_util.bzl
@@ -389,7 +389,6 @@ def _convert_flags(compiler, flags):
 
     Returns:
         list: The converted flags
-
     """
     if compiler == "msvc-cl":
         return [flag.replace("/", "-") if flag.startswith("/") else flag for flag in flags]


### PR DESCRIPTION
This overcomes bugs in MSYS2 where leading slashes are converted to
paths, e.g. "/nologo" is converted to "C:\msys64\nologo".

This commit would modify the flag to become "-nologo". MSVC supports
both slashes and dashes for flags.