### PR TITLE
Allow cmake variable to be set to the empty string

### DIFF
--- a/foreign_cc/cmake.bzl
+++ b/foreign_cc/cmake.bzl
@@ -354,7 +354,8 @@ def _attrs():
             doc = (
                 "CMake cache entries to initialize (they will be passed with `-Dkey=value`) " +
                 "Values, defined by the toolchain, will be joined with the values, passed here. " +
-                "(Toolchain values come first)"
+                "(Toolchain values come first). Note that specifying an empty string value, \"\"" +
+                "causes the key to be unset. Use \"<empty>\" to set the key to the empty string."
             ),
             mandatory = False,
             default = {},

--- a/foreign_cc/private/cmake_script.bzl
+++ b/foreign_cc/private/cmake_script.bzl
@@ -63,7 +63,10 @@ def create_cmake_script(
     toolchain_dict = _fill_crossfile_from_toolchain(workspace_name, tools, flags)
     params = None
 
+    # Collect the keys that are "" in order to suppress them below.
     keys_with_empty_values_in_user_cache = [key for key in user_cache if user_cache.get(key) == ""]
+    # Allow user to actually set a key to "" by specifying "<empty>".
+    user_cache.update([(key, "") for key in user_cache if user_cache.get(key) == "<empty>"])
 
     if no_toolchain_file:
         params = _create_cache_entries_env_vars(toolchain_dict, user_cache, user_env)


### PR DESCRIPTION
The cmake() tules interprets an entry in the cache_entries dictionary with a value of "" as meaning that the key, as a cmake variable name, should be unset. I have a case where I need to actually set a cmake variable to "" because the target library's CMakeFiles.txt checks to see if a variable is set and if not sets it to its idea of a default. This change would allow the user of the cmake() rule to set a variable to "" by specifying the dictionary value as "<empty>".

This is working for me but I'm open to other approaches. I think it'd be better to instead remove the existing interpretation of "" and then add a new list to the cmake() rule that contains the variables to leave unset in the final set passed to cmake. This would probably break existing users, though.