### PR TITLE
Use python3 instead of python2 in macos commands

### DIFF
--- a/foreign_cc/private/framework/toolchains/macos_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/macos_commands.bzl
@@ -261,7 +261,7 @@ def replace_symlink(file):
     # as `readlink` is.
     return """\
 if [[ -L "{file}" ]]; then
-  target="$(python -c "import os; print(os.path.realpath('{file}'))")"
+  target="$(python3 -c "import os; print(os.path.realpath('{file}'))")"
   rm "{file}" && cp -a "${{target}}" "{file}"
 fi
 """.format(file = file)


### PR DESCRIPTION
Fix #1036