### PR TITLE
Resolve symlinks among output binaries

### DIFF
--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -422,6 +422,7 @@ def cc_external_rule_impl(ctx, attrs):
     ] + [
         "##replace_symlink## {}".format(file.path)
         for file in (
+            outputs.out_binary_files +
             outputs.libraries.static_libraries +
             outputs.libraries.shared_libraries +
             outputs.libraries.interface_libraries


### PR DESCRIPTION
Certain (C)Make projects (such as [AFL++](https://github.com/AFLplusplus/AFLplusplus)) emit binaries that are symlinks to other emitted binaries. When built with `rules_foreign_cc`, this can lead to non-deterministic dangling symlink errors since Bazel visits the outputs in an unspecified order. This is fixed by resolving symlinks among the emitted binaries, just like it is already done for libraries.