### PR TITLE
Fix ninja bootstrap on macOS 12.3+

### DIFF
--- a/foreign_cc/built_tools/ninja_build.bzl
+++ b/foreign_cc/built_tools/ninja_build.bzl
@@ -11,7 +11,8 @@ load("//foreign_cc/private/framework:platform.bzl", "os_name")
 
 def _ninja_tool_impl(ctx):
     script = [
-        "./configure.py --bootstrap",
+        # TODO: Drop custom python3 usage https://github.com/ninja-build/ninja/pull/2118
+        "python3 ./configure.py --bootstrap",
         "mkdir $$INSTALLDIR$$/bin",
         "cp -p ./ninja{} $$INSTALLDIR$$/bin/".format(
             ".exe" if "win" in os_name(ctx) else "",


### PR DESCRIPTION
macOS 12.3 removed /usr/bin/python, which is what's currently in the
shebang of ninja's configure.py. This forces us to run this with python3
instead.

This can be removed if https://github.com/ninja-build/ninja/pull/2118 is merged