### PR TITLE
Build msvc cmake with prebuilt cmake

### DIFF
--- a/foreign_cc/built_tools/cmake_build.bzl
+++ b/foreign_cc/built_tools/cmake_build.bzl
@@ -1,14 +1,40 @@
-""" Rule for building CMake from sources. """
+""" Macro for building CMake from sources. """
 
-load("//foreign_cc:defs.bzl", "configure_make")
+load("//foreign_cc:defs.bzl", "cmake_variant", "configure_make")
 
 def cmake_tool(name, srcs, **kwargs):
+    """Macro for building CMake
+
+    Args:
+        name: A unique name for this target
+        srcs: The target containing the build tool's sources
+        **kwargs: Remaining args
+    """
     tags = ["manual"] + kwargs.pop("tags", [])
 
-    configure_make(
+    native.alias(
         name = "{}.build".format(name),
+        actual = select({
+            ":msvc_compiler": "{}_msvc".format(name),
+            "//conditions:default": "{}_default".format(name),
+        }),
+    )
+
+    cmake_variant(
+        name = "{}_msvc".format(name),
+        # to prevent errors with incompatible _WIN32_WINNT in cmlibarchive
+        # override NTDDI_VERSION to match _WIN32_WINNT set in the default cc_toolchain
+        copts = ["/D NTDDI_VERSION=0x06010000"],
+        lib_source = srcs,
+        out_binaries = ["cmake.exe"],
+        toolchain = "@rules_foreign_cc//toolchains:preinstalled_cmake_toolchain",
+        tags = tags,
+        **kwargs
+    )
+
+    configure_make(
+        name = "{}_default".format(name),
         configure_command = "bootstrap",
-        configure_options = ["--", "-DCMAKE_MAKE_PROGRAM=$$MAKE$$"],
         # On macOS at least -DDEBUG gets set for a fastbuild
         copts = ["-UDEBUG"],
         lib_source = srcs,

--- a/toolchains/built_toolchains.bzl
+++ b/toolchains/built_toolchains.bzl
@@ -72,6 +72,9 @@ def _cmake_toolchain(version, register_toolchains):
             sha256 = sha256,
             strip_prefix = prefix,
             urls = urls,
+            patches = [
+                Label("//toolchains:cmake-c++11.patch"),
+            ],
         )
         return
 

--- a/toolchains/cmake-c++11.patch
+++ b/toolchains/cmake-c++11.patch
@@ -1,0 +1,15 @@
+See <https://discourse.cmake.org/t/cmake-error-at-cmakelists-txt-117-message-the-c-compiler-does-not-support-c-11-e-g-std-unique-ptr/3774/8>
+
+--- CMakeLists.txt	2023-01-24 13:46:17.000000000 -0800
++++ CMakeLists.txt	2023-01-24 13:46:43.000000000 -0800
+@@ -96,10 +96,6 @@
+
+   # check for available C++ features
+   include(${CMake_SOURCE_DIR}/Source/Checks/cm_cxx_features.cmake)
+-
+-  if(NOT CMake_HAVE_CXX_UNIQUE_PTR)
+-    message(FATAL_ERROR "The C++ compiler does not support C++11 (e.g. std::unique_ptr).")
+-  endif()
+ endif()
+
+ # Inform STL library header wrappers whether to use system versions.


### PR DESCRIPTION
On Windows using the msvc compiler, CMake can only be built using an existing binary CMake:

https://github.com/Kitware/CMake/blob/master/README.rst#windows

This means the existing `cmake_tool` fails to build for msvc (it tries to pass mingw compiler flags).  This change enables CMake to be built using a preinstalled CMake.

This change follows the pattern for pkg-config whereby unix/msvc have different build rules.