### PR TITLE
Use rsync with chmod for copying files

### DIFF
--- a/foreign_cc/private/framework/toolchains/linux_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/linux_commands.bzl
@@ -86,7 +86,10 @@ fi
     )
 
 def copy_dir_contents_to_dir(source, target):
-    return """cp -L -r --no-target-directory "{source}" "{target}" && find {target} -type f -exec touch -r "{source}" "{{}}" \\;""".format(
+    return """\
+      rsync --chmod=u+w -rRL "{source}/./" "{target}"
+      find {target} -type f -exec touch -r "{source}" "{{}}" \\;
+    """.format(
         source = source,
         target = target,
     )

--- a/foreign_cc/private/framework/toolchains/macos_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/macos_commands.bzl
@@ -88,14 +88,10 @@ fi
 def copy_dir_contents_to_dir(source, target):
     # Beause macos `cp` doesn't have `--no-copy-directory`, we have to
     # do something more complext for this environment.
-    return """\
-if [[ -d "{source}" ]]; then
-  cp -L -R "{source}"/* "{target}"
-else
-  cp -L -R "{source}" "{target}"
-fi
-find {target} -type f -exec touch -r "{source}" "{{}}" \\;
-""".format(
+    return """
+      rsync --chmod=u+w -rRL "{source}/./" "{target}"
+      find {target} -type f -exec touch -r "{source}" "{{}}" \\;
+    """.format(
         source = source,
         target = target,
     )

--- a/foreign_cc/private/framework/toolchains/windows_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/windows_commands.bzl
@@ -90,7 +90,10 @@ fi
     )
 
 def copy_dir_contents_to_dir(source, target):
-    return """cp -L -r --no-target-directory "{source}" "{target}" && find {target} -type f -exec touch -r "{source}" "{{}}" \\;""".format(
+    return """
+      rsync --chmod=u+w -rRL "{source}/./" "{target}"
+      find {target} -type f -exec touch -r "{source}" "{{}}" \\;
+    """.format(
         source = source,
         target = target,
     )


### PR DESCRIPTION
This ensures that files and directories are writable after being copied, which is necessary in a remote execution environment, such as the one provided by bazel-buildfarm. The existing cp command assumes the source files are writable, so the copies will also be writable, but on bazel-buildfarm, the source files and directories are readonly, so the copies are readonly, and therefore Makefile generation often fails.

The path construction with the trailing `/./` and `-R` flag ensures files are copied with relative paths, which I think is equivalent to what the cp option `--no-target-directory` was accomplishing.

Fixes #783