### PR TITLE
Add j2objc fragment to rules

### DIFF
--- a/test/standard_cxx_flags_test/tests.bzl
+++ b/test/standard_cxx_flags_test/tests.bzl
@@ -65,7 +65,7 @@ _flags_test = rule(
         "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
     },
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
-    fragments = ["cpp"],
+    fragments = ["cpp", "j2objc"]],
     test = True,
 )
 

--- a/test/standard_cxx_flags_test/tests.bzl
+++ b/test/standard_cxx_flags_test/tests.bzl
@@ -65,7 +65,7 @@ _flags_test = rule(
         "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
     },
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
-    fragments = ["cpp", "j2objc"]],
+    fragments = ["cpp", "j2objc"],
     test = True,
 )
 


### PR DESCRIPTION
This is required since some linking logic moved to starlark

Fixes https://github.com/bazelbuild/rules_foreign_cc/issues/1174

CC Greenteam @meteorcloudy 