### PR TITLE
Fix compatibility with `--incompatible_sandbox_hermetic_tmp`

### DIFF
--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -458,6 +458,8 @@ def cc_external_rule_impl(ctx, attrs):
             outputs.libraries.shared_libraries +
             outputs.libraries.interface_libraries
         )
+    ] + [
+        "##replace_all_symlinks## $$INSTALLDIR$$",
     ]
 
     script_text = "\n".join([

--- a/foreign_cc/private/framework/toolchains/commands.bzl
+++ b/foreign_cc/private/framework/toolchains/commands.bzl
@@ -176,6 +176,18 @@ PLATFORM_COMMANDS = {
         ],
         doc = "Replaces absolute path 'abs_path' inside 'dir_' with a placeholder value",
     ),
+    "replace_all_symlinks": _command_info(
+        arguments = [
+            _argument_info(
+                name = "dir",
+                data_type = type(""),
+                doc = "Directory to search recursively",
+            ),
+        ],
+        doc = (
+            "Replace all target symlinks within given directory recursively."
+        ),
+    ),
     "replace_in_files": _command_info(
         arguments = [
             _argument_info(name = "dir_", data_type = type(""), doc = "Directory to search recursively"),

--- a/foreign_cc/private/framework/toolchains/freebsd_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/freebsd_commands.bzl
@@ -271,6 +271,12 @@ if [[ -L "{file}" ]]; then
 fi
 """.format(file = file)
 
+def replace_all_symlinks(dir):
+    return """\
+find "{dir}" -type l -exec bash -c 'for i in "$@"; do cp -a --remove-destination "$(realpath "$i")" "$i"; done' bash "{{}}" +""".format(
+        dir = dir,
+    )
+
 commands = struct(
     assert_script_errors = assert_script_errors,
     cat = cat,
@@ -296,6 +302,7 @@ commands = struct(
     replace_in_files = replace_in_files,
     replace_sandbox_paths = replace_sandbox_paths,
     replace_symlink = replace_symlink,
+    replace_all_symlinks = replace_all_symlinks,
     rm_rf = rm_rf,
     script_extension = script_extension,
     script_prelude = script_prelude,

--- a/foreign_cc/private/framework/toolchains/linux_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/linux_commands.bzl
@@ -253,6 +253,12 @@ if [[ -L "{file}" ]]; then
 fi
 """.format(file = file)
 
+def replace_all_symlinks(dir):
+    return """\
+find "{dir}" -type l -exec bash -c 'for i in "$@"; do cp -a --remove-destination "$(realpath "$i")" "$i"; done' bash "{{}}" +""".format(
+        dir = dir,
+    )
+
 commands = struct(
     assert_script_errors = assert_script_errors,
     cat = cat,
@@ -278,6 +284,7 @@ commands = struct(
     replace_in_files = replace_in_files,
     replace_sandbox_paths = replace_sandbox_paths,
     replace_symlink = replace_symlink,
+    replace_all_symlinks = replace_all_symlinks,
     rm_rf = rm_rf,
     script_extension = script_extension,
     script_prelude = script_prelude,

--- a/foreign_cc/private/framework/toolchains/macos_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/macos_commands.bzl
@@ -266,6 +266,21 @@ if [[ -L "{file}" ]]; then
 fi
 """.format(file = file)
 
+def replace_all_symlinks(dir):
+    return """\
+function realpath() {{
+  local previous="$1"
+  local next=$(readlink "${{previous}}")
+  while [ -n "${{next}}" ]; do
+    previous="${{next}}"
+    next=$(readlink "${{previous}}")
+  done
+  echo "${{previous}}"
+}}
+find "{dir}" -type l -exec bash -c 'for i in "$@"; do cp -af "$(realpath "$i")" "$i"; done' bash "{{}}" +""".format(
+        dir = dir,
+    )
+
 commands = struct(
     assert_script_errors = assert_script_errors,
     cat = cat,
@@ -291,6 +306,7 @@ commands = struct(
     replace_in_files = replace_in_files,
     replace_sandbox_paths = replace_sandbox_paths,
     replace_symlink = replace_symlink,
+    replace_all_symlinks = replace_all_symlinks,
     rm_rf = rm_rf,
     script_extension = script_extension,
     script_prelude = script_prelude,

--- a/foreign_cc/private/framework/toolchains/windows_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/windows_commands.bzl
@@ -270,6 +270,12 @@ if [[ -L "{file}" ]]; then
 fi
 """.format(file = file)
 
+def replace_all_symlinks(dir):
+    return """\
+find "{dir}" -type l -exec bash -c 'for i in "$@"; do cp -a --remove-destination "$(realpath "$i")" "$i"; done' bash "{{}}" +""".format(
+        dir = dir,
+    )
+
 commands = struct(
     assert_script_errors = assert_script_errors,
     cat = cat,
@@ -295,6 +301,7 @@ commands = struct(
     replace_in_files = replace_in_files,
     replace_sandbox_paths = replace_sandbox_paths,
     replace_symlink = replace_symlink,
+    replace_all_symlinks = replace_all_symlinks,
     rm_rf = rm_rf,
     script_extension = script_extension,
     script_prelude = script_prelude,


### PR DESCRIPTION
Instead of only replacing symlinks of declared output files, now we need
to replace symlinks of everything in the declared tree artifact. Without
this, Bazel 7 would fail when it verifies the tree artifact contents,
which would contain dangling symlinks when building with
`--incompatible_sandbox_hermetic_tmp`.

Fixes https://github.com/bazelbuild/rules_foreign_cc/issues/1129
