### PR TITLE
Allow `prefix` to be set as an absolute path in `configure`

### DIFF
--- a/foreign_cc/configure.bzl
+++ b/foreign_cc/configure.bzl
@@ -195,13 +195,6 @@ def _attrs():
         "configure_prefix": attr.string(
             doc = "A prefix for the call to the `configure_command`.",
         ),
-        "install_prefix": attr.string(
-            doc = (
-                "Install prefix, i.e. relative path to where to install the result of the build. " +
-                "Passed to the 'configure' script with the flag specified by prefix_flag."
-            ),
-            mandatory = False,
-        ),
         "experimental_absolute_install_prefix": attr.bool(
             doc = (
                 "Allows the install_prefix to be an absolute path, and relies on DESTDIR to place" +
@@ -209,6 +202,13 @@ def _attrs():
             ),
             mandatory = False,
             default = False,
+        ),
+        "install_prefix": attr.string(
+            doc = (
+                "Install prefix, i.e. relative path to where to install the result of the build. " +
+                "Passed to the 'configure' script with the flag specified by prefix_flag."
+            ),
+            mandatory = False,
         ),
         "prefix_flag": attr.string(
             doc = (

--- a/foreign_cc/private/configure_script.bzl
+++ b/foreign_cc/private/configure_script.bzl
@@ -16,6 +16,7 @@ def create_configure_script(
         env_vars,
         configure_in_place,
         prefix_flag,
+        absolute_prefix,
         autoconf,
         autoconf_options,
         autoreconf,
@@ -68,12 +69,15 @@ def create_configure_script(
             options = " ".join(autoreconf_options),
         ).lstrip())
 
+    prefix_dir = "$$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$"
+
     script.append("##mkdirs## $$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$")
-    script.append("{env_vars} {prefix}\"{configure}\" {prefix_flag}$$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$ {user_options}".format(
+    script.append("{env_vars} {prefix}\"{configure}\" {prefix_flag}{prefix_dir} {user_options}".format(
         env_vars = get_make_env_vars(workspace_name, tools, flags, env_vars, deps, inputs),
         prefix = configure_prefix,
         configure = configure_path,
         prefix_flag = prefix_flag,
+        prefix_dir = "$$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$" if not absolute_prefix else "$$INSTALL_PREFIX$$",
         user_options = " ".join(user_options),
     ))
 

--- a/foreign_cc/private/configure_script.bzl
+++ b/foreign_cc/private/configure_script.bzl
@@ -69,8 +69,6 @@ def create_configure_script(
             options = " ".join(autoreconf_options),
         ).lstrip())
 
-    prefix_dir = "$$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$"
-
     script.append("##mkdirs## $$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$")
     script.append("{env_vars} {prefix}\"{configure}\" {prefix_flag}{prefix_dir} {user_options}".format(
         env_vars = get_make_env_vars(workspace_name, tools, flags, env_vars, deps, inputs),


### PR DESCRIPTION
This PR allows setting the `--prefix` flag to an absolute path for `configure`. When `make` is invoked, targets that start with `install` or `uninstall` are given a `DESTDIR` flag which instructs `make` to place the install output into the directory that the rules expect the installed files to be in.

Since there could be some shortfalls with this approach of setting the `prefix` flag (namely if `make` doesn't support `DESTDIR` for some reason) this new option is specified as "experimental"

Closes https://github.com/bazelbuild/rules_foreign_cc/issues/823