### PR TITLE
Upgrade rules_apple to 0.34.0

### DIFF
--- a/examples/WORKSPACE.bazel
+++ b/examples/WORKSPACE.bazel
@@ -60,8 +60,8 @@ rbe_autoconfig(name = "buildkite_config")
 
 http_archive(
     name = "build_bazel_rules_apple",
-    sha256 = "0052d452af7742c8f3a4e0929763388a66403de363775db7e90adecb2ba4944b",
-    url = "https://github.com/bazelbuild/rules_apple/releases/download/0.31.3/rules_apple.0.31.3.tar.gz",
+    sha256 = "4161b2283f80f33b93579627c3bd846169b2d58848b0ffb29b5d4db35263156a",
+    url = "https://github.com/bazelbuild/rules_apple/releases/download/0.34.0/rules_apple.0.34.0.tar.gz",
 )
 
 load(

--- a/examples/third_party/cares/BUILD.bazel
+++ b/examples/third_party/cares/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@build_bazel_rules_apple//apple:apple_binary.bzl", "apple_binary")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 

--- a/examples/third_party/cares/BUILD.bazel
+++ b/examples/third_party/cares/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@build_bazel_rules_apple//apple:apple_binary.bzl", "apple_binary")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@build_bazel_rules_apple//apple:apple_binary.bzl", "apple_binary")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
 cc_test(


### PR DESCRIPTION
This version of rules_apple comes with the Starlark version of the apple_binary rule, whose native equivalent has been removed from Bazel after 5.1.
As a result, this commit will fix the following breakage on Bazel CI with Bazel @ HEAD:

https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/2442#eca49979-d494-4c9b-921d-3faebd957fa4