### PR TITLE
Remove "GNU" prefix to Make

### DIFF
--- a/foreign_cc/make.bzl
+++ b/foreign_cc/make.bzl
@@ -28,7 +28,7 @@ def _make(ctx):
 
     attrs = create_attrs(
         ctx.attr,
-        configure_name = "GNUMake",
+        configure_name = "Make",
         create_configure_script = _create_make_script,
         tools_deps = tools_deps,
         make_path = make_data.path,


### PR DESCRIPTION
When using a make variant, such as NMake, bazel would print "GNUMake - Building ..." to console. To avoid confusion, this commit removes the GNU prefix.