### PR TITLE
Fix tool path for nmake

### DIFF
--- a/foreign_cc/private/make_env_vars.bzl
+++ b/foreign_cc/private/make_env_vars.bzl
@@ -10,8 +10,9 @@ def get_make_env_vars(
         flags,
         user_vars,
         deps,
-        inputs):
-    vars = _get_make_variables(workspace_name, tools, flags, user_vars)
+        inputs,
+        make_commands = []):
+    vars = _get_make_variables(workspace_name, tools, flags, user_vars, make_commands)
     deps_flags = _define_deps_flags(deps, inputs)
 
     # For cross-compilation.
@@ -94,7 +95,7 @@ _MAKE_TOOLS = {
     # missing: cxx_linker_executable
 }
 
-def _get_make_variables(workspace_name, tools, flags, user_env_vars):
+def _get_make_variables(workspace_name, tools, flags, user_env_vars, make_commands):
     vars = {}
 
     for flag in _MAKE_FLAGS:
@@ -115,9 +116,12 @@ def _get_make_variables(workspace_name, tools, flags, user_env_vars):
             # Force absolutize of tool paths, which may relative to the exec root (e.g. hermetic toolchains built from source)
             tool_value_absolute = _absolutize(workspace_name, tool_value, True)
 
-            # If the tool path contains whitespaces (e.g. C:\Program Files\...),
-            # MSYS2 requires that the path is wrapped in double quotes
-            if " " in tool_value_absolute:
+            # There are 2 conditions where we need to wrap the tool path in double quotes:
+            # 1. If the tool path contains whitespaces (e.g. C:\Program Files\...),
+            #    MSYS2 requires that the path is wrapped in double quotes.
+            # 2. If nmake is used, it requires the tool path to be wrapped in double quotes,
+            #    otherwise nmake will output the command as a string instead of executing it.
+            if " " in tool_value_absolute or _nmake_in_make_commands(make_commands):
                 tool_value_absolute = "\\\"" + tool_value_absolute + "\\\""
 
             tools_dict[tool] = [tool_value_absolute]
@@ -140,3 +144,6 @@ def _absolutize(workspace_name, text, force = False):
 
 def _join_flags_list(workspace_name, flags):
     return " ".join([_absolutize(workspace_name, flag) for flag in flags])
+
+def _nmake_in_make_commands(make_commands):
+    return make_commands and "nmake.exe" in make_commands[0]

--- a/foreign_cc/private/make_script.bzl
+++ b/foreign_cc/private/make_script.bzl
@@ -19,7 +19,7 @@ def create_make_script(
     script.append("##symlink_contents_to_dir## $$EXT_BUILD_ROOT$$/{} $$BUILD_TMPDIR$$ False".format(root))
 
     script.append("##enable_tracing##")
-    configure_vars = get_make_env_vars(workspace_name, tools, flags, env_vars, deps, inputs)
+    configure_vars = get_make_env_vars(workspace_name, tools, flags, env_vars, deps, inputs, make_commands)
     script.extend(["{env_vars} {command}".format(
         env_vars = configure_vars,
         command = command,


### PR DESCRIPTION
There is a problem (or feature) with [nmake](https://learn.microsoft.com/en-us/cpp/build/reference/nmake-reference?view=msvc-170) where if you don't wrap the path for tools like CC in double quotes, nmake will only print out the command instead of executing it.

For example, given the following makefile:

```
CC = C:/my/toolchain/path/cl.exe

foo: main.cpp
 $(CC) main.cpp
```

running nmake outputs:

```
F:\USERS\jsun\test>nmake

Microsoft (R) Program Maintenance Utility Version 14.16.27051.0
Copyright (C) Microsoft Corporation.  All rights reserved.

        C:/my/toolchain/path/cl.exe main.cpp
```

I believe this problem hasn't surfaced till now as it is already quoting tool path on windows if they have a space in it. [ref](https://github.com/bazelbuild/rules_foreign_cc/blob/main/foreign_cc/private/make_env_vars.bzl#L120-L121)

We encountered this issue as we are using our own msvc toolchain and it did not have any space in the tool path.

This problem also surfaces when rules_foreign_cc builds its own pkg-config. i.e. 

```
bazel build @rules_foreign_cc//toolchains/private:pkgconfig_tool
```

This PR attempts to fix this by checking if nmake is used as a part of make_commands and if so wrap the tool path in quotes.
