### PR TITLE
Fix `//openssl/...` by calling `openssl_setup()`

### DIFF
--- a/examples/third_party/WORKSPACE.bazel
+++ b/examples/third_party/WORKSPACE.bazel
@@ -17,3 +17,7 @@ local_repository(
 load("//:repositories.bzl", "repositories")
 
 repositories()
+
+load("//:setup.bzl", "setup")
+
+setup()


### PR DESCRIPTION
This is the proximate cause that resulted in https://github.com/bazelbuild/rules_foreign_cc/issues/1135