### PR TITLE
Hermetic ninja build

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -24,6 +24,13 @@ http_archive(
     ],
 )
 
+load("@rules_python//python:repositories.bzl", "python_register_toolchains")
+
+python_register_toolchains(
+    name = "python3_9",
+    python_version = "3.9",
+)
+
 load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
 
 # Creates a default toolchain config for RBE.

--- a/foreign_cc/built_tools/make_build.bzl
+++ b/foreign_cc/built_tools/make_build.bzl
@@ -6,11 +6,11 @@ load(
     "FOREIGN_CC_BUILT_TOOLS_ATTRS",
     "FOREIGN_CC_BUILT_TOOLS_FRAGMENTS",
     "FOREIGN_CC_BUILT_TOOLS_HOST_FRAGMENTS",
+    "absolutize",
     "built_tool_rule_impl",
 )
 load(
     "//foreign_cc/private:cc_toolchain_util.bzl",
-    "absolutize_path_in_str",
     "get_env_vars",
     "get_flags_info",
     "get_tools_info",
@@ -55,10 +55,10 @@ def _make_tool_impl(ctx):
 
         # Make's build script does not forward CFLAGS to all compiler and linker
         # invocations, so we append --sysroot flags directly to CC and LD.
-        absolute_cc = _absolutize(ctx.workspace_name, cc_path, True)
+        absolute_cc = absolutize(ctx.workspace_name, cc_path, True)
         if sysroot_cflags:
             absolute_cc += " " + _join_flags_list(ctx.workspace_name, sysroot_cflags)
-        absolute_ld = _absolutize(ctx.workspace_name, ld_path, True)
+        absolute_ld = absolutize(ctx.workspace_name, ld_path, True)
         if sysroot_ldflags:
             absolute_ld += " " + _join_flags_list(ctx.workspace_name, sysroot_ldflags)
 
@@ -66,7 +66,7 @@ def _make_tool_impl(ctx):
         # "-o". Since the make Makefile only uses ar-style invocations, the
         # output file always comes first and we can append this argument to the
         # flags list.
-        absolute_ar = _absolutize(ctx.workspace_name, ar_path, True)
+        absolute_ar = absolutize(ctx.workspace_name, ar_path, True)
         arflags = [e for e in frozen_arflags]
         if absolute_ar == "libtool" or absolute_ar.endswith("/libtool"):
             arflags.append("-o")
@@ -111,8 +111,5 @@ make_tool = rule(
     ],
 )
 
-def _absolutize(workspace_name, text, force = False):
-    return absolutize_path_in_str(workspace_name, "$$EXT_BUILD_ROOT$$/", text, force)
-
 def _join_flags_list(workspace_name, flags):
-    return " ".join([_absolutize(workspace_name, flag) for flag in flags])
+    return " ".join([absolutize(workspace_name, flag) for flag in flags])

--- a/foreign_cc/built_tools/ninja_build.bzl
+++ b/foreign_cc/built_tools/ninja_build.bzl
@@ -5,14 +5,23 @@ load(
     "FOREIGN_CC_BUILT_TOOLS_ATTRS",
     "FOREIGN_CC_BUILT_TOOLS_FRAGMENTS",
     "FOREIGN_CC_BUILT_TOOLS_HOST_FRAGMENTS",
+    "absolutize",
     "built_tool_rule_impl",
 )
 load("//foreign_cc/private/framework:platform.bzl", "os_name")
 
 def _ninja_tool_impl(ctx):
