### PR TITLE
Add new darwin CC toolchain for tests

### DIFF
--- a/examples/.bazelrc
+++ b/examples/.bazelrc
@@ -1,4 +1,3 @@
-
 # Required for Windows
 build --enable_runfiles
 
@@ -6,3 +5,9 @@ build --enable_runfiles
 startup --windows_enable_symlinks
 build --action_env=MSYS=winsymlinks:nativestrict
 test --action_env=MSYS=winsymlinks:nativestrict
+
+# Enable CC toolchain that supports iOS from https://github.com/bazelbuild/apple_support
+build --enable_platform_specific_config
+build:macos --apple_crosstool_top=@local_config_apple_cc//:toolchain
+build:macos --crosstool_top=@local_config_apple_cc//:toolchain
+build:macos --host_crosstool_top=@local_config_apple_cc//:toolchain

--- a/examples/WORKSPACE.bazel
+++ b/examples/WORKSPACE.bazel
@@ -58,6 +58,13 @@ rbe_preconfig(
 )
 
 http_archive(
+    name = "build_bazel_apple_support",
+    patches = ["//deps:apple_support.patch"],
+    sha256 = "77a121a0f5d4cd88824429464ad2bfb54bdc8a3bccdb4d31a6c846003a3f5e44",
+    url = "https://github.com/bazelbuild/apple_support/releases/download/1.4.1/apple_support.1.4.1.tar.gz",
+)
+
+http_archive(
     name = "build_bazel_rules_apple",
     sha256 = "12865e5944f09d16364aa78050366aca9dc35a32a018fa35f5950238b08bf744",
     url = "https://github.com/bazelbuild/rules_apple/releases/download/0.34.2/rules_apple.0.34.2.tar.gz",

--- a/examples/deps/apple_support.patch
+++ b/examples/deps/apple_support.patch
@@ -1,0 +1,8 @@
+--- crosstool/setup.bzl
++++ crosstool/setup.bzl
+@@ -66,5 +66,3 @@ def apple_cc_configure():
+ def _apple_cc_configure_extension_impl(_):
+     _apple_cc_autoconf_toolchains(name = "local_config_apple_cc_toolchains")
+     _apple_cc_autoconf(name = "local_config_apple_cc")
+-
+-apple_cc_configure_extension = module_extension(implementation = _apple_cc_configure_extension_impl)


### PR DESCRIPTION
Bazel 7.x is going to remove the CC toolchain that supports iOS and use the unix toolchain for macOS support. Since there are some tests that use the iOS toolchain we need to set that up for testing.