### PR TITLE
[configure_make] Add --prefix after user flags

### DIFF
--- a/foreign_cc/private/configure_script.bzl
+++ b/foreign_cc/private/configure_script.bzl
@@ -70,7 +70,7 @@ def create_configure_script(
         ).lstrip())
 
     script.append("##mkdirs## $$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$")
-    script.append("{env_vars} {prefix}\"{configure}\" --prefix=$$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$ {user_options}".format(
+    script.append("{env_vars} {prefix}\"{configure}\" {user_options} --prefix=$$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$".format(
         env_vars = get_make_env_vars(workspace_name, tools, flags, env_vars, deps, inputs),
         prefix = configure_prefix,
         configure = configure_path,


### PR DESCRIPTION
Projects like ICU uses a custom configure script that accepts regular configure flags **after** the ICU specific flags.

foreign_cc was prepending the `--prefix` flag before the user flags. In this change we do the opposite so that we can accommodate scripts accepting regular configure flags at the end.

See https://github.com/unicode-org/icu/blob/main/icu4c/source/runConfigureICU#L23