### PR TITLE
set CC and CXX and their flags in meson

### DIFF
--- a/examples/third_party/mesa/BUILD.mesa.bazel
+++ b/examples/third_party/mesa/BUILD.mesa.bazel
@@ -39,7 +39,6 @@ meson_with_requirements(
         },
     }),
     copts = select({
-        "@platforms//os:macos": ["-std=c++"],
         "@openssl//:msvc_compiler": ["/std:c++14"],
         "@platforms//os:linux": ["-std=c++14"],
         "//conditions:default": [],
@@ -51,6 +50,7 @@ meson_with_requirements(
             "ws2_32.lib",
         ],
         "@platforms//os:linux": ["-lstdc++"],
+        # "@platforms//os:macos": ["-mlinker-version=305"],
         "//conditions:default": [],
     }),
     options = select({

--- a/examples/third_party/mesa/BUILD.mesa.bazel
+++ b/examples/third_party/mesa/BUILD.mesa.bazel
@@ -28,6 +28,11 @@ meson_with_requirements(
             "@m4//:m4_exe",
         ],
     }),
+    copts = select({
+        "@openssl//:msvc_compiler": ["/std:c++11"],
+        "@platforms//os:linux": ["-std=c++14"],
+        "//conditions:default": [],
+    }),
     env = select({
         "@bazel_tools//src/conditions:host_windows": {
             "PATH": "$$(dirname $$EXT_BUILD_ROOT$$/$(location @winflexbison//:gen_dir))/winflexbison:$$(dirname $$EXT_BUILD_ROOT$$/$(PYTHON3)):$$PATH",
@@ -38,12 +43,6 @@ meson_with_requirements(
             "PATH": "$$(dirname $$EXT_BUILD_ROOT$$/$(location @bison//:gen_dir))/bison/bin:$$(dirname $$EXT_BUILD_ROOT$$/$(location @flex//:flex_exe)):$$EXT_BUILD_DEPS$$/bin/m4/bin/:$$(dirname $$EXT_BUILD_ROOT$$/$(PYTHON3)):$$PATH",
         },
     }),
-    copts = select({
-        "@openssl//:msvc_compiler": ["/std:c++11"],
-        "@platforms//os:linux": ["-std=c++14"],
-        "//conditions:default": [],
-    }),
-
     lib_source = ":all_srcs",
     linkopts = select({
         "@openssl//:msvc_compiler": [

--- a/examples/third_party/mesa/BUILD.mesa.bazel
+++ b/examples/third_party/mesa/BUILD.mesa.bazel
@@ -48,7 +48,6 @@ meson_with_requirements(
         "@openssl//:msvc_compiler": [
             "ws2_32.lib",
         ],
-        "@platforms//os:linux": ["-lstdc++"],
         "//conditions:default": [],
     }),
     options = select({

--- a/examples/third_party/mesa/BUILD.mesa.bazel
+++ b/examples/third_party/mesa/BUILD.mesa.bazel
@@ -38,6 +38,13 @@ meson_with_requirements(
             "PATH": "$$(dirname $$EXT_BUILD_ROOT$$/$(location @bison//:gen_dir))/bison/bin:$$(dirname $$EXT_BUILD_ROOT$$/$(location @flex//:flex_exe)):$$EXT_BUILD_DEPS$$/bin/m4/bin/:$$(dirname $$EXT_BUILD_ROOT$$/$(PYTHON3)):$$PATH",
         },
     }),
+    copts = select({
+        "@platforms//os:macos": ["-std=c++"],
+        "@openssl//:msvc_compiler": ["/std:c++14"],
+        "@platforms//os:linux": ["-std=c++14"],
+        "//conditions:default": [],
+    }),
+
     lib_source = ":all_srcs",
     linkopts = select({
         "@openssl//:msvc_compiler": [

--- a/examples/third_party/mesa/BUILD.mesa.bazel
+++ b/examples/third_party/mesa/BUILD.mesa.bazel
@@ -28,11 +28,6 @@ meson_with_requirements(
             "@m4//:m4_exe",
         ],
     }),
-    copts = select({
-        "@openssl//:msvc_compiler": ["/std:c++11"],
-        "@platforms//os:linux": ["-std=c++14"],
-        "//conditions:default": [],
-    }),
     env = select({
         "@bazel_tools//src/conditions:host_windows": {
             "PATH": "$$(dirname $$EXT_BUILD_ROOT$$/$(location @winflexbison//:gen_dir))/winflexbison:$$(dirname $$EXT_BUILD_ROOT$$/$(PYTHON3)):$$PATH",

--- a/examples/third_party/mesa/BUILD.mesa.bazel
+++ b/examples/third_party/mesa/BUILD.mesa.bazel
@@ -39,7 +39,7 @@ meson_with_requirements(
         },
     }),
     copts = select({
-        "@openssl//:msvc_compiler": ["/std:c++14"],
+        # "@openssl//:msvc_compiler": ["/std:c++14"],
         "@platforms//os:linux": ["-std=c++14"],
         "//conditions:default": [],
     }),

--- a/examples/third_party/mesa/BUILD.mesa.bazel
+++ b/examples/third_party/mesa/BUILD.mesa.bazel
@@ -39,6 +39,13 @@ meson_with_requirements(
         },
     }),
     lib_source = ":all_srcs",
+    linkopts = select({
+        "@openssl//:msvc_compiler": [
+            "ws2_32.lib",
+        ],
+        "@platforms//os:linux": ["-lstdc++"],
+        "//conditions:default": [],
+    }),
     options = select({
         "@platforms//os:linux": {
             # Disable LLVM support, as building LLVM in rules_foreign_cc CI would drastically increase the build time

--- a/examples/third_party/mesa/BUILD.mesa.bazel
+++ b/examples/third_party/mesa/BUILD.mesa.bazel
@@ -49,7 +49,7 @@ meson_with_requirements(
         "@openssl//:msvc_compiler": [
             "ws2_32.lib",
         ],
-        "@platforms//os:linux": ["-lstdc++"],
+        # "@platforms//os:linux": ["-lstdc++"],
         # "@platforms//os:macos": ["-mlinker-version=305"],
         "//conditions:default": [],
     }),

--- a/examples/third_party/mesa/BUILD.mesa.bazel
+++ b/examples/third_party/mesa/BUILD.mesa.bazel
@@ -39,7 +39,7 @@ meson_with_requirements(
         },
     }),
     copts = select({
-        # "@openssl//:msvc_compiler": ["/std:c++14"],
+        "@openssl//:msvc_compiler": ["/std:c++11"],
         "@platforms//os:linux": ["-std=c++14"],
         "//conditions:default": [],
     }),

--- a/examples/third_party/mesa/BUILD.mesa.bazel
+++ b/examples/third_party/mesa/BUILD.mesa.bazel
@@ -49,8 +49,7 @@ meson_with_requirements(
         "@openssl//:msvc_compiler": [
             "ws2_32.lib",
         ],
-        # "@platforms//os:linux": ["-lstdc++"],
-        # "@platforms//os:macos": ["-mlinker-version=305"],
+        "@platforms//os:linux": ["-lstdc++"],
         "//conditions:default": [],
     }),
     options = select({

--- a/foreign_cc/meson.bzl
+++ b/foreign_cc/meson.bzl
@@ -82,11 +82,11 @@ def _create_meson_script(configureParameters):
     flags = get_flags_info(ctx)
     if flags.cc:
         print("tanx debug:" + "##export_var## CFLAGS {}".format(" ".join(flags.cc)))
-        script.append("##export_var## CFLAGS {}".format(" ".join(flags.cc)))
+        script.append("##export_var## CFLAGS \"{}\"".format(" ".join(flags.cc)))
     if flags.cxx:
-        script.append("##export_var## CXXFLAGS {}".format(" ".join(flags.cxx)))
+        script.append("##export_var## CXXFLAGS \"{}\"".format(" ".join(flags.cxx)))
     if flags.cxx_linker_executable:
-        script.append("##export_var## LDFLAGS {}".format(" ".join(flags.cxx_linker_executable)))
+        script.append("##export_var## LDFLAGS \"{}\"".format(" ".join(flags.cxx_linker_executable)))
     script.append("##export_var## CMAKE {}".format(attrs.cmake_path))
     script.append("##export_var## NINJA {}".format(attrs.ninja_path))
     script.append("##export_var## PKG_CONFIG {}".format(attrs.pkg_config_path))

--- a/foreign_cc/meson.bzl
+++ b/foreign_cc/meson.bzl
@@ -68,8 +68,6 @@ def _create_meson_script(configureParameters):
 
     tools = get_tools_info(ctx)
     script = pkgconfig_script(inputs.ext_build_dirs)
-    
-
 
     # CFLAGS and CXXFLAGS are also set in foreign_cc/private/cmake_script.bzl, so that meson
     # can use the intended tools.
@@ -78,12 +76,12 @@ def _create_meson_script(configureParameters):
     # Skip setting them in this case.
     if " " not in tools.cc:
         script.append("##export_var## CC {}".format(_absolutize(ctx.workspace_name, tools.cc)))
-        # script.append("##export_var## CC_LD {}".format(_absolutize(ctx.workspace_name, tools.cxx_linker_executable)))
     if " " not in tools.cxx:
-        # print("tanx tools.cxx", tools.cxx)
         script.append("##export_var## CXX {}".format(_absolutize(ctx.workspace_name, tools.cxx)))
-        # script.append("##export_var## CXX_LD {}".format(_absolutize(ctx.workspace_name, tools.cxx_linker_executable)))
     
+    # set flags same as foreign_cc/private/cc_toolchain_util.bzl
+    # cannot use get_flags_info() because bazel adds additional flags that 
+    # aren't compatible with compiler or linker above
     copts = (ctx.fragments.cpp.copts + ctx.fragments.cpp.conlyopts + getattr(ctx.attr, "copts", [])) or []
     cxxopts = (ctx.fragments.cpp.copts + ctx.fragments.cpp.cxxopts + getattr(ctx.attr, "copts", [])) or []
     linkopts = (ctx.fragments.cpp.linkopts + getattr(ctx.attr, "linkopts", [])) or []
@@ -94,10 +92,7 @@ def _create_meson_script(configureParameters):
         script.append("##export_var## CXXFLAGS \"{}\"".format(" ".join(cxxopts).replace("\"", "'")))
     if linkopts:
         script.append("##export_var## LDFLAGS \"{}\"".format(" ".join(linkopts).replace("\"", "'")))
-    # if attrs.copts:
-    #     script.append("##export_var## CFLAGS {}".format(",".join(attrs.copts)))
-    # if attrs.linkopts:
-    #     script.append("##export_var## LDFLAGS {}".format(",".join(attrs.linkopts)))
+   
     script.append("##export_var## CMAKE {}".format(attrs.cmake_path))
     script.append("##export_var## NINJA {}".format(attrs.ninja_path))
     script.append("##export_var## PKG_CONFIG {}".format(attrs.pkg_config_path))

--- a/foreign_cc/meson.bzl
+++ b/foreign_cc/meson.bzl
@@ -234,10 +234,8 @@ def meson_with_requirements(name, requirements, **kwargs):
         **kwargs
     )
 
-# TODO: converge with cmake_script.bzl
 def _absolutize(workspace_name, text, force = False):
     if text.strip(" ").startswith("C:") or text.strip(" ").startswith("c:"):
         return "\"{}\"".format(text)
 
-    # Use bash parameter substitution to replace backslashes with forward slashes as CMake fails if provided paths containing backslashes
-    return "{}".format(absolutize_path_in_str(workspace_name, "$${EXT_BUILD_ROOT//\\\\//}$$/", text, force))
+    return absolutize_path_in_str(workspace_name, "$EXT_BUILD_ROOT/", text, force)

--- a/foreign_cc/meson.bzl
+++ b/foreign_cc/meson.bzl
@@ -81,12 +81,12 @@ def _create_meson_script(configureParameters):
         script.append("##export_var## CXX {}".format(_absolutize(ctx.workspace_name, tools.cxx)))
     flags = get_flags_info(ctx)
     if flags.cc:
-        print("tanx debug:" + "##export_var## CFLAGS {}".format(" ".join(flags.cc)))
-        script.append("##export_var## CFLAGS \"{}\"".format(" ".join(flags.cc)))
+        print("tanx debug:" + "##export_var## CFLAGS {}".format(" ".join(flags.cc.replace("\"", "'"))))
+        script.append("##export_var## CFLAGS \"{}\"".format(" ".join(flags.cc.replace("\"", "'"))))
     if flags.cxx:
-        script.append("##export_var## CXXFLAGS \"{}\"".format(" ".join(flags.cxx)))
+        script.append("##export_var## CXXFLAGS \"{}\"".format(" ".join(flags.cxx.replace("\"", "'"))))
     if flags.cxx_linker_executable:
-        script.append("##export_var## LDFLAGS \"{}\"".format(" ".join(flags.cxx_linker_executable)))
+        script.append("##export_var## LDFLAGS \"{}\"".format(" ".join(flags.cxx_linker_executable.replace("\"", "'"))))
     script.append("##export_var## CMAKE {}".format(attrs.cmake_path))
     script.append("##export_var## NINJA {}".format(attrs.ninja_path))
     script.append("##export_var## PKG_CONFIG {}".format(attrs.pkg_config_path))

--- a/foreign_cc/meson.bzl
+++ b/foreign_cc/meson.bzl
@@ -5,6 +5,7 @@ load("//foreign_cc/built_tools:meson_build.bzl", "meson_tool")
 load(
     "//foreign_cc/private:cc_toolchain_util.bzl",
     "absolutize_path_in_str",
+    "get_flags_info",
     "get_tools_info",
 )
 load(
@@ -84,14 +85,15 @@ def _create_meson_script(configureParameters):
     # aren't compatible with compiler or linker above
     copts = (ctx.fragments.cpp.copts + ctx.fragments.cpp.conlyopts + getattr(ctx.attr, "copts", [])) or []
     cxxopts = (ctx.fragments.cpp.copts + ctx.fragments.cpp.cxxopts + getattr(ctx.attr, "copts", [])) or []
-    linkopts = (ctx.fragments.cpp.linkopts + getattr(ctx.attr, "linkopts", [])) or []
 
     if copts:
         script.append("##export_var## CFLAGS \"{}\"".format(" ".join(copts).replace("\"", "'")))
     if cxxopts:
         script.append("##export_var## CXXFLAGS \"{}\"".format(" ".join(cxxopts).replace("\"", "'")))
-    if linkopts:
-        script.append("##export_var## LDFLAGS \"{}\"".format(" ".join(linkopts).replace("\"", "'")))
+    
+    flags = get_flags_info(ctx)
+    if flags.cxx_linker_executable:
+        script.append("##export_var## LDFLAGS \"{}\"".format(" ".join(flags.cxx_linker_executable).replace("\"", "'")))
 
     script.append("##export_var## CMAKE {}".format(attrs.cmake_path))
     script.append("##export_var## NINJA {}".format(attrs.ninja_path))

--- a/foreign_cc/meson.bzl
+++ b/foreign_cc/meson.bzl
@@ -90,7 +90,7 @@ def _create_meson_script(configureParameters):
         script.append("##export_var## CFLAGS \"{}\"".format(" ".join(copts).replace("\"", "'")))
     if cxxopts:
         script.append("##export_var## CXXFLAGS \"{}\"".format(" ".join(cxxopts).replace("\"", "'")))
-    
+
     flags = get_flags_info(ctx)
     if flags.cxx_linker_executable:
         script.append("##export_var## LDFLAGS \"{}\"".format(" ".join(flags.cxx_linker_executable).replace("\"", "'")))

--- a/foreign_cc/meson.bzl
+++ b/foreign_cc/meson.bzl
@@ -78,9 +78,9 @@ def _create_meson_script(configureParameters):
         script.append("##export_var## CC {}".format(_absolutize(ctx.workspace_name, tools.cc)))
     if " " not in tools.cxx:
         script.append("##export_var## CXX {}".format(_absolutize(ctx.workspace_name, tools.cxx)))
-    
+
     # set flags same as foreign_cc/private/cc_toolchain_util.bzl
-    # cannot use get_flags_info() because bazel adds additional flags that 
+    # cannot use get_flags_info() because bazel adds additional flags that
     # aren't compatible with compiler or linker above
     copts = (ctx.fragments.cpp.copts + ctx.fragments.cpp.conlyopts + getattr(ctx.attr, "copts", [])) or []
     cxxopts = (ctx.fragments.cpp.copts + ctx.fragments.cpp.cxxopts + getattr(ctx.attr, "copts", [])) or []
@@ -92,7 +92,7 @@ def _create_meson_script(configureParameters):
         script.append("##export_var## CXXFLAGS \"{}\"".format(" ".join(cxxopts).replace("\"", "'")))
     if linkopts:
         script.append("##export_var## LDFLAGS \"{}\"".format(" ".join(linkopts).replace("\"", "'")))
-   
+
     script.append("##export_var## CMAKE {}".format(attrs.cmake_path))
     script.append("##export_var## NINJA {}".format(attrs.ninja_path))
     script.append("##export_var## PKG_CONFIG {}".format(attrs.pkg_config_path))

--- a/foreign_cc/meson.bzl
+++ b/foreign_cc/meson.bzl
@@ -81,12 +81,12 @@ def _create_meson_script(configureParameters):
         script.append("##export_var## CXX {}".format(_absolutize(ctx.workspace_name, tools.cxx)))
     flags = get_flags_info(ctx)
     if flags.cc:
-        print("tanx debug:" + "##export_var## CFLAGS {}".format(" ".join(flags.cc.replace("\"", "'"))))
-        script.append("##export_var## CFLAGS \"{}\"".format(" ".join(flags.cc.replace("\"", "'"))))
+        print("tanx debug:" + "##export_var## CFLAGS {}".format(" ".join(flags.cc).replace("\"", "'")))
+        script.append("##export_var## CFLAGS \"{}\"".format(" ".join(flags.cc).replace("\"", "'")))
     if flags.cxx:
-        script.append("##export_var## CXXFLAGS \"{}\"".format(" ".join(flags.cxx.replace("\"", "'"))))
+        script.append("##export_var## CXXFLAGS \"{}\"".format(" ".join(flags.cxx).replace("\"", "'")))
     if flags.cxx_linker_executable:
-        script.append("##export_var## LDFLAGS \"{}\"".format(" ".join(flags.cxx_linker_executable.replace("\"", "'"))))
+        script.append("##export_var## LDFLAGS \"{}\"".format(" ".join(flags.cxx_linker_executable).replace("\"", "'")))
     script.append("##export_var## CMAKE {}".format(attrs.cmake_path))
     script.append("##export_var## NINJA {}".format(attrs.ninja_path))
     script.append("##export_var## PKG_CONFIG {}".format(attrs.pkg_config_path))

--- a/foreign_cc/meson.bzl
+++ b/foreign_cc/meson.bzl
@@ -68,7 +68,7 @@ def _create_meson_script(configureParameters):
 
     tools = get_tools_info(ctx)
     script = pkgconfig_script(inputs.ext_build_dirs)
-
+    
 
 
     # CFLAGS and CXXFLAGS are also set in foreign_cc/private/cmake_script.bzl, so that meson
@@ -78,11 +78,11 @@ def _create_meson_script(configureParameters):
     # Skip setting them in this case.
     if " " not in tools.cc:
         script.append("##export_var## CC {}".format(_absolutize(ctx.workspace_name, tools.cc)))
-        script.append("##export_var## CC_LD {}".format(_absolutize(ctx.workspace_name, tools.cxx_linker_executable)))
+        # script.append("##export_var## CC_LD {}".format(_absolutize(ctx.workspace_name, tools.cxx_linker_executable)))
     if " " not in tools.cxx:
-        print("tanx tools.cxx", tools.cxx)
+        # print("tanx tools.cxx", tools.cxx)
         script.append("##export_var## CXX {}".format(_absolutize(ctx.workspace_name, tools.cxx)))
-        script.append("##export_var## CXX_LD {}".format(_absolutize(ctx.workspace_name, tools.cxx_linker_executable)))
+        # script.append("##export_var## CXX_LD {}".format(_absolutize(ctx.workspace_name, tools.cxx_linker_executable)))
     
     copts = (ctx.fragments.cpp.copts + ctx.fragments.cpp.conlyopts + getattr(ctx.attr, "copts", [])) or []
     cxxopts = (ctx.fragments.cpp.copts + ctx.fragments.cpp.cxxopts + getattr(ctx.attr, "copts", [])) or []
@@ -93,7 +93,6 @@ def _create_meson_script(configureParameters):
     if cxxopts:
         script.append("##export_var## CXXFLAGS \"{}\"".format(" ".join(cxxopts).replace("\"", "'")))
     if linkopts:
-        # print("tanx flags.cxx_linker_executable", linkopts)
         script.append("##export_var## LDFLAGS \"{}\"".format(" ".join(linkopts).replace("\"", "'")))
     # if attrs.copts:
     #     script.append("##export_var## CFLAGS {}".format(",".join(attrs.copts)))

--- a/foreign_cc/private/cc_toolchain_util.bzl
+++ b/foreign_cc/private/cc_toolchain_util.bzl
@@ -237,6 +237,7 @@ def get_flags_info(ctx, link_output_file = None):
         cc_toolchain = cc_toolchain_,
     )
 
+
     copts = (ctx.fragments.cpp.copts + ctx.fragments.cpp.conlyopts + getattr(ctx.attr, "copts", [])) or []
     cxxopts = (ctx.fragments.cpp.copts + ctx.fragments.cpp.cxxopts + getattr(ctx.attr, "copts", [])) or []
     linkopts = (ctx.fragments.cpp.linkopts + getattr(ctx.attr, "linkopts", [])) or []
@@ -306,6 +307,8 @@ def get_flags_info(ctx, link_output_file = None):
             ),
         ),
     )
