### PR TITLE
Add --sysroot flag to CPPFLAGS

### DIFF
--- a/foreign_cc/private/make_env_vars.bzl
+++ b/foreign_cc/private/make_env_vars.bzl
@@ -27,6 +27,11 @@ def get_make_env_vars(
     # https://www.gnu.org/software/autoconf/manual/autoconf-2.63/html_node/Preset-Output-Variables.html
     vars["CPPFLAGS"] = deps_flags.flags
 
+    # CPPFLAGS needs to have access to the custom sysroot, if one is set.
+    for flag in vars["CFLAGS"]:
+        if flag.startswith("--sysroot="):
+            vars["CPPFLAGS"].append(flag)
+
     return " ".join(["{}=\"{}\""
         .format(key, _join_flags_list(workspace_name, vars[key])) for key in vars])
 


### PR DESCRIPTION
This is needed for hermetic toolchains that specify a sysroot via the "builtin_sysroot" in the
"create_cc_toolchain_config_info" function.

Fixes #985