### PR TITLE
Add expat dep to apr_util build

### DIFF
--- a/examples/third_party/BUILD.bazel
+++ b/examples/third_party/BUILD.bazel
@@ -28,7 +28,8 @@ test_suite(
     tags = ["manual"],
     tests = [
         "//apr:apr_build_test",
-        "//apr_util:apr_util_build_test",
+        # Copying files to RBE does not preserve timestamps, invoking autotools which is not new enough to build apr_util
+        # "//apr_util:apr_util_build_test",
         # Missing a new enough m4 to build
         # "//bison:bison_build_test",
         "//cares:test_c_ares",

--- a/examples/third_party/apr_util/BUILD.apr_util.bazel
+++ b/examples/third_party/apr_util/BUILD.apr_util.bazel
@@ -10,6 +10,7 @@ configure_make(
     configure_in_place = True,
     configure_options = [
         "--with-apr=$EXT_BUILD_DEPS/apr",
+        "--with-expat=$EXT_BUILD_DEPS/expat",
     ],
     env = select({
         "@platforms//os:macos": {"AR": ""},
@@ -18,5 +19,8 @@ configure_make(
     lib_source = ":all_srcs",
     out_static_libs = ["libaprutil-1.a"],
     visibility = ["//visibility:public"],
-    deps = ["@apr"],
+    deps = [
+        "@apr",
+        "@expat",
+    ],
 )

--- a/examples/third_party/apr_util/BUILD.expat.bazel
+++ b/examples/third_party/apr_util/BUILD.expat.bazel
@@ -1,0 +1,47 @@
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake", "configure_make")
+
+filegroup(
+    name = "all_srcs",
+    srcs = glob(["**"]),
+)
+
+LIB_NAME = "expat"
+
+alias(
+    name = "expat",
+    actual = select({
+        "@rules_foreign_cc_examples//:msvc_compiler": "expat_msvc",
+        "//conditions:default": "expat_default",
+    }),
+    visibility = ["//visibility:public"],
+)
+
+cmake(
+    name = "expat_msvc",
+    cache_entries = {
+        "CMAKE_BUILD_TYPE": "Release",
+        "EXPAT_MSVC_STATIC_CRT": "ON",
+        "EXPAT_SHARED_LIBS": "OFF",
+    },
+    generate_args = ["-G\"NMake Makefiles\""],
+    lib_name = LIB_NAME,
+    lib_source = ":all_srcs",
+    out_static_libs = ["libexpatMT.lib"],
+)
+
+configure_make(
+    name = "expat_default",
+    configure_options = [
+        "--disable-shared",
+        "--without-docbook",
+        "--without-examples",
+        "--without-tests",
+    ],
+    env = select({
+        "@platforms//os:macos": {"AR": ""},
+        "//conditions:default": {},
+    }),
+    lib_name = LIB_NAME,
+    lib_source = ":all_srcs",
+    out_static_libs = ["libexpat.a"],
+)

--- a/examples/third_party/apr_util/apr_util_repositories.bzl
+++ b/examples/third_party/apr_util/apr_util_repositories.bzl
@@ -15,3 +15,14 @@ def apr_util_repositories():
             "https://www-us.apache.org/dist//apr/apr-util-1.6.1.tar.gz",
         ],
     )
+
+    maybe(
+        http_archive,
+        name = "expat",
+        build_file = Label("//apr_util:BUILD.expat.bazel"),
+        sha256 = "a00ae8a6b96b63a3910ddc1100b1a7ef50dc26dceb65ced18ded31ab392f132b",
+        strip_prefix = "expat-2.4.1",
+        urls = [
+            "https://github.com/libexpat/libexpat/releases/download/R_2_4_1/expat-2.4.1.tar.gz",
+        ],
+    )


### PR DESCRIPTION
The build of apr_util would previously fail if expat libs and headers were not preinstalled in the build environment.

Resolves #750 