### PR TITLE
Exclude filenames with spaces from cmake toolchains

### DIFF
--- a/toolchains/prebuilt_toolchains.bzl
+++ b/toolchains/prebuilt_toolchains.bzl
@@ -29,6 +29,7 @@ filegroup(
             "WORKSPACE.bazel",
             "BUILD",
             "BUILD.bazel",
+            "**/* *",
         ],
     ),
 )

--- a/toolchains/prebuilt_toolchains.py
+++ b/toolchains/prebuilt_toolchains.py
@@ -241,6 +241,7 @@ filegroup(
             "WORKSPACE.bazel",
             "BUILD",
             "BUILD.bazel",
+            "**/* *",
         ],
     ),
 )


### PR DESCRIPTION
Without this, on macOS runfiles fail to build because of `cmake-3.23.2-macos-universal/doc/cmake/html/_sources/generator/Borland Makefiles.rst.txt`