### PR TITLE
Disable cc toolchain resolution in examples on Mac

### DIFF
--- a/.bazelci/config.yaml
+++ b/.bazelci/config.yaml
@@ -78,11 +78,13 @@ tasks:
       - "dbg"
       - "--spawn_strategy=standalone"
       - "-k"
+      - "--noincompatible_enable_cc_toolchain_resolution"
     test_targets: *macos_targets_standalone
     test_flags:
       - "-c"
       - "dbg"
       - "--spawn_strategy=standalone"
+      - "--noincompatible_enable_cc_toolchain_resolution"
   macos_examples:
     name: Examples
     platform: macos
@@ -91,7 +93,11 @@ tasks:
       - "//..."
       - "//:third_party_examples_macos_tests"
     build_targets: *macos_targets
+    build_flags:
+      - "--noincompatible_enable_cc_toolchain_resolution"
     test_targets: *macos_targets
+    test_flags:
+      - "--noincompatible_enable_cc_toolchain_resolution"
   windows_examples:
     name: Examples
     platform: windows


### PR DESCRIPTION
The examples/cmake_android picks up local instead of Android Cc toolchains.