### PR TITLE
Add a configure_nmake rule

### DIFF
--- a/foreign_cc/defs.bzl
+++ b/foreign_cc/defs.bzl
@@ -2,12 +2,13 @@
 
 load(":boost_build.bzl", _boost_build = "boost_build")
 load(":cmake.bzl", _cmake = "cmake")
-load(":configure.bzl", _configure_make = "configure_make")
+load(":configure.bzl", _configure_make = "configure_make", _configure_nmake = "configure_nmake")
 load(":make.bzl", _make = "make")
 load(":ninja.bzl", _ninja = "ninja")
 
 boost_build = _boost_build
 cmake = _cmake
 configure_make = _configure_make
+configure_nmake = _configure_nmake
 make = _make
 ninja = _ninja

--- a/toolchains/BUILD.bazel
+++ b/toolchains/BUILD.bazel
@@ -18,6 +18,10 @@ toolchain_type(
     name = "make_toolchain",
 )
 
+toolchain_type(
+    name = "nmake_toolchain",
+)
+
 toolchain(
     name = "built_cmake_toolchain",
     toolchain = ":built_cmake",
@@ -72,10 +76,9 @@ toolchain(
     name = "preinstalled_nmake_toolchain",
     exec_compatible_with = [
         "@platforms//os:windows",
-        "@bazel_tools//tools/cpp:msvc",
     ],
     toolchain = ":preinstalled_nmake",
-    toolchain_type = ":make_toolchain",
+    toolchain_type = ":nmake_toolchain",
 )
 
 native_tool_toolchain(

--- a/toolchains/native_tools/tool_access.bzl
+++ b/toolchains/native_tools/tool_access.bzl
@@ -32,6 +32,9 @@ def get_ninja_data(ctx):
 def get_make_data(ctx):
     return _access_and_expect_label_copied("@rules_foreign_cc//toolchains:make_toolchain", ctx, "make")
 
+def get_nmake_data(ctx):
+    return _access_and_expect_label_copied("@rules_foreign_cc//toolchains:nmake_toolchain", ctx, "nmake")
+
 def _access_and_expect_label_copied(toolchain_type_, ctx, tool_name):
     tool_data = access_tool(toolchain_type_, ctx, tool_name)
     if tool_data.target:


### PR DESCRIPTION
Note that the msvc constraint was removed from the
exec_compatible_with attribute of preinstalled_nmake_toolchain as
the condition is not actually met even when building with msvc. See
bazelbuild/bazel#7730.

This will be tested in PR #729