### PR TITLE
Skip minimal Bazel version support tasks in Bazel's downstream pipeline

### DIFF
--- a/.bazelci/config.yaml
+++ b/.bazelci/config.yaml
@@ -191,6 +191,7 @@ tasks:
   min_supported_version:
     name: "Minimum Supported Version"
     bazel: "4.0.0"
+    skip_in_bazel_downstream_pipeline: "Bazel 4 required"
     platform: ubuntu1804
     build_targets:
       - "//..."
@@ -205,6 +206,7 @@ tasks:
   min_supported_version_examples:
     name: "Minimum Supported Version Examples"
     bazel: "4.0.0"
+    skip_in_bazel_downstream_pipeline: "Bazel 4 required"
     platform: ubuntu1804
     working_directory: examples
     min_supported_targets: &min_supported_targets


### PR DESCRIPTION
Addressing downstream failures like: https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/2975#0187b105-46c4-43d6-8bae-771282e5d955

Context: https://github.com/bazelbuild/continuous-integration/pull/1492#issuecomment-1310082475