### PR TITLE
fix linux cross compiling on macos

### DIFF
--- a/foreign_cc/cmake.bzl
+++ b/foreign_cc/cmake.bzl
@@ -148,6 +148,7 @@ load("//foreign_cc/private:transitions.bzl", "foreign_cc_rule_variant")
 load(
     "//foreign_cc/private/framework:platform.bzl",
     "os_name",
+    "target_arch_name",
     "target_os_name",
 )
 load(
@@ -253,6 +254,8 @@ def _create_configure_script(configureParameters):
     configure_script = create_cmake_script(
         workspace_name = ctx.workspace_name,
         target_os = target_os_name(ctx),
+        target_arch = target_arch_name(ctx),
+        host_os = os_name(ctx),
         generator = attrs.generator,
         cmake_path = attrs.cmake_path,
         tools = tools,

--- a/foreign_cc/private/cmake_script.bzl
+++ b/foreign_cc/private/cmake_script.bzl
@@ -114,6 +114,9 @@ def create_cmake_script(
         },
     }
 
+    print(target_os)
+    print(host_os)
+    print(arch)
     if target_os != host_os:
         params.cache.update(_target_os_params.get(target_os))
         params.cache.update(_target_arch_params.get(target_arch))

--- a/foreign_cc/private/cmake_script.bzl
+++ b/foreign_cc/private/cmake_script.bzl
@@ -102,16 +102,16 @@ def create_cmake_script(
         },
         "linux": {
             "CMAKE_SYSTEM_NAME": "Linux",
-        }
+        },
     }
 
     _target_arch_params = {
         "x86_64": {
-            "CMAKE_SYSTEM_PROCESSOR": "x86_64"
+            "CMAKE_SYSTEM_PROCESSOR": "x86_64",
         },
         "aarch64": {
             "CMAKE_SYSTEM_PROCESSOR": "aarch64",
-        }
+        },
     }
 
     if target_os != host_os:

--- a/foreign_cc/private/cmake_script.bzl
+++ b/foreign_cc/private/cmake_script.bzl
@@ -101,6 +101,11 @@ def create_cmake_script(
             "CMAKE_SYSTEM_NAME": "Linux",
         })
 
