### PR TITLE
change cygpath to mixed

### DIFF
--- a/foreign_cc/private/framework/toolchains/windows_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/windows_commands.bzl
@@ -9,7 +9,7 @@ def script_extension():
     return ".sh"
 
 def pwd():
-    return "$(type -t cygpath > /dev/null && cygpath $(pwd) -w || pwd -W)"
+    return "$(type -t cygpath > /dev/null && cygpath $(pwd) -m || pwd -W)"
 
 def echo(text):
     return "echo \"{text}\"".format(text = text)


### PR DESCRIPTION
`cygpath -w` will print `\` eg. `c:\Users\msmith`.  

When this is used to calculate `EXT_BUILD_ROOT`, and `EXT_BUILD_ROOT` is used as a suffix for other paths, it can lead to a mix of `\` amd `/` which can cause `configure_make` build failures. eg.

```
unsafe srcdir value: 'C:\tmp\2b4dntvp\execroot\__main__/external/
```

`cygpath` comes preinstalled in msys2, therefore is always used to calculate `pwd`.

The fallback, `pwd -W` will print `/` eg. `c:/Users/msmith`.

This MR changes the Windows `pwd()` to use the `cygpath -m` "mixed" mode that matches `pwd -W`.