### PR TITLE
Set an empty tools_data attribute for boost

### DIFF
--- a/foreign_cc/boost_build.bzl
+++ b/foreign_cc/boost_build.bzl
@@ -15,6 +15,7 @@ def _boost_build_impl(ctx):
         ctx.attr,
         configure_name = "BoostBuild",
         create_configure_script = _create_configure_script,
+        tools_data = [],
     )
     return cc_external_rule_impl(ctx, attrs)
 


### PR DESCRIPTION
This fixes #1071. I don't think there needs to be a tools_data, but the empty attribute is currently required.