### PR TITLE
Increase resiliency of `runnable_binary`

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -123,7 +123,7 @@ release_archive="$${RELEASE}"
 # TODO: If a release is set, we assume it's set to a branch name.
 # thus we default the archive value to a commit. This is likely
 # only appropriate when publishing on the branch in specified
-# and a smarter solution should be found to avoid unexpected behavior. 
+# and a smarter solution should be found to avoid unexpected behavior.
 if [[ -n "\\$${RELEASE:-}" ]]; then
     release="\\$${RELEASE}"
     release_archive="\\$${commit}"

--- a/foreign_cc/private/runnable_binary_wrapper.sh
+++ b/foreign_cc/private/runnable_binary_wrapper.sh
@@ -1,24 +1,5 @@
 #!/usr/bin/env bash
 
-# RUN_UNDER_RUNFILES is set in the "bazel test" environment, where all transitive runfiles are placed into one directory
-# Otherwise, first cd to the runfiles dir for the wrapped executable before searching for shared libraries for the wrapped executable
-if [[ -z $RUN_UNDER_RUNFILES ]]; then
-    SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-    RUNFILES_DIR_TMP=${SCRIPT_DIR}/SH_BINARY_FILENAME.runfiles
-
-    if [[ -d "$RUNFILES_DIR_TMP" ]]; then
-        RUNFILES_DIR="$RUNFILES_DIR_TMP"
-    fi
-
-    unset RUNFILES_DIR_TMP
-fi
-
-if [[ -n "$RUNFILES_DIR" ]] && [[ -d "$RUNFILES_DIR" ]]; then
-    cd ${RUNFILES_DIR}
-else
-    cd "$(pwd)"
-fi
-
 # --- begin runfiles.bash initialization v2 ---
 # Copy-pasted from the Bazel Bash runfiles library v2. (@bazel_tools//tools/bash/runfiles)
 set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
