### PR TITLE
Add toolchain executables to the PATH

### DIFF
--- a/foreign_cc/built_tools/pkgconfig_build.bzl
+++ b/foreign_cc/built_tools/pkgconfig_build.bzl
@@ -18,7 +18,7 @@ def _pkgconfig_tool_impl(ctx):
         "%s install" % make_data.path,
     ]
 
-    additional_tools = depset(transitive = [dep.files for dep in make_data.deps])
+    additional_tools = depset(transitive = [make_data.target.files])
 
     return built_tool_rule_impl(
         ctx,

--- a/foreign_cc/cmake.bzl
+++ b/foreign_cc/cmake.bzl
@@ -159,21 +159,18 @@ load(
 def _cmake_impl(ctx):
     cmake_data = get_cmake_data(ctx)
 
-    tools_deps = cmake_data.deps
-
-    # TODO: `tool_deps` is deprecated. Remove
-    tools_deps += ctx.attr.tools_deps
+    tools_data = [cmake_data]
 
     env = dict(ctx.attr.env)
 
     generator, generate_args = _get_generator_target(ctx)
     if "Unix Makefiles" == generator:
         make_data = get_make_data(ctx)
-        tools_deps.extend(make_data.deps)
+        tools_data.append(make_data)
         generate_args.append("-DCMAKE_MAKE_PROGRAM={}".format(make_data.path))
     elif "Ninja" in generator:
         ninja_data = get_ninja_data(ctx)
-        tools_deps.extend(ninja_data.deps)
+        tools_data.append(ninja_data)
         generate_args.append("-DCMAKE_MAKE_PROGRAM={}".format(ninja_data.path))
 
     attrs = create_attrs(
@@ -183,7 +180,7 @@ def _cmake_impl(ctx):
         generate_args = generate_args,
         configure_name = "CMake",
         create_configure_script = _create_configure_script,
-        tools_deps = tools_deps,
+        tools_data = tools_data,
         cmake_path = cmake_data.path,
     )
 

--- a/foreign_cc/configure.bzl
+++ b/foreign_cc/configure.bzl
@@ -26,7 +26,7 @@ def _configure_make(ctx):
     make_data = get_make_data(ctx)
     pkg_config_data = get_pkgconfig_data(ctx)
 
-    tools_deps = ctx.attr.tools_deps + make_data.deps + pkg_config_data.deps
+    tools_data = [make_data, pkg_config_data]
 
     if ctx.attr.autogen and not ctx.attr.configure_in_place:
         fail("`autogen` requires `configure_in_place = True`. Please update {}".format(
@@ -50,7 +50,7 @@ def _configure_make(ctx):
         configure_name = "Configure",
         create_configure_script = _create_configure_script,
         postfix_script = copy_results + "\n" + ctx.attr.postfix_script,
-        tools_deps = tools_deps,
+        tools_data = tools_data,
         make_path = make_data.path,
     )
     return cc_external_rule_impl(ctx, attrs)

--- a/foreign_cc/make.bzl
+++ b/foreign_cc/make.bzl
@@ -24,13 +24,13 @@ load("//toolchains/native_tools:tool_access.bzl", "get_make_data")
 def _make(ctx):
     make_data = get_make_data(ctx)
 
-    tools_deps = ctx.attr.tools_deps + make_data.deps
+    tools_data = [make_data]
 
     attrs = create_attrs(
         ctx.attr,
         configure_name = "Make",
         create_configure_script = _create_make_script,
-        tools_deps = tools_deps,
+        tools_data = tools_data,
         make_path = make_data.path,
     )
     return cc_external_rule_impl(ctx, attrs)

--- a/foreign_cc/ninja.bzl
+++ b/foreign_cc/ninja.bzl
@@ -25,13 +25,13 @@ def _ninja_impl(ctx):
     """
     ninja_data = get_ninja_data(ctx)
 
-    tools_deps = ctx.attr.tools_deps + ninja_data.deps
+    tools_data = [ninja_data]
 
     attrs = create_attrs(
         ctx.attr,
         configure_name = "Ninja",
         create_configure_script = _create_ninja_script,
-        tools_deps = tools_deps,
+        tools_data = tools_data,
         ninja_path = ninja_data.path,
     )
     return cc_external_rule_impl(ctx, attrs)

--- a/toolchains/native_tools/tool_access.bzl
+++ b/toolchains/native_tools/tool_access.bzl
@@ -49,14 +49,14 @@ def _access_and_expect_label_copied(toolchain_type_, ctx):
                 cmd_file = f
                 break
         return struct(
-            deps = [tool_data.target],
+            target = tool_data.target,
             env = tool_data.env,
             # as the tool will be copied into tools directory
             path = "$EXT_BUILD_ROOT/{}".format(cmd_file.path),
         )
     else:
         return struct(
-            deps = [],
+            target = None,
             env = tool_data.env,
             path = tool_data.path,
         )


### PR DESCRIPTION
Previously, some toolchain executables, e.g. make, pkg-config etc. were not added to the PATH correctly. As such, even if make and pkg-config were built from source, the system executables were used.

This commit modifies the tools_files attribute of the rules_foreign_cc framework to instead be "tools_data", which provides path to the executable and the target that provides it.