+    print("tanx flags.cxx_linker_executable: ", flags.cxx_linker_executable)
+
     return CxxFlagsInfo(
         cc = _convert_flags(cc_toolchain_.compiler, _add_if_needed(flags.cc, copts)),
         cxx = _convert_flags(cc_toolchain_.compiler, _add_if_needed(flags.cxx, cxxopts)),

--- a/foreign_cc/private/cc_toolchain_util.bzl
+++ b/foreign_cc/private/cc_toolchain_util.bzl
@@ -195,10 +195,20 @@ def get_tools_info(ctx):
         ctx: rule context
     """
     cc_toolchain = find_cpp_toolchain(ctx)
+    print("tanx cc_toolchain.basename:",cc_toolchain.all_files.to_list()[-2].basename)
+    print("tanx cc_toolchain.dirname:",cc_toolchain.all_files.to_list()[-2].dirname)
+    print("tanx cc_toolchain.extension:",cc_toolchain.all_files.to_list()[-2].extension)
+    print("tanx cc_toolchain.path:",cc_toolchain.all_files.to_list()[-2].path)
+    print("tanx cc_toolchain.root:",cc_toolchain.all_files.to_list()[-2].root.path)
     feature_configuration = _configure_features(
         ctx = ctx,
         cc_toolchain = cc_toolchain,
     )
+    cppp = cc_common.get_tool_for_action(
+        feature_configuration = feature_configuration,
+        action_name = ACTION_NAMES.cpp_compile,
+    )
+    print("cppp",cppp)
 
     return CxxToolsInfo(
         cc = cc_common.get_tool_for_action(

--- a/foreign_cc/private/cc_toolchain_util.bzl
+++ b/foreign_cc/private/cc_toolchain_util.bzl
@@ -195,7 +195,6 @@ def get_tools_info(ctx):
         ctx: rule context
     """
     cc_toolchain = find_cpp_toolchain(ctx)
-
     feature_configuration = _configure_features(
         ctx = ctx,
         cc_toolchain = cc_toolchain,
@@ -307,7 +306,6 @@ def get_flags_info(ctx, link_output_file = None):
             ),
         ),
     )
