### PR TITLE
Allow selecting individual outputs from a rule

### DIFF
--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -531,7 +531,7 @@ def cc_external_rule_impl(ctx, attrs):
         lib_dir_name = attrs.out_lib_dir,
         include_dir_name = attrs.out_include_dir,
     )
-    output_groups = _declare_output_groups(installdir_copy.file, outputs.out_binary_files)
+    output_groups = _declare_output_groups(installdir_copy.file, outputs.out_binary_files + outputs.libraries.static_libraries + outputs.libraries.shared_libraries + [outputs.out_include_dir])
     wrapped_files = [
         wrapped_outputs.script_file,
         wrapped_outputs.log_file,


### PR DESCRIPTION
If one wants to select a single output from a build (like a single shared library or a single static library), it's not possible to do so with the current code. The current code only creates an output_group for the declared binaries, which isn't sufficient.

This change creates an output group for all the artifacts including the includes.

Fixes #768