### PR TITLE
Add prefix flag config option to make_configure

### DIFF
--- a/foreign_cc/configure.bzl
+++ b/foreign_cc/configure.bzl
@@ -104,6 +104,7 @@ def _create_configure_script(configureParameters):
         inputs = inputs,
         env_vars = user_env,
         configure_in_place = ctx.attr.configure_in_place,
+        prefix_flag = ctx.attr.prefix_flag,
         autoconf = ctx.attr.autoconf,
         autoconf_options = ctx.attr.autoconf_options,
         autoreconf = ctx.attr.autoreconf,
@@ -194,9 +195,16 @@ def _attrs():
         "install_prefix": attr.string(
             doc = (
                 "Install prefix, i.e. relative path to where to install the result of the build. " +
-                "Passed to the 'configure' script with --prefix flag."
+                "Passed to the 'configure' script with the flag specified by prefix_flag."
             ),
             mandatory = False,
+        ),
+        "prefix_flag": attr.string(
+            doc = (
+                "The flag to specify the install directory prefix with."
+            ),
+            mandatory = False,
+            default = "--prefix=",
         ),
         "targets": attr.string_list(
             doc = (

--- a/foreign_cc/private/configure_script.bzl
+++ b/foreign_cc/private/configure_script.bzl
@@ -17,6 +17,7 @@ def create_configure_script(
         inputs,
         env_vars,
         configure_in_place,
+        prefix_flag,
         autoconf,
         autoconf_options,
         autoreconf,
@@ -70,10 +71,11 @@ def create_configure_script(
         ).lstrip())
 
     script.append("##mkdirs## $$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$")
-    script.append("{env_vars} {prefix}\"{configure}\" --prefix=$$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$ {user_options}".format(
+    script.append("{env_vars} {prefix}\"{configure}\" {prefix_flag}$$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$ {user_options}".format(
         env_vars = get_make_env_vars(workspace_name, tools, flags, env_vars, deps, inputs),
         prefix = configure_prefix,
         configure = configure_path,
+        prefix_flag = prefix_flag,
         user_options = " ".join(user_options),
     ))
 


### PR DESCRIPTION
Certain configure scripts use a different flag instead of '--prefix', such as
Perl using '-Dprefix='.