### PR TITLE
Remove arbitrary limits in Starlark "while" loops

### DIFF
--- a/foreign_cc/private/framework/helpers.bzl
+++ b/foreign_cc/private/framework/helpers.bzl
@@ -123,8 +123,7 @@ def replace_var_ref(text, shell_context):
     parts = []
     current = text
 
-    # long enough
-    for i in range(1, 100):
+    for i in range(2147483647):
         (before, varname, after) = extract_wrapped(current, "$$")
         if not varname:
             parts.append(current)
@@ -199,8 +198,7 @@ def split_arguments(text):
     parts = []
     current = text.strip(" ")
 
-    # long enough
-    for i in range(1, 100):
+    for i in range(1, 2147483647):
         if not current:
             break
 


### PR DESCRIPTION
These loops are essentially while loops and have reasonable exit conditions, so there is no reason to arbitrarily limit the range.

There is precedent for this number at:
https://github.com/bazelbuild/bazel/blob/f802525ad37e4f4567103682244d65f6cc55ff57/src/main/starlark/builtins_bzl/common/cc/experimental_cc_shared_library.bzl#L78

Related to #857