### PR TITLE
Replace `escape_locations` with `escape_locations_and_make_variables` everywhere

### DIFF
--- a/examples/make_simple/BUILD.bazel
+++ b/examples/make_simple/BUILD.bazel
@@ -3,14 +3,19 @@ load("@rules_foreign_cc//foreign_cc:defs.bzl", "make")
 
 make(
     name = "make_lib",
-    build_data = ["//make_simple/code:cxx_wrapper.sh"],
+    build_data = [
+        "//make_simple/code:cxx_wrapper.sh",
+        "README.md",
+    ],
     copts = [
         "-DREQUIRED_DEFINE",
     ],
     env = {
         "CXX_WRAPPER": "$(execpath //make_simple/code:cxx_wrapper.sh)",
+        "README_DIR": "$$(dirname $(execpath README.md))",
     },
     lib_source = "//make_simple/code:srcs",
+    out_data_dirs = ["share"],
     out_static_libs = ["liba.a"],
 )
 

--- a/examples/make_simple/code/Makefile
+++ b/examples/make_simple/code/Makefile
@@ -16,7 +16,7 @@ default all $(BUILD_DIR)/lib/liba.a: liba.cpp liba.h
 	ar rcs $(BUILD_DIR)/lib/liba.a $(BUILD_DIR)/lib/liba.o
 
 install: $(BUILD_DIR)/lib/liba.a
-	mkdir -p $(PREFIX)/lib $(PREFIX)/include
+	mkdir -p $(PREFIX)/lib $(PREFIX)/include $(PREFIX)/share
 	cp -rpv $(BUILD_DIR)/lib $(PREFIX)
 	cp -p liba.h $(PREFIX)/include
-	cp $(README_DIR)/README.md $(PREFIX)/share
+	cp $(README_DIR)/README.md $(PREFIX)/share/

--- a/examples/make_simple/code/Makefile
+++ b/examples/make_simple/code/Makefile
@@ -19,3 +19,4 @@ install: $(BUILD_DIR)/lib/liba.a
 	mkdir -p $(PREFIX)/lib $(PREFIX)/include
 	cp -rpv $(BUILD_DIR)/lib $(PREFIX)
 	cp -p liba.h $(PREFIX)/include
+	cp $(README_DIR)/README.md $(PREFIX)/share

--- a/examples/third_party/openssl/BUILD.openssl.bazel
+++ b/examples/third_party/openssl/BUILD.openssl.bazel
@@ -61,7 +61,7 @@ configure_make_variant(
         # as NASM is unsed to build OpenSSL rather than MASM
         "ASFLAGS=\" \"",
     ],
-    configure_prefix = "$PERL",
+    configure_prefix = "$$PERL",
     env = {
         # The Zi flag must be set otherwise OpenSSL fails to build due to missing .pdb files
         "CFLAGS": "-Zi",

--- a/foreign_cc/cmake.bzl
+++ b/foreign_cc/cmake.bzl
@@ -142,7 +142,6 @@ load(
     "CC_EXTERNAL_RULE_FRAGMENTS",
     "cc_external_rule_impl",
     "create_attrs",
-    "expand_locations",
     "expand_locations_and_make_variables",
 )
 load("//foreign_cc/private:transitions.bzl", "make_variant")
@@ -216,7 +215,7 @@ def _create_configure_script(configureParameters):
 
     # Generate a list of arguments for cmake's build command
     build_args = " ".join([
-        expand_locations(ctx, arg, data)
+        expand_locations_and_make_variables(ctx, arg, "build_args", data)
         for arg in ctx.attr.build_args
     ])
 
@@ -240,7 +239,7 @@ def _create_configure_script(configureParameters):
     if ctx.attr.install:
         # Generate a list of arguments for cmake's install command
         install_args = " ".join([
-            expand_locations(ctx, arg, data)
+            expand_locations_and_make_variables(ctx, arg, "install_args", data)
             for arg in ctx.attr.install_args
         ])
 
@@ -251,7 +250,7 @@ def _create_configure_script(configureParameters):
             config = configuration,
         ))
 
-    prefix = expand_locations(ctx, {"prefix": attrs.tool_prefix}, data)["prefix"] if attrs.tool_prefix else ""
+    prefix = expand_locations_and_make_variables(ctx, attrs.tool_prefix, "tool_prefix", data) if attrs.tool_prefix else ""
 
     configure_script = create_cmake_script(
         workspace_name = ctx.workspace_name,

--- a/foreign_cc/cmake.bzl
+++ b/foreign_cc/cmake.bzl
@@ -263,7 +263,7 @@ def _create_configure_script(configureParameters):
         root = root,
         no_toolchain_file = no_toolchain_file,
         user_cache = dict(ctx.attr.cache_entries),
-        user_env = expand_locations_and_make_variables(ctx, "env", data),
+        user_env = expand_locations_and_make_variables(ctx, ctx.attr.env, "env", data),
         options = attrs.generate_args,
         cmake_commands = cmake_commands,
         cmake_prefix = prefix,

--- a/foreign_cc/configure.bzl
+++ b/foreign_cc/configure.bzl
@@ -75,7 +75,7 @@ def _create_configure_script(configureParameters):
         for arg in ctx.attr.args
     ])
 
