### PR TITLE
Add flags from copts and linkopts attributes

### DIFF
--- a/foreign_cc/private/cc_toolchain_util.bzl
+++ b/foreign_cc/private/cc_toolchain_util.bzl
@@ -301,9 +301,9 @@ def get_flags_info(ctx, link_output_file = None):
         cc_toolchain = cc_toolchain_,
     )
 
-    copts = (ctx.fragments.cpp.copts + ctx.fragments.cpp.conlyopts) or []
-    cxxopts = (ctx.fragments.cpp.copts + ctx.fragments.cpp.cxxopts) or []
-    linkopts = ctx.fragments.cpp.linkopts or []
+    copts = (ctx.fragments.cpp.copts + ctx.fragments.cpp.conlyopts + ctx.attr.copts) or []
+    cxxopts = (ctx.fragments.cpp.copts + ctx.fragments.cpp.cxxopts + ctx.attr.copts) or []
+    linkopts = (ctx.fragments.cpp.linkopts + ctx.attr.linkopts) or []
     defines = _defines_from_deps(ctx)
 
     flags = CxxFlagsInfo(

--- a/test/standard_cxx_flags_test/BUILD.bazel
+++ b/test/standard_cxx_flags_test/BUILD.bazel
@@ -1,3 +1,7 @@
 load(":tests.bzl", "flags_test")
 
-flags_test(name = "flags_test")
+flags_test(
+    name = "flags_test",
+    copts = ["-fblah4"],
+    linkopts = ["-fblah5"],
+)

--- a/test/standard_cxx_flags_test/tests.bzl
+++ b/test/standard_cxx_flags_test/tests.bzl
@@ -10,12 +10,26 @@ def _impl(ctx):
 
     assert_contains_once(flags.cc, "-fblah0")
     assert_contains_once(flags.cc, "-fblah2")
+    assert_contains_once(flags.cc, "-fblah4")
+    if "-fblah5" in flags.cc:
+        fail("C flags should not contain '-fblah5'")
 
     assert_contains_once(flags.cxx, "-fblah0")
     assert_contains_once(flags.cxx, "-fblah1")
+    assert_contains_once(flags.cxx, "-fblah4")
+    if "-fblah5" in flags.cxx:
+        fail("C++ flags should not contain '-fblah5'")
 
     assert_contains_once(flags.cxx_linker_executable, "-fblah3")
+    assert_contains_once(flags.cxx_linker_executable, "-fblah5")
+    if "-fblah4" in flags.cxx_linker_executable:
+        fail("Executable linker flags should not contain '-fblah4'")
+
     assert_contains_once(flags.cxx_linker_shared, "-fblah3")
+    assert_contains_once(flags.cxx_linker_shared, "-fblah5")
+    if "-fblah4" in flags.cxx_linker_shared:
+        fail("Shared linker flags should not contain '-fblah4'")
+
     if "-fblah3" in flags.cxx_linker_static:
         fail("Static linker flags should not contain '-fblah3'")
 
@@ -44,7 +58,9 @@ def assert_contains_once(arr, value):
 _flags_test = rule(
     implementation = _impl,
     attrs = {
+        "copts": attr.string_list(),
         "deps": attr.label_list(),
+        "linkopts": attr.string_list(),
         "out": attr.output(),
         "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
     },


### PR DESCRIPTION
Without this commit, the copts and linkopts attributes on rules such as make and cmake did not actually add any flags to the foreign build system.

This is similar to https://github.com/bazelbuild/rules_foreign_cc/pull/777 and another place where, as far as I can tell, user-supplied flags were silently swallowed. `copts` is being used in https://github.com/bazelbuild/rules_foreign_cc/blob/a7105dafb067c785cc9ade2c70b0d0ce967490fc/foreign_cc/private/cc_toolchain_util.bzl#L224 but that function always returns an empty dictionary for me. @UebelAndre Do you know how this relates to https://github.com/bazelbuild/rules_foreign_cc/blob/a7105dafb067c785cc9ade2c70b0d0ce967490fc/foreign_cc/private/cc_toolchain_util.bzl#L287 which seems much more feature complete?