### PR TITLE
Set CMAKE_OSX_ARCHITECTURES to target architecture

### DIFF
--- a/examples/third_party/WORKSPACE.bazel
+++ b/examples/third_party/WORKSPACE.bazel
@@ -17,39 +17,3 @@ local_repository(
 load("//:repositories.bzl", "repositories")
 
 repositories()
-
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-http_archive(
-    name = "build_bazel_rules_apple",
-    sha256 = "0052d452af7742c8f3a4e0929763388a66403de363775db7e90adecb2ba4944b",
-    url = "https://github.com/bazelbuild/rules_apple/releases/download/0.31.3/rules_apple.0.31.3.tar.gz",
-)
-
-load(
-    "@build_bazel_rules_apple//apple:repositories.bzl",
-    "apple_rules_dependencies",
-)
-
-apple_rules_dependencies()
-
-load(
-    "@build_bazel_rules_swift//swift:repositories.bzl",
-    "swift_rules_dependencies",
-)
-
-swift_rules_dependencies()
-
-load(
-    "@build_bazel_rules_swift//swift:extras.bzl",
-    "swift_rules_extra_dependencies",
-)
-
-swift_rules_extra_dependencies()
-
-load(
-    "@build_bazel_apple_support//lib:repositories.bzl",
-    "apple_support_dependencies",
-)
-
-apple_support_dependencies()

--- a/examples/third_party/cares/BUILD.bazel
+++ b/examples/third_party/cares/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_build_test")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
 cc_test(
@@ -15,10 +15,17 @@ cc_library(
     deps = ["@cares"],
 )
 
-ios_build_test(
-    name = "test_c_ares_ios",
+apple_binary(
+    name = "ios_binary",
     minimum_os_version = "12.0",
+    platform_type = "ios",
+    deps = [":ios_lib"],
+)
+
+build_test(
+    name = "test_c_ares_ios",
     tags = ["manual"],
-    targets = ["ios_lib"],
+    target_compatible_with = ["@platforms//os:macos"],
+    targets = ["ios_binary"],
     visibility = ["//:__pkg__"],
 )

--- a/foreign_cc/built_tools/private/built_tools_framework.bzl
+++ b/foreign_cc/built_tools/private/built_tools_framework.bzl
@@ -27,6 +27,7 @@ FOREIGN_CC_BUILT_TOOLS_ATTRS = {
 
 # Common fragments for all built_tool rules
 FOREIGN_CC_BUILT_TOOLS_FRAGMENTS = [
+    "apple",
     "cpp",
 ]
 

--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -217,6 +217,7 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
 
 # A list of common fragments required by rules using this framework
 CC_EXTERNAL_RULE_FRAGMENTS = [
+    "apple",
     "cpp",
 ]
 
@@ -306,6 +307,7 @@ def get_env_prelude(ctx, lib_name, data_dependencies, target_root):
             "export DEVELOPER_DIR=\"$developer_dir_tmp\"",
             "sdkroot_tmp=\"$(xcrun --sdk {} --show-sdk-path)\"".format(sdk),
             "export SDKROOT=\"$sdkroot_tmp\"",
+            "export CMAKE_OSX_ARCHITECTURES={}".format(ctx.fragments.apple.single_arch_cpu),
         ])
 
     cc_toolchain = find_cpp_toolchain(ctx)


### PR DESCRIPTION
This fixes a bug where on M1 macOS machines, when building for the
x86_64 iOS simulator, the cmake dependencies were building for arm64
instead, _if_ you had `/usr/sbin` in your `$PATH` used with bazel. The
issue is that cmake calls `/usr/sbin/sysctl` to determine the host
architecture:

https://gitlab.kitware.com/cmake/cmake/-/blob/6453bd046ef23798c64333042d76851f15eff2fc/Modules/Platform/Darwin-Initialize.cmake#L23-41

And then it uses that computed value here if no other archs are set:

https://gitlab.kitware.com/cmake/cmake/-/blob/6453bd046ef23798c64333042d76851f15eff2fc/Source/cmGeneratorTarget.cxx#L3378-3399

As far as I can tell this is a mismatch in expectation between how we
call cmake vs how you would normally call it for cross compilation since
we do not set `CMAKE_SYSTEM_NAME` https://github.com/bazelbuild/rules_foreign_cc/pull/523

By setting `CMAKE_OSX_ARCHITECTURES` ourselves to the target arch, we
stop cmake from checking this default value. To get the target arch we
use the Apple fragment, which as far as I can tell is the only way to
get this from a bazel API. Alternatively we could theoretically parse
the command line args and extract the arch from the `-target` but that
felt more fragile. This option is ignored on non-Apple platforms, and
it's conditional on bazel's Apple logic, so it shouldn't affect any
other cases.

This also updates the Apple related test to catch this case, which
requires linking, which the ios_build_test was not doing. For now it
also uses apple_binary to force the transition, which means rules_apple
isn't required.