### PR TITLE
Advertise CcInfo provider

### DIFF
--- a/foreign_cc/configure.bzl
+++ b/foreign_cc/configure.bzl
@@ -224,6 +224,7 @@ configure_make = rule(
     attrs = _attrs(),
     fragments = CC_EXTERNAL_RULE_FRAGMENTS,
     output_to_genfiles = True,
+    provides = [CcInfo],
     implementation = _configure_make,
     toolchains = [
         "@rules_foreign_cc//toolchains:autoconf_toolchain",


### PR DESCRIPTION
I somehow missed this in #1095 for `configure_make`.