+    if target_os == "linux":
+        params.cache.update({
+            "CMAKE_SYSTEM_NAME": "Linux",
+        })
+
     set_env_vars = [
         "export {}=\"{}\"".format(key, _escape_dquote_bash(params.env[key]))
         for key in params.env

--- a/foreign_cc/private/cmake_script.bzl
+++ b/foreign_cc/private/cmake_script.bzl
@@ -116,7 +116,7 @@ def create_cmake_script(
 
     print(target_os)
     print(host_os)
-    print(arch)
+    print(target_arch)
     if target_os != host_os:
         params.cache.update(_target_os_params.get(target_os))
         params.cache.update(_target_arch_params.get(target_arch))

--- a/foreign_cc/private/cmake_script.bzl
+++ b/foreign_cc/private/cmake_script.bzl
@@ -114,10 +114,7 @@ def create_cmake_script(
         },
     }
 
-    print(target_os)
-    print(host_os)
-    print(target_arch)
-    if target_os != host_os:
+    if target_os != host_os and target_os != "unknown":
         params.cache.update(_target_os_params.get(target_os))
         params.cache.update(_target_arch_params.get(target_arch))
 

--- a/foreign_cc/private/cmake_script.bzl
+++ b/foreign_cc/private/cmake_script.bzl
@@ -20,6 +20,8 @@ def _escape_dquote_bash_crosstool(text):
 def create_cmake_script(
         workspace_name,
         target_os,
+        target_arch,
+        host_os,
         generator,
         cmake_path,
         tools,
@@ -93,6 +95,29 @@ def create_cmake_script(
     if not params.cache.get("CMAKE_RANLIB"):
         params.cache.update({"CMAKE_RANLIB": ""})
 
+    _target_os_params = {
+        "android": {
+            "ANDROID": "YES",
+            "CMAKE_SYSTEM_NAME": "Linux",
+        },
+        "linux": {
+            "CMAKE_SYSTEM_NAME": "Linux",
+        }
+    }
+
+    _target_arch_params = {
+        "x86_64": {
+            "CMAKE_SYSTEM_PROCESSOR": "x86_64"
+        },
+        "aarch64": {
+            "CMAKE_SYSTEM_PROCESSOR": "aarch64",
+        }
+    }
+
+    if target_os != host_os:
+        params.cache.update(_target_os_params.get(target_os))
+        params.cache.update(_target_arch_params.get(target_arch))
+
     # Avoid cmake passing wrong linker flags when targeting android on macOS
     # https://github.com/bazelbuild/rules_foreign_cc/issues/289
     if target_os == "android":
@@ -104,6 +129,12 @@ def create_cmake_script(
     if target_os == "linux":
         params.cache.update({
             "CMAKE_SYSTEM_NAME": "Linux",
+            "CMAKE_SYSTEM_PROCESSOR": "x86_64",
+        })
+
+    if params.cache.get("CMAKE_SYSTEM_NAME"):
+        params.cache.update({
+            "CMAKE_SYSTEM_PROCESSOR": 
         })
 
     set_env_vars = [

--- a/foreign_cc/private/cmake_script.bzl
+++ b/foreign_cc/private/cmake_script.bzl
@@ -118,25 +118,6 @@ def create_cmake_script(
         params.cache.update(_target_os_params.get(target_os))
         params.cache.update(_target_arch_params.get(target_arch))
 
-    # Avoid cmake passing wrong linker flags when targeting android on macOS
-    # https://github.com/bazelbuild/rules_foreign_cc/issues/289
-    if target_os == "android":
-        params.cache.update({
-            "ANDROID": "YES",
-            "CMAKE_SYSTEM_NAME": "Linux",
-        })
-
-    if target_os == "linux":
-        params.cache.update({
-            "CMAKE_SYSTEM_NAME": "Linux",
-            "CMAKE_SYSTEM_PROCESSOR": "x86_64",
-        })
-
-    if params.cache.get("CMAKE_SYSTEM_NAME"):
-        params.cache.update({
-            "CMAKE_SYSTEM_PROCESSOR": 
-        })
-
     set_env_vars = [
         "export {}=\"{}\"".format(key, _escape_dquote_bash(params.env[key]))
         for key in params.env

--- a/foreign_cc/private/cmake_script.bzl
+++ b/foreign_cc/private/cmake_script.bzl
@@ -41,6 +41,8 @@ def create_cmake_script(
     Args:
         workspace_name: current workspace name
         target_os: The target OS for the build
+        target_arch: The target arch for the build
+        host_os: The execution OS for the build
         generator: The generator target for cmake to use
         cmake_path: The path to the cmake executable
         tools: cc_toolchain tools (CxxToolsInfo)
@@ -106,11 +108,11 @@ def create_cmake_script(
     }
 
     _target_arch_params = {
-        "x86_64": {
-            "CMAKE_SYSTEM_PROCESSOR": "x86_64",
-        },
         "aarch64": {
             "CMAKE_SYSTEM_PROCESSOR": "aarch64",
+        },
+        "x86_64": {
+            "CMAKE_SYSTEM_PROCESSOR": "x86_64",
         },
     }
 

--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -210,7 +210,6 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
         default = [],
     ),
     "_android_constraint": attr.label(default = Label("@platforms//os:android")),
-    "_linux_constraint": attr.label(default = Label("@platforms//os:linux")),
     # we need to declare this attribute to access cc_toolchain
     "_cc_toolchain": attr.label(
         default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
@@ -220,6 +219,7 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
         cfg = "exec",
         default = Label("@rules_foreign_cc//foreign_cc/private/framework:platform_info"),
     ),
+    "_linux_constraint": attr.label(default = Label("@platforms//os:linux")),
 }
 
 # A list of common fragments required by rules using this framework

--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -210,6 +210,7 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
         default = [],
     ),
     "_android_constraint": attr.label(default = Label("@platforms//os:android")),
+    "_linux_constraint": attr.label(default = Label("@platforms//os:linux")),
     # we need to declare this attribute to access cc_toolchain
     "_cc_toolchain": attr.label(
         default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),

--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -209,6 +209,7 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
         cfg = "exec",
         default = [],
     ),
+    "_aarch64_constraint": attr.label(default = Label("@platforms//cpu:aarch64")),
     "_android_constraint": attr.label(default = Label("@platforms//os:android")),
     # we need to declare this attribute to access cc_toolchain
     "_cc_toolchain": attr.label(
@@ -220,6 +221,7 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
         default = Label("@rules_foreign_cc//foreign_cc/private/framework:platform_info"),
     ),
     "_linux_constraint": attr.label(default = Label("@platforms//os:linux")),
+    "_x86_64_constraint": attr.label(default = Label("@platforms//cpu:x86_64")),
 }
 
 # A list of common fragments required by rules using this framework

--- a/foreign_cc/private/framework/platform.bzl
+++ b/foreign_cc/private/framework/platform.bzl
@@ -75,7 +75,7 @@ def target_os_name(ctx):
     Returns:
         str: The string of the current platform
     """
-    operating_systems = ["android"]
+    operating_systems = ["android", "linux"]
     for os in operating_systems:
         constraint = getattr(ctx.attr, "_{}_constraint".format(os))
         if constraint and ctx.target_platform_has_constraint(constraint[platform_common.ConstraintValueInfo]):

--- a/foreign_cc/private/framework/platform.bzl
+++ b/foreign_cc/private/framework/platform.bzl
@@ -67,6 +67,14 @@ def os_name(ctx):
     return platform_info[ForeignCcPlatformInfo].os
 
 def target_arch_name(ctx):
+    """A helper function for getting the target architecture name based on the constraints
+
+    Args:
+        ctx (ctx): The current rule's context object
+
+    Returns:
+        str: The string of the current platform
+    """
     archs = ["x86_64", "aarch64"]
     for arch in archs:
         constraint = getattr(ctx.attr, "_{}_constraint".format(arch))

--- a/foreign_cc/private/framework/platform.bzl
+++ b/foreign_cc/private/framework/platform.bzl
@@ -66,6 +66,15 @@ def os_name(ctx):
 
     return platform_info[ForeignCcPlatformInfo].os
 
+def target_arch_name(ctx):
+    archs = ["x86_64", "aarch64"]
+    for arch in archs:
+        constraint = getattr(ctx.attr, "_{}_constraint".format(arch))
+        if constraint and ctx.target_platform_has_constraint(constraint[platform_common.ConstraintValueInfo]):
+            return arch
+
+    return "unknown"
+
 def target_os_name(ctx):
     """A helper function for getting the target operating system name based on the constraints
 

--- a/test/cmake_text_tests.bzl
+++ b/test/cmake_text_tests.bzl
@@ -566,6 +566,71 @@ cmake -DCMAKE_AR="/cxx_linker_static" -DCMAKE_CXX_LINK_EXECUTABLE="became" -DCMA
 
     return unittest.end(env)
 
+def _create_cmake_script_linux_test(ctx):
+    env = unittest.begin(ctx)
+
+    tools = CxxToolsInfo(
+        cc = "/some-cc-value",
+        cxx = "external/cxx-value",
+        cxx_linker_static = "/cxx_linker_static",
+        cxx_linker_executable = "ws/cxx_linker_executable",
+    )
+    flags = CxxFlagsInfo(
+        cc = ["-cc-flag", "-gcc_toolchain", "cc-toolchain"],
+        cxx = [
+            "--quoted=\"abc def\"",
+            "--sysroot=/abc/sysroot",
+            "--gcc_toolchain",
+            "cxx-toolchain",
+        ],
+        cxx_linker_shared = ["shared1", "shared2"],
+        cxx_linker_static = ["static"],
+        cxx_linker_executable = ["executable"],
+        assemble = ["assemble"],
+    )
+    user_env = {
+        "CC": "sink-cc-value",
+        "CFLAGS": "--from-env",
+        "CUSTOM_ENV": "YES",
+        "CXX": "sink-cxx-value",
+    }
+    user_cache = {
+        "CMAKE_ASM_FLAGS": "assemble-user",
+        "CMAKE_BUILD_TYPE": "user_type",
+        "CMAKE_CXX_LINK_EXECUTABLE": "became",
+        "CMAKE_C_FLAGS": "--additional-flag",
+        "CUSTOM_CACHE": "YES",
+    }
+
+    script = create_cmake_script(
+        "ws",
+        "linux",
+        "Ninja",
+        "cmake",
+        tools,
+        flags,
+        "test_rule",
+        "external/test_rule",
+        True,
+        user_cache,
+        user_env,
+        ["--debug-output", "-Wdev"],
+        cmake_commands = [],
+    )
+    expected = r"""export CC="sink-cc-value"
+export CXX="sink-cxx-value"
+export CFLAGS="-cc-flag -gcc_toolchain cc-toolchain --from-env --additional-flag"
+export CXXFLAGS="--quoted=\\\"abc def\\\" --sysroot=/abc/sysroot --gcc_toolchain cxx-toolchain"
+export ASMFLAGS="assemble assemble-user"
+export CUSTOM_ENV="YES"
+##enable_tracing##
+cmake -DCMAKE_AR="/cxx_linker_static" -DCMAKE_CXX_LINK_EXECUTABLE="became" -DCMAKE_SHARED_LINKER_FLAGS="shared1 shared2" -DCMAKE_EXE_LINKER_FLAGS="executable" -DCMAKE_BUILD_TYPE="user_type" -DCUSTOM_CACHE="YES" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$$EXT_BUILD_DEPS$$" -DCMAKE_RANLIB="" -DCMAKE_SYSTEM_NAME="Linux" --debug-output -Wdev -G 'Ninja' $$EXT_BUILD_ROOT$$/external/test_rule
+##disable_tracing##
+"""
+    asserts.equals(env, expected.splitlines(), script)
+
+    return unittest.end(env)
+
 def _create_cmake_script_toolchain_file_test(ctx):
     env = unittest.begin(ctx)
 
@@ -664,6 +729,7 @@ create_min_cmake_script_toolchain_file_test = unittest.make(_create_min_cmake_sc
 create_cmake_script_no_toolchain_file_test = unittest.make(_create_cmake_script_no_toolchain_file_test)
 create_cmake_script_toolchain_file_test = unittest.make(_create_cmake_script_toolchain_file_test)
 create_cmake_script_android_test = unittest.make(_create_cmake_script_android_test)
+create_cmake_script_linux_test = unittest.make(_create_cmake_script_linux_test)
 merge_flag_values_no_toolchain_file_test = unittest.make(_merge_flag_values_no_toolchain_file_test)
 create_min_cmake_script_wipe_toolchain_test = unittest.make(_create_min_cmake_script_wipe_toolchain_test)
 
@@ -682,6 +748,7 @@ def cmake_script_test_suite():
         create_cmake_script_no_toolchain_file_test,
         create_cmake_script_toolchain_file_test,
         create_cmake_script_android_test,
+        create_cmake_script_linux_test,
         merge_flag_values_no_toolchain_file_test,
         create_min_cmake_script_wipe_toolchain_test,
     )

--- a/test/cmake_text_tests.bzl
+++ b/test/cmake_text_tests.bzl
@@ -243,6 +243,8 @@ def _merge_flag_values_no_toolchain_file_test(ctx):
     script = create_cmake_script(
         "ws",
         "unknown",
+        "unknown",
+        "unknown",
         "Unix Makefiles",
         "cmake",
         tools,
@@ -292,6 +294,8 @@ def _create_min_cmake_script_no_toolchain_file_test(ctx):
 
     script = create_cmake_script(
         "ws",
+        "unknown",
+        "unknown",
         "unknown",
         "Ninja",
         "cmake",
@@ -347,6 +351,8 @@ def _create_min_cmake_script_wipe_toolchain_test(ctx):
     script = create_cmake_script(
         "ws",
         "unknown",
+        "unknown",
+        "unknown",
         "Ninja",
         "cmake",
         tools,
@@ -396,6 +402,8 @@ def _create_min_cmake_script_toolchain_file_test(ctx):
 
     script = create_cmake_script(
         "ws",
+        "unknown",
+        "unknown",
         "unknown",
         "Ninja",
         "cmake",
@@ -475,6 +483,8 @@ def _create_cmake_script_no_toolchain_file_test(ctx):
     script = create_cmake_script(
         "ws",
         "unknown",
+        "unknown",
+        "unknown",
         "Ninja",
         "cmake",
         tools,
@@ -540,6 +550,8 @@ def _create_cmake_script_android_test(ctx):
     script = create_cmake_script(
         "ws",
         "android",
+        "x86_64",
+        "unknown",
         "Ninja",
         "cmake",
         tools,
@@ -559,7 +571,7 @@ export CXXFLAGS="--quoted=\\\"abc def\\\" --sysroot=/abc/sysroot --gcc_toolchain
 export ASMFLAGS="assemble assemble-user"
 export CUSTOM_ENV="YES"
 ##enable_tracing##
-cmake -DCMAKE_AR="/cxx_linker_static" -DCMAKE_CXX_LINK_EXECUTABLE="became" -DCMAKE_SHARED_LINKER_FLAGS="shared1 shared2" -DCMAKE_EXE_LINKER_FLAGS="executable" -DCMAKE_BUILD_TYPE="user_type" -DCUSTOM_CACHE="YES" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$$EXT_BUILD_DEPS$$" -DCMAKE_RANLIB="" -DANDROID="YES" -DCMAKE_SYSTEM_NAME="Linux" --debug-output -Wdev -G 'Ninja' $$EXT_BUILD_ROOT$$/external/test_rule
+cmake -DCMAKE_AR="/cxx_linker_static" -DCMAKE_CXX_LINK_EXECUTABLE="became" -DCMAKE_SHARED_LINKER_FLAGS="shared1 shared2" -DCMAKE_EXE_LINKER_FLAGS="executable" -DCMAKE_BUILD_TYPE="user_type" -DCUSTOM_CACHE="YES" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$$EXT_BUILD_DEPS$$" -DCMAKE_RANLIB="" -DANDROID="YES" -DCMAKE_SYSTEM_NAME="Linux" -DCMAKE_SYSTEM_PROCESSOR="x86_64" --debug-output -Wdev -G 'Ninja' $$EXT_BUILD_ROOT$$/external/test_rule
 ##disable_tracing##
 """
     asserts.equals(env, expected.splitlines(), script)
@@ -605,6 +617,8 @@ def _create_cmake_script_linux_test(ctx):
     script = create_cmake_script(
         "ws",
         "linux",
+        "aarch64",
+        "unknown",
         "Ninja",
         "cmake",
         tools,
@@ -624,7 +638,7 @@ export CXXFLAGS="--quoted=\\\"abc def\\\" --sysroot=/abc/sysroot --gcc_toolchain
 export ASMFLAGS="assemble assemble-user"
 export CUSTOM_ENV="YES"
 ##enable_tracing##
-cmake -DCMAKE_AR="/cxx_linker_static" -DCMAKE_CXX_LINK_EXECUTABLE="became" -DCMAKE_SHARED_LINKER_FLAGS="shared1 shared2" -DCMAKE_EXE_LINKER_FLAGS="executable" -DCMAKE_BUILD_TYPE="user_type" -DCUSTOM_CACHE="YES" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$$EXT_BUILD_DEPS$$" -DCMAKE_RANLIB="" -DCMAKE_SYSTEM_NAME="Linux" --debug-output -Wdev -G 'Ninja' $$EXT_BUILD_ROOT$$/external/test_rule
+cmake -DCMAKE_AR="/cxx_linker_static" -DCMAKE_CXX_LINK_EXECUTABLE="became" -DCMAKE_SHARED_LINKER_FLAGS="shared1 shared2" -DCMAKE_EXE_LINKER_FLAGS="executable" -DCMAKE_BUILD_TYPE="user_type" -DCUSTOM_CACHE="YES" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$$EXT_BUILD_DEPS$$" -DCMAKE_RANLIB="" -DCMAKE_SYSTEM_NAME="Linux" -DCMAKE_SYSTEM_PROCESSOR="aarch64" --debug-output -Wdev -G 'Ninja' $$EXT_BUILD_ROOT$$/external/test_rule
 ##disable_tracing##
 """
     asserts.equals(env, expected.splitlines(), script)

--- a/test/cmake_text_tests.bzl
+++ b/test/cmake_text_tests.bzl
@@ -683,6 +683,8 @@ def _create_cmake_script_toolchain_file_test(ctx):
     script = create_cmake_script(
         "ws",
         "unknown",
+        "unknown",
+        "unknown",
         "Ninja",
         "cmake",
         tools,


### PR DESCRIPTION
Fixes cross-compiling from macos to linux.

see #997 for background.

I had to make a couple of extra changes to support this:
- Setting `CMAKE_SYSTEM_NAME` manually causes `CMAKE_SYSTEM_PROCESSOR` to not be set. This breaks some builds that expect this variable to be set like [libjpeg-turbo](https://github.com/libjpeg-turbo/libjpeg-turbo/blob/4e52b66f342a803d3b8099b79607e3158d3a241c/CMakeLists.txt#L43).
- I made it so that the above variables are only set when cross-compilation is detected so that `rules_foreign_cc` only takes on responsibility of setting them when necessary.