### PR TITLE
Fix building for iOS

### DIFF
--- a/examples/WORKSPACE.bazel
+++ b/examples/WORKSPACE.bazel
@@ -26,7 +26,33 @@ load("//deps:deps_jvm_external.bzl", "deps_jvm_external")
 
 deps_jvm_external()
 
+local_repository(
+    name = "rules_foreign_cc_examples_third_party",
+    path = "third_party",
+)
+
+load("@rules_foreign_cc_examples_third_party//:repositories.bzl", examples_third_party_repositories = "repositories")
+
+examples_third_party_repositories()
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "bazel_toolchains",
+    sha256 = "179ec02f809e86abf56356d8898c8bd74069f1bd7c56044050c2cd3d79d0e024",
+    strip_prefix = "bazel-toolchains-4.1.0",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/releases/download/4.1.0/bazel-toolchains-4.1.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-toolchains/releases/download/4.1.0/bazel-toolchains-4.1.0.tar.gz",
+    ],
+)
+
+load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
+
+# Creates a default toolchain config for RBE.
+# Use this as is if you are using the rbe_ubuntu16_04 container,
+# otherwise refer to RBE docs.
+rbe_autoconfig(name = "buildkite_config")
 
 http_archive(
     name = "build_bazel_rules_apple",
@@ -61,29 +87,3 @@ load(
 )
 
 apple_support_dependencies()
-
-local_repository(
-    name = "rules_foreign_cc_examples_third_party",
-    path = "third_party",
-)
-
-load("@rules_foreign_cc_examples_third_party//:repositories.bzl", examples_third_party_repositories = "repositories")
-
-examples_third_party_repositories()
-
-http_archive(
-    name = "bazel_toolchains",
-    sha256 = "179ec02f809e86abf56356d8898c8bd74069f1bd7c56044050c2cd3d79d0e024",
-    strip_prefix = "bazel-toolchains-4.1.0",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/releases/download/4.1.0/bazel-toolchains-4.1.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-toolchains/releases/download/4.1.0/bazel-toolchains-4.1.0.tar.gz",
-    ],
-)
-
-load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
-
-# Creates a default toolchain config for RBE.
-# Use this as is if you are using the rbe_ubuntu16_04 container,
-# otherwise refer to RBE docs.
-rbe_autoconfig(name = "buildkite_config")

--- a/examples/WORKSPACE.bazel
+++ b/examples/WORKSPACE.bazel
@@ -26,6 +26,42 @@ load("//deps:deps_jvm_external.bzl", "deps_jvm_external")
 
 deps_jvm_external()
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "build_bazel_rules_apple",
+    sha256 = "0052d452af7742c8f3a4e0929763388a66403de363775db7e90adecb2ba4944b",
+    url = "https://github.com/bazelbuild/rules_apple/releases/download/0.31.3/rules_apple.0.31.3.tar.gz",
+)
+
+load(
+    "@build_bazel_rules_apple//apple:repositories.bzl",
+    "apple_rules_dependencies",
+)
+
+apple_rules_dependencies()
+
+load(
+    "@build_bazel_rules_swift//swift:repositories.bzl",
+    "swift_rules_dependencies",
+)
+
+swift_rules_dependencies()
+
+load(
+    "@build_bazel_rules_swift//swift:extras.bzl",
+    "swift_rules_extra_dependencies",
+)
+
+swift_rules_extra_dependencies()
+
+load(
+    "@build_bazel_apple_support//lib:repositories.bzl",
+    "apple_support_dependencies",
+)
+
+apple_support_dependencies()
+
 local_repository(
     name = "rules_foreign_cc_examples_third_party",
     path = "third_party",
@@ -34,8 +70,6 @@ local_repository(
 load("@rules_foreign_cc_examples_third_party//:repositories.bzl", examples_third_party_repositories = "repositories")
 
 examples_third_party_repositories()
-
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "bazel_toolchains",

--- a/examples/third_party/BUILD.bazel
+++ b/examples/third_party/BUILD.bazel
@@ -58,6 +58,7 @@ test_suite(
         "//apr:apr_build_test",
         "//apr_util:apr_util_build_test",
         "//cares:test_c_ares",
+        "//cares:test_c_ares_ios",
         "//curl:curl_test_suite",
         "//gn:gn_launch_test",
         "//gperftools:test",

--- a/examples/third_party/WORKSPACE.bazel
+++ b/examples/third_party/WORKSPACE.bazel
@@ -9,6 +9,42 @@ load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_depende
 
 rules_foreign_cc_dependencies(register_preinstalled_tools = False)
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "build_bazel_rules_apple",
+    sha256 = "0052d452af7742c8f3a4e0929763388a66403de363775db7e90adecb2ba4944b",
+    url = "https://github.com/bazelbuild/rules_apple/releases/download/0.31.3/rules_apple.0.31.3.tar.gz",
+)
+
+load(
+    "@build_bazel_rules_apple//apple:repositories.bzl",
+    "apple_rules_dependencies",
+)
+
+apple_rules_dependencies()
+
+load(
+    "@build_bazel_rules_swift//swift:repositories.bzl",
+    "swift_rules_dependencies",
+)
+
+swift_rules_dependencies()
+
+load(
+    "@build_bazel_rules_swift//swift:extras.bzl",
+    "swift_rules_extra_dependencies",
+)
+
+swift_rules_extra_dependencies()
+
+load(
+    "@build_bazel_apple_support//lib:repositories.bzl",
+    "apple_support_dependencies",
+)
+
+apple_support_dependencies()
+
 local_repository(
     name = "rules_foreign_cc_examples",
     path = "..",

--- a/examples/third_party/WORKSPACE.bazel
+++ b/examples/third_party/WORKSPACE.bazel
@@ -9,6 +9,15 @@ load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_depende
 
 rules_foreign_cc_dependencies(register_preinstalled_tools = False)
 
+local_repository(
+    name = "rules_foreign_cc_examples",
+    path = "..",
+)
+
+load("//:repositories.bzl", "repositories")
+
+repositories()
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
@@ -44,12 +53,3 @@ load(
 )
 
 apple_support_dependencies()
-
-local_repository(
-    name = "rules_foreign_cc_examples",
-    path = "..",
-)
-
-load("//:repositories.bzl", "repositories")
-
-repositories()

--- a/examples/third_party/cares/BUILD.bazel
+++ b/examples/third_party/cares/BUILD.bazel
@@ -1,8 +1,24 @@
-load("@rules_cc//cc:defs.bzl", "cc_test")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_build_test")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
 cc_test(
     name = "test_c_ares",
     srcs = ["c-ares-test.cpp"],
     visibility = ["//:__pkg__"],
     deps = ["@cares"],
+)
+
+cc_library(
+    name = "ios_lib",
+    srcs = ["c-ares-test.cpp"],
+    tags = ["manual"],
+    deps = ["@cares"],
+)
+
+ios_build_test(
+    name = "test_c_ares_ios",
+    minimum_os_version = "12.0",
+    tags = ["manual"],
+    targets = ["ios_lib"],
+    visibility = ["//:__pkg__"],
 )


### PR DESCRIPTION
Some projects like envoy-mobile use rules_foreign_cc to build targeting
iOS, so this is useful to validate on CI as part of the macOS test
build. This also fixes a bug where this was broken since 
c41020e4655fc9adb4bad7e9c04a3f2cf2cc9250 because the wrong SDKROOT was used