### PR TITLE
Add toolchain types for autotools tools

### DIFF
--- a/foreign_cc/cmake.bzl
+++ b/foreign_cc/cmake.bzl
@@ -412,6 +412,8 @@ cmake = rule(
         "@rules_foreign_cc//toolchains:cmake_toolchain",
         "@rules_foreign_cc//toolchains:ninja_toolchain",
         "@rules_foreign_cc//toolchains:make_toolchain",
+        "@rules_foreign_cc//toolchains:m4_toolchain",
+        "@rules_foreign_cc//toolchains:pkgconfig_toolchain",
         "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
         "@bazel_tools//tools/cpp:toolchain_type",
     ],

--- a/foreign_cc/configure.bzl
+++ b/foreign_cc/configure.bzl
@@ -224,7 +224,11 @@ configure_make = rule(
     output_to_genfiles = True,
     implementation = _configure_make,
     toolchains = [
+        "@rules_foreign_cc//toolchains:autoconf_toolchain",
+        "@rules_foreign_cc//toolchains:automake_toolchain",
         "@rules_foreign_cc//toolchains:make_toolchain",
+        "@rules_foreign_cc//toolchains:m4_toolchain",
+        "@rules_foreign_cc//toolchains:pkgconfig_toolchain",
         "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
         "@bazel_tools//tools/cpp:toolchain_type",
     ],

--- a/foreign_cc/repositories.bzl
+++ b/foreign_cc/repositories.bzl
@@ -47,6 +47,13 @@ def rules_foreign_cc_dependencies(
 
     native.register_toolchains(*native_tools_toolchains)
 
+    native.register_toolchains(
+        str(Label("//toolchains:preinstalled_autoconf_toolchain")),
+        str(Label("//toolchains:preinstalled_automake_toolchain")),
+        str(Label("//toolchains:preinstalled_m4_toolchain")),
+        str(Label("//toolchains:preinstalled_pkgconfig_toolchain")),
+    )
+
     if register_default_tools:
         prebuilt_toolchains(cmake_version, ninja_version)
 

--- a/toolchains/BUILD.bazel
+++ b/toolchains/BUILD.bazel
@@ -18,6 +18,22 @@ toolchain_type(
     name = "make_toolchain",
 )
 
+toolchain_type(
+    name = "pkgconfig_toolchain",
+)
+
+toolchain_type(
+    name = "m4_toolchain",
+)
+
+toolchain_type(
+    name = "autoconf_toolchain",
+)
+
+toolchain_type(
+    name = "automake_toolchain",
+)
+
 toolchain(
     name = "built_cmake_toolchain",
     toolchain = ":built_cmake",
@@ -141,6 +157,62 @@ native_tool_toolchain(
         "//conditions:default": "$(execpath :ninja_tool)/bin/ninja",
     }),
     target = ":ninja_tool",
+)
+
+toolchain(
+    name = "preinstalled_autoconf_toolchain",
+    toolchain = ":preinstalled_autoconf",
+    toolchain_type = ":autoconf_toolchain",
+)
+
+native_tool_toolchain(
+    name = "preinstalled_autoconf",
+    path = select({
+        "@platforms//os:windows": "autoconf.exe",
+        "//conditions:default": "autoconf",
+    }),
+)
+
+toolchain(
+    name = "preinstalled_automake_toolchain",
+    toolchain = ":preinstalled_automake",
+    toolchain_type = ":automake_toolchain",
+)
+
+native_tool_toolchain(
+    name = "preinstalled_automake",
+    path = select({
+        "@platforms//os:windows": "automake.exe",
+        "//conditions:default": "automake",
+    }),
+)
+
+toolchain(
+    name = "preinstalled_m4_toolchain",
+    toolchain = ":preinstalled_m4",
+    toolchain_type = ":m4_toolchain",
+)
+
+native_tool_toolchain(
+    name = "preinstalled_m4",
+    path = select({
+        "@platforms//os:windows": "m4.exe",
+        "//conditions:default": "m4",
+    }),
+)
+
+toolchain(
+    name = "preinstalled_pkgconfig_toolchain",
+    toolchain = ":preinstalled_pkgconfig",
+    toolchain_type = ":pkgconfig_toolchain",
+)
+
+native_tool_toolchain(
+    name = "preinstalled_pkgconfig",
+    path = select({
+        "@platforms//os:windows": "pkg-config.exe",
+        "//conditions:default": "pkg-config",
+    }),
 )
 
 bzl_library(

--- a/toolchains/native_tools/tool_access.bzl
+++ b/toolchains/native_tools/tool_access.bzl
@@ -23,14 +23,26 @@ def access_tool(toolchain_type_, ctx, tool_name):
         target = None,
     )
 
-def get_cmake_data(ctx):
-    return _access_and_expect_label_copied("@rules_foreign_cc//toolchains:cmake_toolchain", ctx, "cmake")
+def get_autoconf_data(ctx):
+    return _access_and_expect_label_copied(str(Label("//toolchains:autoconf_toolchain")), ctx, "autoconf")
 
-def get_ninja_data(ctx):
-    return _access_and_expect_label_copied("@rules_foreign_cc//toolchains:ninja_toolchain", ctx, "ninja")
+def get_automake_data(ctx):
+    return _access_and_expect_label_copied(str(Label("//toolchains:automake_toolchain")), ctx, "automake")
+
+def get_cmake_data(ctx):
+    return _access_and_expect_label_copied(str(Label("//toolchains:cmake_toolchain")), ctx, "cmake")
+
+def get_m4_data(ctx):
+    return _access_and_expect_label_copied(str(Label("//toolchains:m4_toolchain")), ctx, "m4")
 
 def get_make_data(ctx):
-    return _access_and_expect_label_copied("@rules_foreign_cc//toolchains:make_toolchain", ctx, "make")
+    return _access_and_expect_label_copied(str(Label("//toolchains:make_toolchain")), ctx, "make")
+
+def get_ninja_data(ctx):
+    return _access_and_expect_label_copied(str(Label("//toolchains:ninja_toolchain")), ctx, "ninja")
+
+def get_pkgconfig_data(ctx):
+    return _access_and_expect_label_copied(str(Label("//toolchains:pkgconfig_toolchain")), ctx, "pkg-config")
 
 def _access_and_expect_label_copied(toolchain_type_, ctx, tool_name):
     tool_data = access_tool(toolchain_type_, ctx, tool_name)


### PR DESCRIPTION
Add the toolchain types and resolve these to the preinstalled versions of such tools.

Note this only sets up the toolchains and doesn't actually make use of them yet.