### PR TITLE
Fix multiple-definition error on windows_config_setting

### DIFF
--- a/foreign_cc/utils.bzl
+++ b/foreign_cc/utils.bzl
@@ -22,9 +22,11 @@ def runnable_binary(name, binary, foreign_cc_target, match_binary_name = False, 
 
     tags = kwargs.pop("tags", [])
 
+    config_setting_name = name + "_windows_config_setting"
+
     # filegroups cannot select on constraint_values in before Bazel 5.1. Add this config_setting as a workaround. See https://github.com/bazelbuild/bazel/issues/13047
     native.config_setting(
-        name = "windows_config_setting",
+        name = config_setting_name,
         constraint_values = [
             "@platforms//os:windows",
         ],
@@ -35,7 +37,7 @@ def runnable_binary(name, binary, foreign_cc_target, match_binary_name = False, 
         srcs = [foreign_cc_target],
         tags = tags + ["manual"],
         output_group = select({
-            ":windows_config_setting": binary + ".exe",
+            ":" + config_setting_name: binary + ".exe",
             "//conditions:default": binary,
         }),
     )


### PR DESCRIPTION
When using runnable_binary twice in the same package, windows_config_setting was being defined twice producing an error like:

Error in config_setting: config_setting rule 'windows_config_setting' in package '' conflicts with existing config_setting rule, defined at .../BUILD.bazel:29:16

This fix prefixes the setting with the name, the same as the other rules defined by the macro.