### PR TITLE
Fix - Copy Dir ignores hidden files on macOS

### DIFF
--- a/foreign_cc/private/framework/toolchains/macos_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/macos_commands.bzl
@@ -90,7 +90,7 @@ def copy_dir_contents_to_dir(source, target):
     # do something more complext for this environment.
     return """\
 if [[ -d "{source}" ]]; then
-  cp -L -R "{source}"/* "{target}"
+  cp -L -R "{source}"/ "{target}"
 else
   cp -L -R "{source}" "{target}"
 fi


### PR DESCRIPTION
The copy_dir_contents_to_dir command currently ignores hidden files (e.g. dotfiles), leading to missing files after copying. Removing the * character in this case maintains the same behaviour, only with the inclusion of hidden files (.clang-tidy, .gitignore, etc).