### PR TITLE
Faciliate usage of jom

### DIFF
--- a/foreign_cc/configure.bzl
+++ b/foreign_cc/configure.bzl
@@ -82,7 +82,7 @@ def _create_configure_script(configureParameters):
 
     for target in ctx.attr.targets:
         # Configure will have generated sources into `$BUILD_TMPDIR` so make sure we `cd` there
-        make_commands.append("{prefix}{make} -C $$BUILD_TMPDIR$$ {target} {args}".format(
+        make_commands.append("{prefix}{make} {target} {args}".format(
             prefix = prefix,
             make = attrs.make_path,
             args = args,

--- a/foreign_cc/make.bzl
+++ b/foreign_cc/make.bzl
@@ -58,7 +58,7 @@ def _create_make_script(configureParameters):
     make_commands = []
     prefix = "{} ".format(expand_locations_and_make_variables(ctx, attrs.tool_prefix, "tool_prefix", data)) if attrs.tool_prefix else ""
     for target in ctx.attr.targets:
-        make_commands.append("{prefix}{make} -C $$BUILD_TMPDIR$$ {target} {args} PREFIX={install_prefix}".format(
+        make_commands.append("{prefix}{make} {target} {args} PREFIX={install_prefix}".format(
             prefix = prefix,
             make = attrs.make_path,
             args = args,


### PR DESCRIPTION
The jom tool (a fork of nmake which supports parallel builds) does not
support the "-C dir" arg. Given that the build script generated by
rules_foreign_cc changes the working directory to $BUILD_TMPDIR before
invoking make/nmake/jom, there is no need to add the "-C $BUILD_TMPDIR"
arg. This commit removes the addition of the "-C $BUILD_TMPDIR" arg so
that jom can be used as a make variant.