### PR TITLE
Adds some documentation specific to the `make` rule.

### DIFF
--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -139,7 +139,7 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
         default = [],
     ),
     "out_bin_dir": attr.string(
-        doc = "Optional name of the output subdirectory with the binary files, defaults to 'bin'.",
+        doc = "Optional name of the output subdirectory with the binary files, defaults to 'bin'. ",
         mandatory = False,
         default = "bin",
     ),


### PR DESCRIPTION
I learned the hard way that the `make` build rule does not work out of the box with just any makefile, unlike other rules in this repository.

The single `make` example does *not* emphasize this, and it is important for the usability of the rule.

These are the things I learned:

- the `make( targets = [...])` invocation must at least execute an equivalent of `make install`, since all `out_*` params are relative to the *installation* directory, not to either the source or the buidkl directory.  So if your default target does not install anything, or you have a `install` make target, but don't invoke it, bazel will be unable to find your build outputs.
- The make file must either be able to recognize the `PREFIX=` env variable and use it, or have a different way of wiring the `$$INSTALLDIR$$` make variable through.
- Finally, the `make install` recipe must ensure that it does not copy symlinks. This will bite you if you use `cp $SOURCE DEST` instead of `cp -L $SOURCE $DEST` since the former will create a bunch of symlinks pointing to the sandbox. Which, of course, is useless once the sandbox is removed. Using `-L` will ensure that the actual file contents are
copied.

Issue: #1049 