-
     return CxxFlagsInfo(
         cc = _convert_flags(cc_toolchain_.compiler, _add_if_needed(flags.cc, copts)),
         cxx = _convert_flags(cc_toolchain_.compiler, _add_if_needed(flags.cxx, cxxopts)),

--- a/foreign_cc/private/cc_toolchain_util.bzl
+++ b/foreign_cc/private/cc_toolchain_util.bzl
@@ -195,6 +195,7 @@ def get_tools_info(ctx):
         ctx: rule context
     """
     cc_toolchain = find_cpp_toolchain(ctx)
+
     # print("tanx cc_toolchain.basename:",cc_toolchain.all_files.to_list()[-2].basename)
     # print("tanx cc_toolchain.dirname:",cc_toolchain.all_files.to_list()[-2].dirname)
     # print("tanx cc_toolchain.extension:",cc_toolchain.all_files.to_list()[-2].extension)
@@ -208,7 +209,7 @@ def get_tools_info(ctx):
         feature_configuration = feature_configuration,
         action_name = ACTION_NAMES.cpp_compile,
     )
-    print("cppp",cppp)
+    print("cppp", cppp)
 
     return CxxToolsInfo(
         cc = cc_common.get_tool_for_action(
@@ -246,7 +247,6 @@ def get_flags_info(ctx, link_output_file = None):
         ctx = ctx,
         cc_toolchain = cc_toolchain_,
     )
-
 
     copts = (ctx.fragments.cpp.copts + ctx.fragments.cpp.conlyopts + getattr(ctx.attr, "copts", [])) or []
     cxxopts = (ctx.fragments.cpp.copts + ctx.fragments.cpp.cxxopts + getattr(ctx.attr, "copts", [])) or []

--- a/foreign_cc/private/cc_toolchain_util.bzl
+++ b/foreign_cc/private/cc_toolchain_util.bzl
@@ -195,11 +195,11 @@ def get_tools_info(ctx):
         ctx: rule context
     """
     cc_toolchain = find_cpp_toolchain(ctx)
-    print("tanx cc_toolchain.basename:",cc_toolchain.all_files.to_list()[-2].basename)
-    print("tanx cc_toolchain.dirname:",cc_toolchain.all_files.to_list()[-2].dirname)
-    print("tanx cc_toolchain.extension:",cc_toolchain.all_files.to_list()[-2].extension)
-    print("tanx cc_toolchain.path:",cc_toolchain.all_files.to_list()[-2].path)
-    print("tanx cc_toolchain.root:",cc_toolchain.all_files.to_list()[-2].root.path)
+    # print("tanx cc_toolchain.basename:",cc_toolchain.all_files.to_list()[-2].basename)
+    # print("tanx cc_toolchain.dirname:",cc_toolchain.all_files.to_list()[-2].dirname)
+    # print("tanx cc_toolchain.extension:",cc_toolchain.all_files.to_list()[-2].extension)
+    # print("tanx cc_toolchain.path:",cc_toolchain.all_files.to_list()[-2].path)
+    # print("tanx cc_toolchain.root:",cc_toolchain.all_files.to_list()[-2].root.path)
     feature_configuration = _configure_features(
         ctx = ctx,
         cc_toolchain = cc_toolchain,

--- a/foreign_cc/private/cc_toolchain_util.bzl
+++ b/foreign_cc/private/cc_toolchain_util.bzl
@@ -196,20 +196,10 @@ def get_tools_info(ctx):
     """
     cc_toolchain = find_cpp_toolchain(ctx)
 
-    # print("tanx cc_toolchain.basename:",cc_toolchain.all_files.to_list()[-2].basename)
-    # print("tanx cc_toolchain.dirname:",cc_toolchain.all_files.to_list()[-2].dirname)
-    # print("tanx cc_toolchain.extension:",cc_toolchain.all_files.to_list()[-2].extension)
-    # print("tanx cc_toolchain.path:",cc_toolchain.all_files.to_list()[-2].path)
-    # print("tanx cc_toolchain.root:",cc_toolchain.all_files.to_list()[-2].root.path)
     feature_configuration = _configure_features(
         ctx = ctx,
         cc_toolchain = cc_toolchain,
     )
-    cppp = cc_common.get_tool_for_action(
-        feature_configuration = feature_configuration,
-        action_name = ACTION_NAMES.cpp_compile,
-    )
-    print("cppp", cppp)
 
     return CxxToolsInfo(
         cc = cc_common.get_tool_for_action(
@@ -317,7 +307,6 @@ def get_flags_info(ctx, link_output_file = None):
             ),
         ),
     )
-    print("tanx flags.cxx_linker_executable: ", flags.cxx_linker_executable)
 
     return CxxFlagsInfo(
         cc = _convert_flags(cc_toolchain_.compiler, _add_if_needed(flags.cc, copts)),

--- a/foreign_cc/private/framework/helpers.bzl
+++ b/foreign_cc/private/framework/helpers.bzl
@@ -148,6 +148,7 @@ def replace_exports(text, shell_context):
         fail("Wrong export declaration")
 
     (funname, after) = get_function_name(value.strip(" "))
+
     if funname:
         value = call_shell(shell_context, funname, *split_arguments(after.strip(" ")))
 
@@ -185,12 +186,12 @@ def do_function_call(text, shell_context):
     (funname, after) = get_function_name(text.strip(" "))
     if not funname:
         return text
-    print("tanx:", (funname, after))
+
     if funname == "export":
         return replace_exports(after, shell_context)
 
     arguments = split_arguments(after.strip(" ")) if after else []
-    print("tanx args:", arguments)
+
     return call_shell(shell_context, funname, *arguments)
 
 # buildifier: disable=function-docstring

--- a/foreign_cc/private/framework/helpers.bzl
+++ b/foreign_cc/private/framework/helpers.bzl
@@ -207,21 +207,21 @@ def split_arguments(text):
         # we are ignoring escaped quotes
         s_quote = current.find("\"")
         if s_quote < 0:
-            for e in current.split(" ") :
+            for e in current.split(" "):
                 if len(e) > 0:
                     parts.append(e)
             break
 
-        e_quote = current.find("\"", s_quote+1)
+        e_quote = current.find("\"", s_quote + 1)
         if e_quote < 0:
             fail("Incorrect quoting in fragment: {}".format(current))
-        
+
         # backtrack to first space, from here to e_quote is a token
-        e_before = current.rfind(" ", 0,s_quote)
+        e_before = current.rfind(" ", 0, s_quote)
         if e_before >= 0:
             before = current[0:e_before].strip(" ")
             parts += before.split(" ")
-        parts.append(current[e_before+1:e_quote+1])
-        current = current[e_quote+1:]
+        parts.append(current[e_before + 1:e_quote + 1])
+        current = current[e_quote + 1:]
 
     return parts

--- a/test/convert_shell_script_test.bzl
+++ b/test/convert_shell_script_test.bzl
@@ -84,6 +84,7 @@ def _split_arguments_test(ctx):
         " 1 2 3": ["1", "2", "3"],
         " usual \"quoted argument\"": ["usual", "\"quoted argument\""],
         "1 2": ["1", "2"],
+        'var "-flag1="redacted" -flag2="redacted""': ["var", "-flag1=\"redacted\" -flag2=\"redacted\""],
     }
     for case in cases:
         result = split_arguments(case)

--- a/test/convert_shell_script_test.bzl
+++ b/test/convert_shell_script_test.bzl
@@ -84,7 +84,7 @@ def _split_arguments_test(ctx):
         " 1 2 3": ["1", "2", "3"],
         " usual \"quoted argument\"": ["usual", "\"quoted argument\""],
         "1 2": ["1", "2"],
-        'var "-flag1="redacted" -flag2="redacted""': ["var", "-flag1=\"redacted\" -flag2=\"redacted\""],
+        "var -flag1=\"redacted\" -flag2=\"redacted\"": ["var", "-flag1=\"redacted\"", "-flag2=\"redacted\""],
     }
     for case in cases:
         result = split_arguments(case)


### PR DESCRIPTION
- The PR sets CC and CXX in meson to the ones configured in bazel, instead of system's. 
- It also tries to merge and set CFLAGS, CXXFLAGS, LDFLAGS with implicit flags from bazel
- refactoring `split_arguments` helper function to be more readable and able to process arguments with quotes 

Fixes #1073 