### PR TITLE
Disable fdo features.

### DIFF
--- a/foreign_cc/private/cc_toolchain_util.bzl
+++ b/foreign_cc/private/cc_toolchain_util.bzl
@@ -41,6 +41,8 @@ CxxFlagsInfo = provider(
 # them here when configuring the toolchain flags to pass to the external
 # build system.
 FOREIGN_CC_DISABLED_FEATURES = [
+    "fdo_instrument",
+    "fdo_optimize",
     "layering_check",
     "module_maps",
     "thin_lto",


### PR DESCRIPTION
fdo_instrument and fdo_optimize features should be disabled. These are not supported by external build systems.