+    py_toolchain = ctx.toolchains["@rules_python//python:toolchain_type"]
+
+    additional_tools = depset(
+        [py_toolchain.py3_runtime.interpreter],
+        transitive = [py_toolchain.py3_runtime.files],
+    )
+
+    absolute_py_interpreter_path = absolutize(ctx.workspace_name, py_toolchain.py3_runtime.interpreter.path, True)
+
     script = [
-        # TODO: Drop custom python3 usage https://github.com/ninja-build/ninja/pull/2118
-        "python3 ./configure.py --bootstrap",
+        "{} ./configure.py --bootstrap".format(absolute_py_interpreter_path),
         "mkdir $$INSTALLDIR$$/bin",
         "cp -p ./ninja{} $$INSTALLDIR$$/bin/".format(
             ".exe" if "win" in os_name(ctx) else "",
@@ -24,6 +33,7 @@ def _ninja_tool_impl(ctx):
         script,
         ctx.actions.declare_directory("ninja"),
         "BootstrapNinjaBuild",
+        additional_tools,
     )
 
 ninja_tool = rule(
@@ -36,5 +46,6 @@ ninja_tool = rule(
     toolchains = [
         "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
         "@bazel_tools//tools/cpp:toolchain_type",
+        "@rules_python//python:toolchain_type",
     ],
 )

--- a/foreign_cc/built_tools/private/built_tools_framework.bzl
+++ b/foreign_cc/built_tools/private/built_tools_framework.bzl
@@ -1,6 +1,7 @@
 """A module defining a common framework for "built_tools" rules"""
 
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("//foreign_cc/private:cc_toolchain_util.bzl", "absolutize_path_in_str")
 load("//foreign_cc/private:detect_root.bzl", "detect_root")
 load("//foreign_cc/private:framework.bzl", "get_env_prelude", "wrap_outputs")
 load("//foreign_cc/private/framework:helpers.bzl", "convert_shell_script", "shebang")
@@ -35,6 +36,9 @@ FOREIGN_CC_BUILT_TOOLS_FRAGMENTS = [
 FOREIGN_CC_BUILT_TOOLS_HOST_FRAGMENTS = [
     "cpp",
 ]
+
+def absolutize(workspace_name, text, force = False):
+    return absolutize_path_in_str(workspace_name, "$$EXT_BUILD_ROOT$$/", text, force)
 
 def built_tool_rule_impl(ctx, script_lines, out_dir, mnemonic):
     """Framework function for bootstrapping C/C++ build tools.

--- a/foreign_cc/built_tools/private/built_tools_framework.bzl
+++ b/foreign_cc/built_tools/private/built_tools_framework.bzl
@@ -40,7 +40,7 @@ FOREIGN_CC_BUILT_TOOLS_HOST_FRAGMENTS = [
 def absolutize(workspace_name, text, force = False):
     return absolutize_path_in_str(workspace_name, "$$EXT_BUILD_ROOT$$/", text, force)
 
-def built_tool_rule_impl(ctx, script_lines, out_dir, mnemonic):
+def built_tool_rule_impl(ctx, script_lines, out_dir, mnemonic, additional_tools = None):
     """Framework function for bootstrapping C/C++ build tools.
 
     This macro should be shared by all "built-tool" rules defined in rules_foreign_cc.
@@ -52,6 +52,7 @@ def built_tool_rule_impl(ctx, script_lines, out_dir, mnemonic):
         script_lines (list): A list of lines of a bash script for building the build tool
         out_dir (File): The output directory of the build tool
         mnemonic (str): The mnemonic of the build action
+        additional_tools (depset): A list of additional tools to include in the build action
 
     Returns:
         list: A list of providers
@@ -92,6 +93,9 @@ def built_tool_rule_impl(ctx, script_lines, out_dir, mnemonic):
         [wrapped_outputs.wrapper_script_file, wrapped_outputs.script_file],
         transitive = [cc_toolchain.all_files],
     )
+
+    if additional_tools:
+        tools = depset(transitive = [tools, additional_tools])
 
     # The use of `run_shell` here is intended to ensure bash is correctly setup on windows
     # environments. This should not be replaced with `run` until a cross platform implementation

--- a/foreign_cc/repositories.bzl
+++ b/foreign_cc/repositories.bzl
@@ -81,3 +81,11 @@ def rules_foreign_cc_dependencies(
         ],
         sha256 = "f7be3474d42aae265405a592bb7da8e171919d74c16f082a5457840f06054728",
     )
+
+    maybe(
+        http_archive,
+        name = "rules_python",
+        sha256 = "5fa3c738d33acca3b97622a13a741129f67ef43f5fdfcec63b29374cc0574c29",
+        strip_prefix = "rules_python-0.9.0",
+        url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.9.0.tar.gz",
+    )


### PR DESCRIPTION
 Use python toolchain when building ninja

This allows for a hermetic build of ninja by using a hermetic python
toolchain, like the one provided by the python_register_toolchains macro
in rules_python.