### PR TITLE
Add ability to specify DLL dir

### DIFF
--- a/examples/cmake_hello_world_lib/shared/BUILD.bazel
+++ b/examples/cmake_hello_world_lib/shared/BUILD.bazel
@@ -18,16 +18,14 @@ cmake(
         "CMAKE_MACOSX_RPATH": "True",
     },
     lib_source = ":srcs",
+    out_interface_libs = select({
+        "//:windows": ["libhello.lib"],
+        "//conditions:default": [],
+    }),
     out_shared_libs = select({
         "//:macos": ["libhello.dylib"],
         "//:windows": ["libhello.dll"],
         "//conditions:default": ["libhello.so"],
-    }),
-    # TODO: The `.dll` is installed in the `bin` directory. To account for this, windows
-    # moves it to the `lib` directory. The rules should account for this case.
-    postfix_script = select({
-        "//:windows": "cp -p $$INSTALLDIR$$/bin/libhello.dll $$INSTALLDIR$$/lib",
-        "//conditions:default": None,
     }),
 )
 

--- a/examples/cmake_hello_world_lib/shared/CMakeLists.txt
+++ b/examples/cmake_hello_world_lib/shared/CMakeLists.txt
@@ -3,6 +3,8 @@
 
 cmake_minimum_required(VERSION 2.8.4)
 
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
 project(hellolib LANGUAGES C)
 
 add_subdirectory(src)

--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -151,6 +151,11 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
         doc = "Optional names of additional directories created by the build that should be declared as bazel action outputs",
         mandatory = False,
     ),
+    "out_dll_dir": attr.string(
+        doc = "Optional name of the output subdirectory with the dll files, defaults to 'bin'.",
+        mandatory = False,
+        default = "bin",
+    ),
     "out_headers_only": attr.bool(
         doc = "Flag variable to indicate that the library produces only headers",
         mandatory = False,
@@ -493,6 +498,7 @@ def cc_external_rule_impl(ctx, attrs):
     externally_built = ForeignCcArtifactInfo(
         gen_dir = installdir_copy.file,
         bin_dir_name = attrs.out_bin_dir,
+        dll_dir_name = attrs.out_dll_dir,
         lib_dir_name = attrs.out_lib_dir,
         include_dir_name = attrs.out_include_dir,
     )
@@ -732,7 +738,7 @@ def _define_outputs(ctx, attrs, lib_name):
 
     libraries = LibrariesToLinkInfo(
         static_libraries = _declare_out(ctx, lib_name, attrs.out_lib_dir, static_libraries),
-        shared_libraries = _declare_out(ctx, lib_name, attrs.out_lib_dir, attr_shared_libs),
+        shared_libraries = _declare_out(ctx, lib_name, attrs.out_dll_dir if targets_windows(ctx, None) else attrs.out_lib_dir, attr_shared_libs),
         interface_libraries = _declare_out(ctx, lib_name, attrs.out_lib_dir, attr_interface_libs),
     )
 

--- a/foreign_cc/providers.bzl
+++ b/foreign_cc/providers.bzl
@@ -17,6 +17,7 @@ Can not be used as a top-level provider.
 Instances of ForeignCcArtifactInfo are encapsulated in a depset [ForeignCcDepsInfo::artifacts](#ForeignCcDepsInfo-artifacts).""",
     fields = {
         "bin_dir_name": "Bin directory, relative to install directory",
+        "dll_dir_name": "DLL directory, relative to install directory",
         "gen_dir": "Install directory",
         "include_dir_name": "Include directory, relative to install directory",
         "lib_dir_name": "Lib directory, relative to install directory",


### PR DESCRIPTION
C/C++ projects typically install DLLs in the "bin" folder and the
associated interface library in the "lib" folder. This commit changes
the default behaviour accordingly.

The now redundant postfix script in the cmake_hello_world_lib shared test has been removed. The test was also previously broken as no interface library was generated. This commit resolves that issue