### PR TITLE
Allow runnable_binary to work on non-external targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ The following flags are required in Bazel 4.x but not Bazel 5.x or newer:
 Note that the rules may be compatible with older versions of Bazel but support may break
 in future changes as these older versions are not tested.
 
+Note also that the `runnable_binary` macro requires bazel 5.4.0, for the `rlocationpath` [path
+variable](https://bazel.build/reference/be/make-variables)
+
 ## News
 
 For more generalized updates, please see [NEWS.md](./NEWS.md) or checkout the

--- a/foreign_cc/utils.bzl
+++ b/foreign_cc/utils.bzl
@@ -9,7 +9,7 @@ def runnable_binary(name, binary, foreign_cc_target, match_binary_name = False, 
 
     The wrapper script also facilitates the running of binaries that are dynamically linked to shared libraries also built by rules_foreign_cc. The runnable bin could be used as a tool in a dependent bazel target
 
-    Note that this macro only works on foreign_cc_targets in external repositories, not in the main repository. This is due to the issue described here: https://github.com/bazelbuild/bazel/issues/10923
+    Note that this macro requires bazel 5.4.0 due to the use of the rlocationpath variable (see https://github.com/bazelbuild/bazel/issues/10923 for context)
     Also note that the macro requires the `--enable_runfiles` option to be set on Windows.
 
     Args:
@@ -43,7 +43,7 @@ def runnable_binary(name, binary, foreign_cc_target, match_binary_name = False, 
     )
 
     wrapper_cmd = """
-    sed s@EXECUTABLE@$(rootpath {name})@g $(location @rules_foreign_cc//foreign_cc/private:runnable_binary_wrapper.sh) > tmp
+    sed s@EXECUTABLE@$(rlocationpath {name})@g $(location @rules_foreign_cc//foreign_cc/private:runnable_binary_wrapper.sh) > tmp
     sed s@SH_BINARY_FILENAME@{sh_binary_filename}@g tmp > $@
     """
 


### PR DESCRIPTION
Before this change, runnable_binary would only work on targets in external repositories. This is due to a limitation of the rootpath function, with more context in https://github.com/bazelbuild/bazel/issues/10923

This switches the macro to use rlocationpath, which handles this use-case. Using rlocationpath requires bazel 5.4.0, so this also updates the docs accordingly.