### PR TITLE
Add missing sha256 for meson_src 1.1.1

### DIFF
--- a/toolchains/built_toolchains.bzl
+++ b/toolchains/built_toolchains.bzl
@@ -166,6 +166,7 @@ def _meson_toolchain(version, register_toolchains):
             http_archive,
             name = "meson_src",
             build_file_content = _MESON_BUILD_FILE_CONTENT,
+            sha256 = "d04b541f97ca439fb82fab7d0d480988be4bd4e62563a5ca35fadb5400727b1c",
             strip_prefix = "meson-1.1.1",
             url = "https://github.com/mesonbuild/meson/releases/download/1.1.1/meson-1.1.1.tar.gz",
         )


### PR DESCRIPTION
"calculated" with
```sh
curl -fsSL "https://github.com/mesonbuild/meson/releases/download/1.1.1/meson-1.1.1.tar.gz" | sha256sum -
```

See also https://bazelbuild.slack.com/archives/CA31HN1T3/p1698414059647089?thread_ts=1698412415.105119&cid=CA31HN1T3