### PR TITLE
Expand variables in `configure_options`

### DIFF
--- a/foreign_cc/configure.bzl
+++ b/foreign_cc/configure.bzl
@@ -96,7 +96,7 @@ def _create_configure_script(configureParameters):
         tools = tools,
         flags = flags,
         root = detect_root(ctx.attr.lib_source),
-        user_options = ctx.attr.configure_options,
+        user_options = expand_locations_and_make_variables(ctx, ctx.attr.configure_options, "configure_options", data),
         is_debug = is_debug_mode(ctx),
         configure_prefix = configure_prefix,
         configure_command = ctx.attr.configure_command,


### PR DESCRIPTION
For cross compiling ffmpeg, I needed to supply the compiler as an argument to `configure`. That is why I needed to add variable expansion to `configure_options` of `configure_make` rule.
```
configure_make(
  ...
  configure_options = [
    ...
    "--cc=$(CC)",
  ]
)
```