### PR TITLE
Add <rule>_variant macros

### DIFF
--- a/foreign_cc/cmake.bzl
+++ b/foreign_cc/cmake.bzl
@@ -144,6 +144,7 @@ load(
     "create_attrs",
     "expand_locations",
 )
+load("//foreign_cc/private:transitions.bzl", "make_variant")
 load(
     "//foreign_cc/private/framework:platform.bzl",
     "os_name",
@@ -416,3 +417,18 @@ cmake = rule(
     # version is updated to a release of Bazel containing the new default for this setting.
     incompatible_use_toolchain_transition = True,
 )
+
+def cmake_variant(name, toolchain, **kwargs):
+    """ Wrapper macro around the cmake() rule to force usage of the given make variant toolchain.
+
+    Args:
+        name: The target name
+        toolchain: The desired make variant toolchain to use, e.g. @rules_foreign_cc//toolchains:preinstalled_nmake_toolchain
+        **kwargs: Remaining keyword arguments
+    """
+    make_variant(
+        name = name,
+        rule = cmake,
+        toolchain = toolchain,
+        **kwargs
+    )

--- a/foreign_cc/configure.bzl
+++ b/foreign_cc/configure.bzl
@@ -18,6 +18,7 @@ load(
     "create_attrs",
     "expand_locations",
 )
+load("//foreign_cc/private:transitions.bzl", "make_variant")
 load("//foreign_cc/private/framework:platform.bzl", "os_name")
 load("//toolchains/native_tools:tool_access.bzl", "get_make_data")
 
@@ -230,3 +231,18 @@ configure_make = rule(
     # version is updated to a release of Bazel containing the new default for this setting.
     incompatible_use_toolchain_transition = True,
 )
+
+def configure_make_variant(name, toolchain, **kwargs):
+    """ Wrapper macro around the configure_make() rule to force usage of the given make variant toolchain.
+
+    Args:
+        name: The target name
+        toolchain: The desired make variant toolchain to use, e.g. @rules_foreign_cc//toolchains:preinstalled_nmake_toolchain
+        **kwargs: Remaining keyword arguments
+    """
+    make_variant(
+        name = name,
+        rule = configure_make,
+        toolchain = toolchain,
+        **kwargs
+    )

--- a/foreign_cc/defs.bzl
+++ b/foreign_cc/defs.bzl
@@ -1,13 +1,16 @@
 """Public entry point to all Foreign CC rules and supported APIs."""
 
 load(":boost_build.bzl", _boost_build = "boost_build")
-load(":cmake.bzl", _cmake = "cmake")
-load(":configure.bzl", _configure_make = "configure_make")
-load(":make.bzl", _make = "make")
+load(":cmake.bzl", _cmake = "cmake", _cmake_variant = "cmake_variant")
+load(":configure.bzl", _configure_make = "configure_make", _configure_make_variant = "configure_make_variant")
+load(":make.bzl", _make = "make", _make_variant = "make_variant")
 load(":ninja.bzl", _ninja = "ninja")
 
 boost_build = _boost_build
 cmake = _cmake
+cmake_variant = _cmake_variant
 configure_make = _configure_make
+configure_make_variant = _configure_make_variant
+make_variant = _make_variant
 make = _make
 ninja = _ninja

--- a/foreign_cc/make.bzl
+++ b/foreign_cc/make.bzl
@@ -18,6 +18,7 @@ load(
     "expand_locations",
 )
 load("//foreign_cc/private:make_script.bzl", "create_make_script")
+load("//foreign_cc/private:transitions.bzl", _make_variant = "make_variant")
 load("//toolchains/native_tools:tool_access.bzl", "get_make_data")
 
 def _make(ctx):
@@ -106,3 +107,18 @@ make = rule(
     # version is updated to a release of Bazel containing the new default for this setting.
     incompatible_use_toolchain_transition = True,
 )
+
+def make_variant(name, toolchain, **kwargs):
+    """ Wrapper macro around the make() rule to force usage of the given make variant toolchain.
+
+    Args:
+        name: The target name
+        toolchain: The desired make variant toolchain to use, e.g. @rules_foreign_cc//toolchains:preinstalled_nmake_toolchain
+        **kwargs: Remaining keyword arguments
+    """
+    _make_variant(
+        name = name,
+        rule = make,
+        toolchain = toolchain,
+        **kwargs
+    )

--- a/foreign_cc/private/transitions.bzl
+++ b/foreign_cc/private/transitions.bzl
@@ -1,0 +1,69 @@
+"""This file contains rules for configuration transitions"""
+
+load("//foreign_cc:providers.bzl", "ForeignCcDepsInfo")
+
+def _extra_toolchains_transition_impl(settings, attrs):
+    return {"//command_line_option:extra_toolchains": attrs.extra_toolchains + settings["//command_line_option:extra_toolchains"]}
+
+_extra_toolchains_transition = transition(
+    implementation = _extra_toolchains_transition_impl,
+    inputs = ["//command_line_option:extra_toolchains"],
+    outputs = ["//command_line_option:extra_toolchains"],
+)
+
+def _extra_toolchains_transitioned_foreign_cc_target_impl(ctx):
+    # Return the providers from the transitioned foreign_cc target
+    return [
+        ctx.attr.target[DefaultInfo],
+        ctx.attr.target[CcInfo],
+        ctx.attr.target[ForeignCcDepsInfo],
+        ctx.attr.target[OutputGroupInfo],
+    ]
+
+extra_toolchains_transitioned_foreign_cc_target = rule(
+    doc = "A rule for adding extra toolchains to consider when building the given target",
+    implementation = _extra_toolchains_transitioned_foreign_cc_target_impl,
+    cfg = _extra_toolchains_transition,
+    attrs = {
+        "extra_toolchains": attr.string_list(
+            doc = "Additional toolchains to consider",
+            mandatory = True,
+        ),
+        "target": attr.label(
+            doc = "The target to build after considering the extra toolchains",
+            providers = [ForeignCcDepsInfo],
+            mandatory = True,
+        ),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+    incompatible_use_toolchain_transition = True,
+)
+
+def make_variant(name, rule, toolchain, **kwargs):
+    """ Wrapper macro around foreign cc rules to force usage of the given make variant toolchain.
+
+    Args:
+        name: The target name
+        rule: The foreign cc rule to instantiate, e.g. configure_make
+        toolchain: The desired make variant toolchain to use, e.g. @rules_foreign_cc//toolchains:preinstalled_nmake_toolchain
+        **kwargs: Remaining keyword arguments
+    """
+
+    make_variant_target_name = name + "_"
+
+    tags = kwargs.pop("tags", [])
+
+    rule(
+        name = make_variant_target_name,
+        tags = tags + ["manual"],
+        **kwargs
+    )
+
+    extra_toolchains_transitioned_foreign_cc_target(
+        name = name,
+        extra_toolchains = [toolchain],
+        target = make_variant_target_name,
+        tags = tags,
+    )

--- a/foreign_cc/repositories.bzl
+++ b/foreign_cc/repositories.bzl
@@ -50,12 +50,6 @@ def rules_foreign_cc_dependencies(
     if register_default_tools:
         prebuilt_toolchains(cmake_version, ninja_version)
 
-        # `nmake` is a unique toolchin in that it's non-hermetic since it relies on the
-        # host environment but there does not appear to be any way to get `nmake` outside
-        # of installing Visual Studio. It is considered a default toolchain to add better
-        # support for MSVC Windows platforms.
-        native.register_toolchains(str(Label("//toolchains:preinstalled_nmake_toolchain")))
-
     if register_built_tools:
         built_toolchains(
             cmake_version = cmake_version,

--- a/toolchains/BUILD.bazel
+++ b/toolchains/BUILD.bazel
@@ -72,7 +72,6 @@ toolchain(
     name = "preinstalled_nmake_toolchain",
     exec_compatible_with = [
         "@platforms//os:windows",
-        "@bazel_tools//tools/cpp:msvc",
     ],
     toolchain = ":preinstalled_nmake",
     toolchain_type = ":make_toolchain",

--- a/toolchains/toolchains.bzl
+++ b/toolchains/toolchains.bzl
@@ -16,5 +16,4 @@ def preinstalled_toolchains():
         str(Label("//toolchains:preinstalled_cmake_toolchain")),
         str(Label("//toolchains:preinstalled_make_toolchain")),
         str(Label("//toolchains:preinstalled_ninja_toolchain")),
-        str(Label("//toolchains:preinstalled_nmake_toolchain")),
     )


### PR DESCRIPTION
The macros utilise bazel "transitions" to set the `make` toolchain to
be the preinstalled `nmake` tool.

Note that the msvc constraint was removed from the
`exec_compatible_with` attribute of `preinstalled_nmake_toolchain` as
the condition is not actually met even when building with msvc. See
https://github.com/bazelbuild/bazel/issues/7730.

This will be tested in PR #729