-    user_env = expand_locations_and_make_variables(ctx, "env", data)
+    user_env = expand_locations_and_make_variables(ctx, ctx.attr.env, "env", data)
 
     make_commands = []
     prefix = "{} ".format(expand_locations(ctx, attrs.tool_prefix, data)) if attrs.tool_prefix else ""

--- a/foreign_cc/configure.bzl
+++ b/foreign_cc/configure.bzl
@@ -16,7 +16,6 @@ load(
     "CC_EXTERNAL_RULE_FRAGMENTS",
     "cc_external_rule_impl",
     "create_attrs",
-    "expand_locations",
     "expand_locations_and_make_variables",
 )
 load("//foreign_cc/private:transitions.bzl", "make_variant")
@@ -78,8 +77,8 @@ def _create_configure_script(configureParameters):
     user_env = expand_locations_and_make_variables(ctx, ctx.attr.env, "env", data)
 
     make_commands = []
-    prefix = "{} ".format(expand_locations(ctx, attrs.tool_prefix, data)) if attrs.tool_prefix else ""
-    configure_prefix = "{} ".format(expand_locations(ctx, ctx.attr.configure_prefix, data)) if ctx.attr.configure_prefix else ""
+    prefix = "{} ".format(expand_locations_and_make_variables(ctx, attrs.tool_prefix, "tool_prefix", data)) if attrs.tool_prefix else ""
+    configure_prefix = "{} ".format(expand_locations_and_make_variables(ctx, ctx.attr.configure_prefix, "configure_prefix", data)) if ctx.attr.configure_prefix else ""
 
     for target in ctx.attr.targets:
         # Configure will have generated sources into `$BUILD_TMPDIR` so make sure we `cd` there

--- a/foreign_cc/make.bzl
+++ b/foreign_cc/make.bzl
@@ -15,7 +15,7 @@ load(
     "CC_EXTERNAL_RULE_FRAGMENTS",
     "cc_external_rule_impl",
     "create_attrs",
-    "expand_locations",
+    "expand_locations_and_make_variables",
 )
 load("//foreign_cc/private:make_script.bzl", "create_make_script")
 load("//foreign_cc/private:transitions.bzl", _make_variant = "make_variant")
@@ -53,10 +53,10 @@ def _create_make_script(configureParameters):
         for arg in ctx.attr.args
     ])
 
-    user_env = expand_locations(ctx, ctx.attr.env, data)
+    user_env = expand_locations_and_make_variables(ctx, ctx.attr.env, "env", data)
 
     make_commands = []
-    prefix = "{} ".format(expand_locations(ctx, attrs.tool_prefix, data)) if attrs.tool_prefix else ""
+    prefix = "{} ".format(expand_locations_and_make_variables(ctx, attrs.tool_prefix, "tool_prefix", data)) if attrs.tool_prefix else ""
     for target in ctx.attr.targets:
         make_commands.append("{prefix}{make} -C $$BUILD_TMPDIR$$ {target} {args} PREFIX={install_prefix}".format(
             prefix = prefix,

--- a/foreign_cc/ninja.bzl
+++ b/foreign_cc/ninja.bzl
@@ -10,7 +10,7 @@ load(
     "CC_EXTERNAL_RULE_FRAGMENTS",
     "cc_external_rule_impl",
     "create_attrs",
-    "expand_locations",
+    "expand_locations_and_make_variables",
 )
 load("//toolchains/native_tools:tool_access.bzl", "get_ninja_data")
 
@@ -66,7 +66,7 @@ def _create_ninja_script(configureParameters):
     if ctx.attr.directory:
         directory = ctx.expand_location(ctx.attr.directory, data)
 
-    prefix = "{} ".format(expand_locations(ctx, attrs.tool_prefix, data)) if attrs.tool_prefix else ""
+    prefix = "{} ".format(expand_locations_and_make_variables(ctx, attrs.tool_prefix, "tool_prefix", data)) if attrs.tool_prefix else ""
 
     # Generate commands for all the targets, ensuring there's
     # always at least 1 call to the default target.

--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -942,7 +942,7 @@ def expand_locations_and_make_variables(ctx, unexpanded, attr_name, data):
     Returns:
         (dict, list, str): expandable with locations and make variables expanded (does not apply to the keys of a dict)
     """
-    location_expanded = expand_locations(ctx, unexpanded, data)
+    location_expanded = _expand_locations(ctx, unexpanded, data)
 
     if type(location_expanded) == type(dict()):
         return {key: _expand_make_variables_in_string(ctx, value, attr_name) for key, value in location_expanded.items()}
@@ -958,7 +958,7 @@ def _expand_make_variables_in_string(ctx, expandable, attr_name):
     # Double-escape $s which we insert in expand_locations.
     return ctx.expand_make_variables(attr_name, expandable.replace("$$EXT_BUILD_ROOT$$", "$$$$EXT_BUILD_ROOT$$$$"), {})
 
-def expand_locations(ctx, expandable, data):
+def _expand_locations(ctx, expandable, data):
     """Expand locations on a dictionary while ensuring `execpath` is always set to an absolute path
 
     This function is not expected to be passed to any action.env argument but instead rendered into


### PR DESCRIPTION
This fixes #857 fundamentally by adressing the root cause - `expand_locations` can't be applied to a shell command fragment by itself as it doesn't unescape `$$`.

I divided this PR into individual commits with more detailed commit messages to make the review easier, but feel free to squash them in the end if that's your preferred workflow.