### PR TITLE
Build cmake in parallel

### DIFF
--- a/foreign_cc/built_tools/cmake_build.bzl
+++ b/foreign_cc/built_tools/cmake_build.bzl
@@ -5,12 +5,17 @@ load("//foreign_cc:defs.bzl", "configure_make")
 def cmake_tool(name, srcs, **kwargs):
     tags = ["manual"] + kwargs.pop("tags", [])
 
+    parallelism = 16
+    conf_opts = ["--parallel=%d" % parallelism]
+    make_opts = ["-j%d" % parallelism]
+
     configure_make(
         name = "{}.build".format(name),
         configure_command = "bootstrap",
-        configure_options = ["--", "-DCMAKE_MAKE_PROGRAM=$$MAKE$$"],
+        configure_options = conf_opts + ["--", "-DCMAKE_MAKE_PROGRAM=$$MAKE$$"],
         # On macOS at least -DDEBUG gets set for a fastbuild
         copts = ["-UDEBUG"],
+        args = make_opts,
         lib_source = srcs,
         out_binaries = select({
             "@platforms//os:windows": ["cmake.exe"],


### PR DESCRIPTION
Without running the build in parallel, it takes forever. Most modern
machines have many cores, and for those that do not, the overhead will
probably not be that large. Most systems will likely use the prebuilt
toolchain anyway.