### PR TITLE
Move more example build config into example BUILD files

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -16,13 +16,6 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
-config_setting(
-    name = "msvc_compiler",
-    flag_values = {
-        "@bazel_tools//tools/cpp:compiler": "msvc-cl",
-    },
-)
-
 test_suite(
     name = "third_party_examples_linux_tests",
     tags = ["manual"],

--- a/examples/third_party/apr/BUILD.apr.bazel
+++ b/examples/third_party/apr/BUILD.apr.bazel
@@ -7,10 +7,17 @@ filegroup(
     srcs = glob(["**"]),
 )
 
+config_setting(
+    name = "msvc_compiler",
+    flag_values = {
+        "@bazel_tools//tools/cpp:compiler": "msvc-cl",
+    },
+)
+
 alias(
     name = "apr",
     actual = select({
-        "@rules_foreign_cc_examples//:msvc_compiler": "apr_msvc",
+        ":msvc_compiler": "apr_msvc",
         "//conditions:default": "apr_default",
     }),
     visibility = ["//visibility:public"],

--- a/examples/third_party/apr_util/BUILD.expat.bazel
+++ b/examples/third_party/apr_util/BUILD.expat.bazel
@@ -10,7 +10,7 @@ LIB_NAME = "expat"
 alias(
     name = "expat",
     actual = select({
-        "@rules_foreign_cc_examples//:msvc_compiler": "expat_msvc",
+        "@apr//:msvc_compiler": "expat_msvc",
         "//conditions:default": "expat_default",
     }),
     visibility = ["//visibility:public"],

--- a/examples/third_party/curl/BUILD.bazel
+++ b/examples/third_party/curl/BUILD.bazel
@@ -12,17 +12,17 @@ cc_test(
     name = "curl_test",
     srcs = ["curl_test.cc"],
     defines = select({
-        "@rules_foreign_cc_examples//:msvc_compiler": ["CURL_STATICLIB"],
+        "@openssl//:msvc_compiler": ["CURL_STATICLIB"],
         "//conditions:default": [],
     }),
     linkopts = select({
-        "@platforms//os:linux": ["-ldl"],
-        "@rules_foreign_cc_examples//:msvc_compiler": [
+        "@openssl//:msvc_compiler": [
             "crypt32.lib",
             "ws2_32.lib",
             "advapi32.lib",
             "user32.lib",
         ],
+        "@platforms//os:linux": ["-ldl"],
         "//conditions:default": [],
     }),
     deps = [

--- a/examples/third_party/openssl/BUILD.bazel
+++ b/examples/third_party/openssl/BUILD.bazel
@@ -12,7 +12,7 @@ cc_test(
     name = "openssl_test",
     srcs = ["openssl_test.cc"],
     linkopts = select({
-        "@rules_foreign_cc_examples//:msvc_compiler": [
+        "@openssl//:msvc_compiler": [
             "advapi32.lib",
             "user32.lib",
         ],

--- a/examples/third_party/openssl/BUILD.openssl.bazel
+++ b/examples/third_party/openssl/BUILD.openssl.bazel
@@ -25,10 +25,18 @@ MAKE_TARGETS = [
     "install_dev",
 ]
 
+config_setting(
+    name = "msvc_compiler",
+    flag_values = {
+        "@bazel_tools//tools/cpp:compiler": "msvc-cl",
+    },
+    visibility = ["//visibility:public"],
+)
+
 alias(
     name = "openssl",
     actual = select({
-        "@rules_foreign_cc_examples//:msvc_compiler": "openssl_msvc",
+        ":msvc_compiler": "openssl_msvc",
         "//conditions:default": "openssl_default",
     }),
     visibility = ["//visibility:public"],


### PR DESCRIPTION
These dependencies are not intended to be loaded through `rules_foreign_cc_examples` so moving these config flags into the BUILD files themselves should make the targets more snapshot-able.