@@ -29,6 +10,8 @@ source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null
 source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
 { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
+
+cd "${RUNFILES_DIR}"
 
 EXE=EXECUTABLE
 EXE_PATH=$(rlocation "${EXE#external/}")
@@ -71,5 +54,4 @@ if [ ${#SHARED_LIBS_DIRS_ARRAY[@]} -ne 0 ]; then
 fi
 
 cd - &> /dev/null
-
 exec ${EXE_PATH} "$@"

--- a/foreign_cc/private/runnable_binary_wrapper.sh
+++ b/foreign_cc/private/runnable_binary_wrapper.sh
@@ -15,6 +15,8 @@ fi
 
 if [[ -n "$RUNFILES_DIR" ]] && [[ -d "$RUNFILES_DIR" ]]; then
     cd ${RUNFILES_DIR}
+else
+    cd "$(pwd)"
 fi
 
 # --- begin runfiles.bash initialization v2 ---
@@ -68,8 +70,6 @@ if [ ${#SHARED_LIBS_DIRS_ARRAY[@]} -ne 0 ]; then
     set -u
 fi
 
-if [[ -n "$RUNFILES_DIR" ]] && [[ -d "$RUNFILES_DIR" ]]; then
-    cd - &> /dev/null
-fi
+cd - &> /dev/null
 
 exec ${EXE_PATH} "$@"

--- a/foreign_cc/private/runnable_binary_wrapper.sh
+++ b/foreign_cc/private/runnable_binary_wrapper.sh
@@ -16,7 +16,7 @@ if [[ ! -d "${RUNFILES_DIR}" ]]; then
     exit 1;
 fi
 
-RUNFILES_DIR=$(realpath ${RUNFILES_DIR})
+RUNFILES_DIR=$( cd "$(dirname "${RUNFILES_DIR}")" ; pwd -P )
 
 cd "${RUNFILES_DIR}"
 

--- a/foreign_cc/private/runnable_binary_wrapper.sh
+++ b/foreign_cc/private/runnable_binary_wrapper.sh
@@ -7,7 +7,7 @@ if [[ -z $RUN_UNDER_RUNFILES ]]; then
     RUNFILES_DIR=${SCRIPT_DIR}/SH_BINARY_FILENAME.runfiles
 fi
 
-if [[ -n "$RUNFILES_DIR"]] && [[ -d "$RUNFILES_DIR" ]]; then
+if [[ -n "$RUNFILES_DIR" ]] && [[ -d "$RUNFILES_DIR" ]]; then
     cd ${RUNFILES_DIR}
 fi
 

--- a/foreign_cc/private/runnable_binary_wrapper.sh
+++ b/foreign_cc/private/runnable_binary_wrapper.sh
@@ -43,7 +43,7 @@ done < <(find . -name "*${SHARED_LIB_SUFFIX}" -print0)
 # Allow unbound variable here, in case there are no shared libraries
 set +u
 SHARED_LIBS_DIRS_ARRAY=()
-for lib in "${SHARED_LIBS_ARRAY[@]}"; do
+for lib in "${SHARED_LIBS_ARRAY[@]-}"; do
     SHARED_LIBS_DIRS_ARRAY+=($(dirname $(realpath $lib)))
 done
 set -u

--- a/foreign_cc/private/runnable_binary_wrapper.sh
+++ b/foreign_cc/private/runnable_binary_wrapper.sh
@@ -4,7 +4,13 @@
 # Otherwise, first cd to the runfiles dir for the wrapped executable before searching for shared libraries for the wrapped executable
 if [[ -z $RUN_UNDER_RUNFILES ]]; then
     SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-    RUNFILES_DIR=${SCRIPT_DIR}/SH_BINARY_FILENAME.runfiles
+    RUNFILES_DIR_TMP=${SCRIPT_DIR}/SH_BINARY_FILENAME.runfiles
+
+    if [[ -d "$RUNFILES_DIR_TMP" ]]; then
+        RUNFILES_DIR="$RUNFILES_DIR_TMP"
+    fi
+
+    unset RUNFILES_DIR_TMP
 fi
 
 if [[ -n "$RUNFILES_DIR" ]] && [[ -d "$RUNFILES_DIR" ]]; then

--- a/foreign_cc/private/runnable_binary_wrapper.sh
+++ b/foreign_cc/private/runnable_binary_wrapper.sh
@@ -16,7 +16,7 @@ if [[ ! -d "${RUNFILES_DIR}" ]]; then
     exit 1;
 fi
 
-RUNFILES_DIR=$( cd "$(dirname "${RUNFILES_DIR}")" ; pwd -P )
+RUNFILES_DIR=$( cd "${RUNFILES_DIR}" ; pwd -P )
 
 cd "${RUNFILES_DIR}"
 

--- a/foreign_cc/private/runnable_binary_wrapper.sh
+++ b/foreign_cc/private/runnable_binary_wrapper.sh
@@ -40,10 +40,13 @@ while IFS=  read -r -d $'\0'; do
 done < <(find . -name "*${SHARED_LIB_SUFFIX}" -print0)
 
 # Add paths to shared library directories to SHARED_LIBS_DIRS_ARRAY
+# Allow unbound variable here, in case there are no shared libraries
+set +u
 SHARED_LIBS_DIRS_ARRAY=()
 for lib in "${SHARED_LIBS_ARRAY[@]}"; do
     SHARED_LIBS_DIRS_ARRAY+=($(dirname $(realpath $lib)))
 done
+set -u
 
 # Remove duplicates from array
 IFS=" " read -r -a SHARED_LIBS_DIRS_ARRAY <<< "$(tr ' ' '\n' <<< "${SHARED_LIBS_DIRS_ARRAY[@]}" | sort -u | tr '\n' ' ')"

--- a/foreign_cc/private/runnable_binary_wrapper.sh
+++ b/foreign_cc/private/runnable_binary_wrapper.sh
@@ -6,7 +6,10 @@ if [[ -z $RUN_UNDER_RUNFILES ]]; then
     SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
     RUNFILES_DIR=${SCRIPT_DIR}/SH_BINARY_FILENAME.runfiles
 fi
-cd ${RUNFILES_DIR}
+
+if [[ -n "$RUNFILES_DIR"]] && [[ -d "$RUNFILES_DIR" ]]; then
+    cd ${RUNFILES_DIR}
+fi
 
 # --- begin runfiles.bash initialization v2 ---
 # Copy-pasted from the Bazel Bash runfiles library v2. (@bazel_tools//tools/bash/runfiles)
@@ -59,5 +62,8 @@ if [ ${#SHARED_LIBS_DIRS_ARRAY[@]} -ne 0 ]; then
     set -u
 fi
 
-cd - &> /dev/null
+if [[ -n "$RUNFILES_DIR" ]] && [[ -d "$RUNFILES_DIR" ]]; then
+    cd - &> /dev/null
+fi
+
 exec ${EXE_PATH} "$@"

--- a/foreign_cc/private/runnable_binary_wrapper.sh
+++ b/foreign_cc/private/runnable_binary_wrapper.sh
@@ -49,11 +49,9 @@ if [[ -v SHARED_LIBS_ARRAY[@] ]]; then
 fi
 
 if [[ -v SHARED_LIBS_DIRS_ARRAY[@] ]]; then
-   # Remove duplicates from array
-   IFS=" " read -r -a SHARED_LIBS_DIRS_ARRAY <<< "$(tr ' ' '\n' <<< "${SHARED_LIBS_DIRS_ARRAY[@]}" | sort -u | tr '\n' ' ')"
-fi
+    # Remove duplicates from array
+    IFS=" " read -r -a SHARED_LIBS_DIRS_ARRAY <<< "$(tr ' ' '\n' <<< "${SHARED_LIBS_DIRS_ARRAY[@]}" | sort -u | tr '\n' ' ')"
 
-if [[ -v SHARED_LIBS_DIRS_ARRAY[@] ]]; then
     # Allow unbound variable here, in case LD_LIBRARY_PATH or similar is not already set
     set +u
     for dir in "${SHARED_LIBS_DIRS_ARRAY[@]}"; do

--- a/foreign_cc/private/runnable_binary_wrapper.sh
+++ b/foreign_cc/private/runnable_binary_wrapper.sh
@@ -11,6 +11,13 @@ source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/
 { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
+if [[ ! -d "${RUNFILES_DIR}" ]]; then
+    >&2 echo "RUNFILES_DIR is set to '${RUNFILES_DIR}' which does not exist";
+    exit 1;
+fi
+
+RUNFILES_DIR=$(realpath ${RUNFILES_DIR})
+
 cd "${RUNFILES_DIR}"
 
 EXE=EXECUTABLE

--- a/foreign_cc/private/runnable_binary_wrapper.sh
+++ b/foreign_cc/private/runnable_binary_wrapper.sh
@@ -40,15 +40,14 @@ while IFS=  read -r -d $'\0'; do
 done < <(find . -name "*${SHARED_LIB_SUFFIX}" -print0)
 
 # Add paths to shared library directories to SHARED_LIBS_DIRS_ARRAY
-
-if [[ -v SHARED_LIBS_ARRAY[@] ]]; then
-    SHARED_LIBS_DIRS_ARRAY=()
+SHARED_LIBS_DIRS_ARRAY=()
+if [ ${#SHARED_LIBS_ARRAY[@]} -ne 0 ]; then
     for lib in "${SHARED_LIBS_ARRAY[@]}"; do
         SHARED_LIBS_DIRS_ARRAY+=($(dirname $(realpath $lib)))
     done
 fi
 
-if [[ -v SHARED_LIBS_DIRS_ARRAY[@] ]]; then
+if [ ${#SHARED_LIBS_DIRS_ARRAY[@]} -ne 0 ]; then
     # Remove duplicates from array
     IFS=" " read -r -a SHARED_LIBS_DIRS_ARRAY <<< "$(tr ' ' '\n' <<< "${SHARED_LIBS_DIRS_ARRAY[@]}" | sort -u | tr '\n' ' ')"
 


### PR DESCRIPTION
In the same vein as https://github.com/bazelbuild/rules_foreign_cc/pull/1093, we want to allow `runnable_binary` to run on targets without shared libraries

Copy and pasted from #1093 

> When using the runnable_binary macro with a binary e.g. diff that does not involve any shared libraries, the following error is produced:
>
> line 46: SHARED_LIBS_ARRAY[@]: unbound variable
>
> As find . -name "*${SHARED_LIB_SUFFIX}" -print0 does not return any results (thus SHARED_LIBS_ARRAY) , along with set -uo earlier in the script, this assumes that there will always be some shared library files.

Also, this PR introduces checks for whether the directory which is specified by `$RUNFILES_DIR` actually exists. If it does not exist, `cd`ing into it will crash the script (even though the rest of the script would have run fine). This is applicable for cases where the binary has runfiles, and is also a runfile itself.