### PR TITLE
Add the ability to define toolchains that are compiled locally

### DIFF
--- a/foreign_cc/repositories.bzl
+++ b/foreign_cc/repositories.bzl
@@ -16,6 +16,7 @@ def rules_foreign_cc_dependencies(
         register_preinstalled_tools = True,
         register_built_tools = True,
         register_toolchains = True,
+        built_toolchain_no_remote = False,
         register_built_pkgconfig_toolchain = False):
     """Call this function from the WORKSPACE file to initialize rules_foreign_cc \
     dependencies and let neccesary code generation happen \
@@ -49,6 +50,8 @@ def rules_foreign_cc_dependencies(
 
         register_toolchains: If true, registers the toolchains via native.register_toolchains. Used by bzlmod
 
+        built_toolchain_no_remote: If true, build the built toolchain locally. In some cases, remote executors may be FUSE based and not handle system time well
+
         register_built_pkgconfig_toolchain: If true, the built pkgconfig toolchain will be registered. On Windows it may be preferrable to set this to False, as
             this requires the --enable_runfiles bazel option. Also note that building pkgconfig from source under bazel results in paths that are more
             than 256 characters long, which will not work on Windows unless the following options are added to the .bazelrc and symlinks are enabled in Windows.
@@ -74,6 +77,7 @@ def rules_foreign_cc_dependencies(
             pkgconfig_version = pkgconfig_version,
             register_toolchains = register_toolchains,
             register_built_pkgconfig_toolchain = register_built_pkgconfig_toolchain,
+            built_toolchain_no_remote = built_toolchain_no_remote,
         )
 
     if register_preinstalled_tools:

--- a/toolchains/BUILD.bazel
+++ b/toolchains/BUILD.bazel
@@ -298,3 +298,30 @@ bzl_library(
         "//toolchains/native_tools:bzl_srcs",
     ],
 )
+
+# No-remote toolchains
+toolchain(
+    name = "built_make_toolchain_local",
+    toolchain = ":built_make_local",
+    toolchain_type = ":make_toolchain",
+)
+
+make_tool(
+    name = "make_tool_local",
+    srcs = "@gnumake_src//:all_srcs",
+    tags = ["manual", "no-remote-exec"],
+)
+
+native_tool_toolchain(
+    name = "built_make_local",
+    env = select({
+        "@platforms//os:windows": {"MAKE": "$(execpath :make_tool_local)/bin/make.exe"},
+        "//conditions:default": {"MAKE": "$(execpath :make_tool_local)/bin/make"},
+    }),
+    path = select({
+        "@platforms//os:windows": "$(execpath :make_tool_local)/bin/make.exe",
+        "//conditions:default": "$(execpath :make_tool_local)/bin/make",
+    }),
+    target = ":make_tool_local",
+    tags = ["no-remote-exec"]
+)

--- a/toolchains/built_toolchains.bzl
+++ b/toolchains/built_toolchains.bzl
@@ -16,7 +16,7 @@ filegroup(
 """
 
 # buildifier: disable=unnamed-macro
-def built_toolchains(cmake_version, make_version, ninja_version, pkgconfig_version, register_toolchains, register_built_pkgconfig_toolchain):
+def built_toolchains(cmake_version, make_version, ninja_version, pkgconfig_version, register_toolchains, register_built_pkgconfig_toolchain, built_toolchain_no_remote):
     """
     Register toolchains for built tools that will be built from source
 
@@ -33,9 +33,11 @@ def built_toolchains(cmake_version, make_version, ninja_version, pkgconfig_versi
         register_toolchains: If true, registers the toolchains via native.register_toolchains. Used by bzlmod
 
         register_built_pkgconfig_toolchain: If true, the built pkgconfig toolchain will be registered.
+
+        built_toolchain_no_remote: If true, built toolchain will be compiled with tag no-remote-exec
     """
     _cmake_toolchain(cmake_version, register_toolchains)
-    _make_toolchain(make_version, register_toolchains)
+    _make_toolchain(make_version, register_toolchains, built_toolchain_no_remote)
     _ninja_toolchain(ninja_version, register_toolchains)
 
     if register_built_pkgconfig_toolchain:
@@ -64,11 +66,16 @@ def _cmake_toolchain(version, register_toolchains):
 
     fail("Unsupported cmake version: " + str(version))
 
-def _make_toolchain(version, register_toolchains):
+def _make_toolchain(version, register_toolchains, built_toolchain_no_remote):
     if register_toolchains:
-        native.register_toolchains(
-            "@rules_foreign_cc//toolchains:built_make_toolchain",
-        )
+        if built_toolchain_no_remote:
+            native.register_toolchains(
+                "@rules_foreign_cc//toolchains:built_make_toolchain_local",
+            )
+        else:
+            native.register_toolchains(
+                "@rules_foreign_cc//toolchains:built_make_toolchain",
+            )
     if version == "4.4":
         maybe(
             http_archive,


### PR DESCRIPTION


When building make toolchain on remote execution, autoconf has a sanity check which complains due to system clock check. Given that our remote executors are FUSE based, the way to resolve this would be to build the make toolchain which cmake rule is dependent upon to run locally.

ERROR: /home/ryang/.cache/bazel/_bazel_ryang/d74806228f9a8a972e76dd6f55d51b26/external/rules_foreign_cc/toolchains/BUILD.bazel:137:10: BootstrapGNUMake external/rules_foreign_cc/toolchains/make [for tool] failed: (Exit 1): bash failed: error executing command (from target @rules_foreign_cc//toolchains:make_tool) 

```
....
rules_foreign_cc: Build failed!
rules_foreign_cc: Keeping temp build directory and dependencies directory for debug.
rules_foreign_cc: Please note that the directories inside a sandbox are still cleaned unless you specify --sandbox_debug Bazel command line flag.
rules_foreign_cc: Printing build logs:
_____ BEGIN BUILD LOGS _____
+ AR=/usr/bin/ar
+ ARFLAGS=rcsD
+ CC=/usr/bin/gcc
+ CFLAGS='-U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer -g0 -O2 -D_FORTIFY_SOURCE=1 -DNDEBUG -ffunction-sections -fdata-sections -fno-canonical-system-headers -Wno-builtin-macro-redefined -D__DATE__=redacted -D__TIMESTAMP__=redacted -D__TIME__=redacted -Werror'
+ LD=/usr/bin/gcc
+ LDFLAGS='-fuse-ld=gold -Wl,-no-as-needed -Wl,-z,relro,-z,now -B/usr/bin -pass-exit-codes -lstdc++ -lm -Wl,--gc-sections'
+ ./configure --without-guile --with-guile=no --disable-dependency-tracking --prefix=/worker/build/009becc197ab3312/root/bazel-out/k8-opt-exec-BA56BB51/bin/external/rules_foreign_cc/toolchains/make
checking for a BSD-compatible install... /bin/install -c
checking whether build environment is sane... configure: error: newly created file is older than distributed files!
Check your system clock
_____ END BUILD LOGS _____
rules_foreign_cc: Build wrapper script location: bazel-out/k8-opt-exec-BA56BB51/bin/external/rules_foreign_cc/toolchains/make_tool_foreign_cc/wrapper_build_script.sh
rules_foreign_cc: Build script location: bazel-out/k8-opt-exec-BA56BB51/bin/external/rules_foreign_cc/toolchains/make_tool_foreign_cc/build_script.sh
rules_foreign_cc: Build log location: bazel-out/k8-opt-exec-BA56BB51/bin/external/rules_foreign_cc/toolchains/make_tool_foreign_cc/BootstrapGNUMake.log
```
