### PR TITLE
fix: change cygpath to mixed mode

### DIFF
--- a/foreign_cc/private/framework/toolchains/windows_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/windows_commands.bzl
@@ -9,7 +9,7 @@ def script_extension():
     return ".sh"
 
 def pwd():
-    return "$(type -t cygpath > /dev/null && cygpath $(pwd) -w || pwd -W)"
+    return "$(type -t cygpath > /dev/null && cygpath $(pwd) -m || pwd -W)"
 
 def echo(text):
     return "echo \"{text}\"".format(text = text)


### PR DESCRIPTION
'autoconf' applications often has a ./configure stage that checks the $srcdir (source directory). This is represented in foreign_cc by a combination of $EXT_BUILD_ROOT and a relative path to the source. This check fails on windows if $EXT_BUILD_ROOT contains '\\' since it is an escape char under unix. Therefore, we need to generate $EXT_BUILD_ROOT with '/' instead.

Generating $EXT_BUILD_ROOT with '/' present a different problem as now the resulting PATH variable becomes the format "/C:/path/to/a:/C:/path/to/b". Due to ':' being used as both window drive leter assignment and linux path delimiter, MSYS2 gets very confused and doesn't resolve this correctly. Therefore, we need this to become the format "/C/path/to/a:/C/path/to/b".

$EXT_BUILD_ROOT is sometimes passed through the 'env' attribute by the user. We need to handle this scenario as well.