### PR TITLE
Add make 4.4.1

### DIFF
--- a/foreign_cc/repositories.bzl
+++ b/foreign_cc/repositories.bzl
@@ -10,7 +10,7 @@ def rules_foreign_cc_dependencies(
         native_tools_toolchains = [],
         register_default_tools = True,
         cmake_version = "3.23.2",
-        make_version = "4.4",
+        make_version = "4.4.1",
         ninja_version = "1.11.1",
         meson_version = "1.1.1",
         pkgconfig_version = "0.29.2",

--- a/toolchains/built_toolchains.bzl
+++ b/toolchains/built_toolchains.bzl
@@ -85,6 +85,21 @@ def _make_toolchain(version, register_toolchains):
         native.register_toolchains(
             "@rules_foreign_cc//toolchains:built_make_toolchain",
         )
+
+    if version == "4.4.1":
+        maybe(
+            http_archive,
+            name = "gnumake_src",
+            build_file_content = _ALL_CONTENT,
+            sha256 = "dd16fb1d67bfab79a72f5e8390735c49e3e8e70b4945a15ab1f81ddb78658fb3",
+            strip_prefix = "make-4.4.1",
+            urls = [
+                "https://mirror.bazel.build/ftpmirror.gnu.org/gnu/make/make-4.4.1.tar.gz",
+                "http://ftpmirror.gnu.org/gnu/make/make-4.4.1.tar.gz",
+            ],
+        )
+        return
+
     if version == "4.4":
         maybe(
             http_archive,


### PR DESCRIPTION
It was released a while ago, and, although I haven't been able to track down the exact reason why, I keep seeing jobserver failures (on linux) that don't happen on either 4.3 or 4.4.1, leading me to believe there's probably a bug in the new 4.4 jobserver code that was fixed in 4.4.1.