### PR TITLE
Fix issue where meson documentation was blank on docs site

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -78,6 +78,7 @@ DOCS_TARGETS = [
     ":ninja_docs",
     ":make_docs",
     ":configure_make_docs",
+    ":meson_docs",
     ":providers_docs",
 ]
 


### PR DESCRIPTION
I'm not 100% sure the change will fix the issue...