### PR TITLE
Do not set user defined env variables twice for (c)make

### DIFF
--- a/foreign_cc/private/make_env_vars.bzl
+++ b/foreign_cc/private/make_env_vars.bzl
@@ -123,10 +123,8 @@ def _get_make_variables(workspace_name, tools, flags, user_env_vars):
 
     vars.update(tools_dict)
 
-    # Put all other environment variables, passed by the user
-    for user_var in user_env_vars:
-        if not vars.get(user_var):
-            vars[user_var] = [user_env_vars[user_var]]
+    # Do not put in the other user-defined env variables at this point as they
+    # have already been exported globally by the prelude.
 
     return vars
 


### PR DESCRIPTION
These variables are already exported in the build script prelude and thus don't have to be set on individual make commands.

Resolves an undesired side effect of https://github.com/bazelbuild/rules_foreign_cc/commit/f61ce5d10b221c643ae48063c3484fadf84066d4, that however should not have resulted in this kind of breakage.

Workaround for #857, the fix for the underlying issue will be submitted as a separate PR.
