### PR TITLE
Expand locations and make variables for `cmake::cache_entries`

### DIFF
--- a/foreign_cc/cmake.bzl
+++ b/foreign_cc/cmake.bzl
@@ -262,7 +262,7 @@ def _create_configure_script(configureParameters):
         install_prefix = "$$INSTALLDIR$$",
         root = root,
         no_toolchain_file = no_toolchain_file,
-        user_cache = dict(ctx.attr.cache_entries),
+        user_cache = expand_locations(ctx, ctx.attr.cache_entries, data),
         user_env = expand_locations_and_make_variables(ctx, "env", data),
         options = attrs.generate_args,
         cmake_commands = cmake_commands,


### PR DESCRIPTION
I was attempting to use [find_package](https://cmake.org/cmake/help/v3.22/command/find_package.html) by setting `<project_name>_DIR` in `cmake::cache_entries` and realized the locations weren't being expanded.

eg:
```python
cmake(
    name = "project",
    cache_entries = {
        "my_module_DIR": "$$(dirname $(execpath @my_module//:module.cmake))",
    },
    data = ["@my_module//:module.cmake"],
    lib_source = ":all_srcs",
    visibility = ["//visibility:public"],
)
```

The above snippet did not work without the changes in this PR. I'm happy to use alternative approaches but unfortunately couldn't find any.