### PR TITLE
Pass all tags to execution_requirements

### DIFF
--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -429,9 +429,9 @@ def cc_external_rule_impl(ctx, attrs):
     rule_outputs = outputs.declared_outputs + [installdir_copy.file]
     cc_toolchain = find_cpp_toolchain(ctx)
 
-    execution_requirements = {"block-network": ""}
-    if "requires-network" in ctx.attr.tags:
-        execution_requirements = {"requires-network": ""}
+    execution_requirements = {tag: "" for tag in ctx.attr.tags}
+    if "requires-network" not in execution_requirements:
+        execution_requirements["block-network"] = ""
 
     # TODO: `additional_tools` is deprecated, remove.
     legacy_tools = ctx.files.additional_tools + ctx.files.tools_deps


### PR DESCRIPTION
This allows passing all the usual tags to the underlying run_shell action, such as 'no-sandbox', 'no-cache', etc. https://docs.bazel.build/versions/main/be/common-definitions.html#common.tags