### PR TITLE
Remove cpu:x86_64 from mac ninja target

### DIFF
--- a/toolchains/prebuilt_toolchains.py
+++ b/toolchains/prebuilt_toolchains.py
@@ -143,7 +143,6 @@ NINJA_TARGETS = {
         "@platforms//os:linux",
     ],
     "mac": [
-        "@platforms//cpu:x86_64",
         "@platforms//os:macos",
     ],
     "win": [


### PR DESCRIPTION
Ninja provides universal binaries, the cpu restriction is unnecessary and causes toolchain resolution issues when running on Apple Silicon. E.g.:

```
INFO: ToolchainResolution: Performing resolution of @@rules_foreign_cc~0.10.1//toolchains:ninja_toolchain for target platform @@local_config_platform//:host
      ToolchainResolution:   Toolchain @@rules_foreign_cc~0.10.1~tools~ninja_1.11.1_linux//:ninja_tool is compatible with target plaform, searching for execution platforms:
      ToolchainResolution:     Incompatible execution platform @@local_config_platform//:host; mismatching values: x86_64, linux
      ToolchainResolution:   Toolchain @@rules_foreign_cc~0.10.1~tools~ninja_1.11.1_mac//:ninja_tool is compatible with target plaform, searching for execution platforms:
      ToolchainResolution:     Incompatible execution platform @@local_config_platform//:host; mismatching values: x86_64
      ToolchainResolution:   Toolchain @@rules_foreign_cc~0.10.1~tools~ninja_1.11.1_win//:ninja_tool is compatible with target plaform, searching for execution platforms:
      ToolchainResolution:     Incompatible execution platform @@local_config_platform//:host; mismatching values: x86_64, windows
      ToolchainResolution: No @@rules_foreign_cc~0.10.1//toolchains:ninja_toolchain toolchain found for target platform @@local_config_platform//:host.
```