### PR TITLE
Wrap tool paths that contain whitespaces in quotes

### DIFF
--- a/examples/configure_with_bazel_transitive/simple_lib/configure
+++ b/examples/configure_with_bazel_transitive/simple_lib/configure
@@ -1,11 +1,11 @@
 #!/bin/bash
 echo "# simple" > Makefile
 
-echo "CC = \"${CC}\"" > Makefile
+echo "CC = ${CC}" > Makefile
 
 
 if [[ "$(uname)" == *"NT"* ]]; then
-    echo "AR = \"${AR}\"" >>  Makefile
+    echo "AR = ${AR}" >>  Makefile
     echo "OBJECT = simple.obj" >> Makefile
     echo "OUTPUT = simple.lib" >> Makefile
     echo "BUILT_WITH_BAZEL = $EXT_BUILD_DEPS/lib/built_with_bazel.lib" >> Makefile

--- a/foreign_cc/private/configure_script.bzl
+++ b/foreign_cc/private/configure_script.bzl
@@ -194,10 +194,15 @@ def _get_configure_variables(workspace_name, tools, flags, user_env_vars):
     for tool in _CONFIGURE_TOOLS:
         tool_value = getattr(tools, _CONFIGURE_TOOLS[tool])
         if tool_value:
-            # Force absolutize of tool paths, which may relative to the workspace
-            # dir (hermetic toolchains) be provided in project repositories
-            # (i.e hermetic toolchains).
-            tools_dict[tool] = [_absolutize(workspace_name, tool_value, True)]
+            # Force absolutize of tool paths, which may relative to the exec root (e.g. hermetic toolchains built from source)
+            tool_value_absolute = _absolutize(workspace_name, tool_value, True)
+
+            # If the tool path contains whitespaces (e.g. C:\Program Files\...),
+            # MSYS2 requires that the path is wrapped in double quotes
+            if " " in tool_value_absolute:
+                tool_value_absolute = "\\\"" + tool_value_absolute + "\\\""
+
+            tools_dict[tool] = [tool_value_absolute]
 
     # Replace tools paths if user passed other values
     for user_var in user_env_vars:


### PR DESCRIPTION
This change is required when using the MSVC toolchain on Windows,
as paths for tools such as the compiler contain whitespaces (e.g.
C:\Program Files\...)