### PR TITLE
Remove tests that depend on shared libraries

### DIFF
--- a/.bazelci/config.yaml
+++ b/.bazelci/config.yaml
@@ -72,6 +72,9 @@ tasks:
     macos_targets: &macos_targets_standalone
       - "//..."
       - "//:third_party_examples_macos_tests"
+      # Remove tests that depend on shared libraries, which currently doesn't work on MacOS - https://github.com/bazelbuild/bazel/issues/10254
+      - "-@rules_foreign_cc_examples_third_party//curl:curl_test"
+      - "-@rules_foreign_cc_examples_third_party//openssl:openssl_test"
     build_targets: *macos_targets_standalone
     build_flags:
       - "-c"
@@ -92,7 +95,7 @@ tasks:
     macos_targets: &macos_targets
       - "//..."
       - "//:third_party_examples_macos_tests"
-      # Remove tests that depend on shared libraries, which currently doesn't work on sandboxed MacOS - https://github.com/bazelbuild/bazel/issues/10254
+      # Remove tests that depend on shared libraries, which currently doesn't work on MacOS - https://github.com/bazelbuild/bazel/issues/10254
       - "-@rules_foreign_cc_examples_third_party//curl:curl_test"
       - "-@rules_foreign_cc_examples_third_party//openssl:openssl_test"
     build_targets: *macos_targets

--- a/examples/third_party/iconv/iconv_repositories.bzl
+++ b/examples/third_party/iconv/iconv_repositories.bzl
@@ -23,7 +23,7 @@ def iconv_repositories():
             "https://opensource.apple.com/tarballs/libiconv/libiconv-59.tar.gz",
         ],
         type = "tar.gz",
-        sha256 = "f7729999a9f2adc8c158012bc4bc8d69bea5dec88c8203cdd62067f91ed60b43",
-        strip_prefix = "libiconv-59/libiconv",
+        sha256 = "975f31be8eb193d5099b5fc4fc343b95c0eb83d59ffa6e5bde9454def2228a53",
+        strip_prefix = "libiconv-libiconv-59/libiconv",
         build_file = Label("//iconv:BUILD.iconv.macos.bazel"),
     )


### PR DESCRIPTION
These tests currently dont work on MacOS