### PR TITLE
Adapt tests to new cc_binary file extension on macOS

### DIFF
--- a/examples/cmake_with_data/tests/test_cmake_with_shared_lib.cpp
+++ b/examples/cmake_with_data/tests/test_cmake_with_shared_lib.cpp
@@ -20,7 +20,13 @@ int main(int argc, char* argv[])
 #ifdef _WIN32
     test_opening_file(".\\cmake_with_data\\lib_b\\lib_b.dll");
 #else
-    test_opening_file("./cmake_with_data/lib_b/liblib_b.so");
+    // Shared libraries used to have the .so file extension on macOS.
+    // See https://github.com/bazelbuild/bazel/pull/14369.
+    try {
+        test_opening_file("./cmake_with_data/lib_b/liblib_b.so");
+    } catch (std::runtime_error& e) {
+        test_opening_file("./cmake_with_data/lib_b/liblib_b.dylib");
+    }
 #endif
     std::cout << "Everything's fine!";
 }


### PR DESCRIPTION
As of https://github.com/bazelbuild/bazel/pull/14369, shared libraries produced with cc_binary on macOS with the auto-configured toolchain use the correct file extension for dynamic libraries (`.dylib` rather than `.so`). This requires adapting a test.