### PR TITLE
Fix windows examples CI by upgrading TLS trust store

### DIFF
--- a/.bazelci/config.yaml
+++ b/.bazelci/config.yaml
@@ -157,6 +157,13 @@ tasks:
       - "-//cmake_hello_world_lib/static:libhello_example"
       - "-//cmake_hello_world_lib/static:test_hello"
       - "-//cmake_with_data/..."
+    batch_commands:
+      - cd $env:USERPROFILE;
+      - Invoke-WebRequest https://curl.haxx.se/ca/cacert.pem -OutFile $env:USERPROFILE\cacert.pem;
+      - $plaintext_pw = 'PASSWORD';
+      - $secure_pw = ConvertTo-SecureString $plaintext_pw -AsPlainText -Force;
+      - & 'C:\Program Files\OpenSSL-Win64\bin\openssl.exe' pkcs12 -export -nokeys -out certs.pfx -in cacert.pem -passout pass:$plaintext_pw;
+      - Import-PfxCertificate -Password $secure_pw  -CertStoreLocation Cert:\LocalMachine\Root -FilePath certs.pfx;
     build_targets: *windows_targets
     test_targets: *windows_targets
     build_flags:

--- a/.bazelci/config.yaml
+++ b/.bazelci/config.yaml
@@ -158,8 +158,7 @@ tasks:
       - "-//cmake_hello_world_lib/static:test_hello"
       - "-//cmake_with_data/..."
     batch_commands:
-      - echo %cd%
-      - powershell -noexit "& "".\.bazelci\windows-update-certs.ps1"""
+      - powershell -noexit "& "".\..\.bazelci\windows-update-certs.ps1"""
     build_targets: *windows_targets
     test_targets: *windows_targets
     build_flags:

--- a/.bazelci/config.yaml
+++ b/.bazelci/config.yaml
@@ -158,7 +158,7 @@ tasks:
       - "-//cmake_hello_world_lib/static:test_hello"
       - "-//cmake_with_data/..."
     batch_commands:
-      - powershell -noexit "& ""windows-update-certs.ps1"""
+      - powershell -noexit "& "".\.bazelci\windows-update-certs.ps1"""
     build_targets: *windows_targets
     test_targets: *windows_targets
     build_flags:

--- a/.bazelci/config.yaml
+++ b/.bazelci/config.yaml
@@ -158,12 +158,7 @@ tasks:
       - "-//cmake_hello_world_lib/static:test_hello"
       - "-//cmake_with_data/..."
     batch_commands:
-      - cd $env:USERPROFILE;
-      - Invoke-WebRequest https://curl.haxx.se/ca/cacert.pem -OutFile $env:USERPROFILE\cacert.pem;
-      - $plaintext_pw = 'PASSWORD';
-      - $secure_pw = ConvertTo-SecureString $plaintext_pw -AsPlainText -Force;
-      - \& 'C:\Program Files\OpenSSL-Win64\bin\openssl.exe' pkcs12 -export -nokeys -out certs.pfx -in cacert.pem -passout pass:$plaintext_pw;
-      - Import-PfxCertificate -Password $secure_pw  -CertStoreLocation Cert:\LocalMachine\Root -FilePath certs.pfx;
+      - powershell -noexit "& "windows-update-certs.ps1"""
     build_targets: *windows_targets
     test_targets: *windows_targets
     build_flags:

--- a/.bazelci/config.yaml
+++ b/.bazelci/config.yaml
@@ -158,6 +158,7 @@ tasks:
       - "-//cmake_hello_world_lib/static:test_hello"
       - "-//cmake_with_data/..."
     batch_commands:
+      - echo %cd%
       - powershell -noexit "& "".\.bazelci\windows-update-certs.ps1"""
     build_targets: *windows_targets
     test_targets: *windows_targets

--- a/.bazelci/config.yaml
+++ b/.bazelci/config.yaml
@@ -158,7 +158,7 @@ tasks:
       - "-//cmake_hello_world_lib/static:test_hello"
       - "-//cmake_with_data/..."
     batch_commands:
-      - powershell -noexit "& "windows-update-certs.ps1"""
+      - powershell -noexit "& ""windows-update-certs.ps1"""
     build_targets: *windows_targets
     test_targets: *windows_targets
     build_flags:

--- a/.bazelci/config.yaml
+++ b/.bazelci/config.yaml
@@ -162,7 +162,7 @@ tasks:
       - Invoke-WebRequest https://curl.haxx.se/ca/cacert.pem -OutFile $env:USERPROFILE\cacert.pem;
       - $plaintext_pw = 'PASSWORD';
       - $secure_pw = ConvertTo-SecureString $plaintext_pw -AsPlainText -Force;
-      - & 'C:\Program Files\OpenSSL-Win64\bin\openssl.exe' pkcs12 -export -nokeys -out certs.pfx -in cacert.pem -passout pass:$plaintext_pw;
+      - \& 'C:\Program Files\OpenSSL-Win64\bin\openssl.exe' pkcs12 -export -nokeys -out certs.pfx -in cacert.pem -passout pass:$plaintext_pw;
       - Import-PfxCertificate -Password $secure_pw  -CertStoreLocation Cert:\LocalMachine\Root -FilePath certs.pfx;
     build_targets: *windows_targets
     test_targets: *windows_targets

--- a/.bazelci/windows-update-certs.ps1
+++ b/.bazelci/windows-update-certs.ps1
@@ -2,5 +2,5 @@ cd $env:USERPROFILE;
 Invoke-WebRequest https://curl.haxx.se/ca/cacert.pem -OutFile $env:USERPROFILE\cacert.pem;
 $plaintext_pw = 'PASSWORD';
 $secure_pw = ConvertTo-SecureString $plaintext_pw -AsPlainText -Force;
-& 'C:\Program Files\OpenSSL-Win64\bin\openssl.exe' pkcs12 -export -nokeys -out certs.pfx -in cacert.pem -passout pass:$plaintext_pw;
+& openssl.exe pkcs12 -export -nokeys -out certs.pfx -in cacert.pem -passout pass:$plaintext_pw;
 Import-PfxCertificate -Password $secure_pw  -CertStoreLocation Cert:\LocalMachine\Root -FilePath certs.pfx;

--- a/.bazelci/windows-update-certs.ps1
+++ b/.bazelci/windows-update-certs.ps1
@@ -1,0 +1,6 @@
+cd $env:USERPROFILE;
+Invoke-WebRequest https://curl.haxx.se/ca/cacert.pem -OutFile $env:USERPROFILE\cacert.pem;
+$plaintext_pw = 'PASSWORD';
+$secure_pw = ConvertTo-SecureString $plaintext_pw -AsPlainText -Force;
+& 'C:\Program Files\OpenSSL-Win64\bin\openssl.exe' pkcs12 -export -nokeys -out certs.pfx -in cacert.pem -passout pass:$plaintext_pw;
+Import-PfxCertificate -Password $secure_pw  -CertStoreLocation Cert:\LocalMachine\Root -FilePath certs.pfx;


### PR DESCRIPTION
This PR is an attempt to fix the CI windows failure caused by out of date TLS certificates, the solution is lifted from the python repo link here https://github.com/python/cpython/issues/80192#issuecomment-1093815328

I couldn't get the windows build to work locally, so CI was the testbed