### PR TITLE
Don't load examples dependencies from main WORKSPACE

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -10,18 +10,6 @@ local_repository(
     path = "examples",
 )
 
-load("@rules_foreign_cc_examples//deps:repositories.bzl", examples_repositories = "repositories")
-
-examples_repositories()
-
-load("@rules_foreign_cc_examples//deps:deps_android.bzl", examples_deps_android = "deps_android")
-
-examples_deps_android()
-
-load("@rules_foreign_cc_examples//deps:deps_jvm_external.bzl", examples_deps_jvm_external = "deps_jvm_external")
-
-examples_deps_jvm_external()
-
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()


### PR DESCRIPTION
We don't configure all the dependencies correctly to be able to run the examples from the main WORKSPACE so don't setup any of the dependencies there.