### PR TITLE
Improve failed exports logic

### DIFF
--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -292,8 +292,10 @@ def get_env_prelude(ctx, lib_name, data_dependencies, target_root):
         sdk = "{}{}".format(platform.lower(), version)
         env_snippet.extend([
             # TODO: This path needs to take cc_env["XCODE_VERSION_OVERRIDE"] into account
-            "export DEVELOPER_DIR=\"$(xcode-select --print-path)\"",
-            "export SDKROOT=\"$(xcrun --sdk {} --show-sdk-path)\"".format(sdk),
+            "developer_dir_tmp=\"$(xcode-select --print-path)\"",
+            "export DEVELOPER_DIR=\"$developer_dir_tmp\"",
+            "sdkroot_tmp=\"$(xcrun --sdk {} --show-sdk-path)\"".format(sdk),
+            "export SDKROOT=\"$sdkroot_tmp\"",
         ])
 
     cc_toolchain = find_cpp_toolchain(ctx)

--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -292,6 +292,7 @@ def get_env_prelude(ctx, lib_name, data_dependencies, target_root):
         sdk = "{}{}".format(platform.lower(), version)
         env_snippet.extend([
             # TODO: This path needs to take cc_env["XCODE_VERSION_OVERRIDE"] into account
+            # Declare and export separately so bash doesn't ignore failures from the commands https://github.com/koalaman/shellcheck/wiki/SC2155
             "developer_dir_tmp=\"$(xcode-select --print-path)\"",
             "export DEVELOPER_DIR=\"$developer_dir_tmp\"",
             "sdkroot_tmp=\"$(xcrun --sdk {} --show-sdk-path)\"".format(sdk),


### PR DESCRIPTION
If something is misconfigured in your setup, these commands can fail.
Example:

```
xcodebuild: error: SDK "iphonesimulator14.4" cannot be located.
xcodebuild: error: SDK "iphonesimulator14.4" cannot be located.
xcrun: error: unable to lookup item 'Path' in SDK 'iphonesimulator14.4
```

In this case, because the execution of the command, and the `export`,
were in the statement, bash ignores the exit code. This breaks that up.

We could also break this up with:

```
foo=$(...)
export foo
```

But that doesn't work in the postprocessing currently done with exports.