### PR TITLE
Expand locations for cache entries

### DIFF
--- a/foreign_cc/cmake.bzl
+++ b/foreign_cc/cmake.bzl
@@ -263,7 +263,7 @@ def _create_configure_script(configureParameters):
         install_prefix = "$$INSTALLDIR$$",
         root = root,
         no_toolchain_file = no_toolchain_file,
-        user_cache = dict(ctx.attr.cache_entries),
+        user_cache = expand_locations_and_make_variables(ctx, ctx.attr.cache_entries, "cache_entries", data),
         user_env = expand_locations_and_make_variables(ctx, ctx.attr.env, "env", data),
         options = expand_locations_and_make_variables(ctx, ctx.attr.generate_args, "generate_args", data),
         cmake_commands = cmake_commands,


### PR DESCRIPTION
I'm confused about how to dynamically set `cache_entries`, but there may be another way of doing this that I'm not aware of?

If adding this feature is wanted by the community, I will draft up some changes to the documentation to reflect the new behavior. However, I wanted to gauge the interest and solicit some feedback before doing so.