### PR TITLE
fix: path expansion on windows

### DIFF
--- a/foreign_cc/private/framework/toolchains/windows_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/windows_commands.bzl
@@ -27,7 +27,25 @@ def env():
     return "env"
 
 def path(expression):
+    # In windows we cannot add vars like $$EXT_BUILD_DEPS$$ directly to PATH as PATH is
+    # required to be in unix format. This implementation also assumes that the vars
+    # like $$EXT_BUILD_DEPS$$ are exported to the ENV.
+    expression = _path_var_expansion(expression)
     return "export PATH=\"{expression}:$PATH\"".format(expression = expression)
+
+def _path_var_expansion(expression):
+    result = []
+    parts = expression.split("$$")
+    if len(parts) < 3:
+        return expression
+
+    for index, part in enumerate(parts):
+        if index % 2 == 0:
+            result.append(part)
+        else:
+            result.append("${" + part + "/:/}")
+
+    return "/" + "".join(result)
 
 def touch(path):
     return "touch " + path


### PR DESCRIPTION
This is an extension of https://github.com/bazelbuild/rules_foreign_cc/pull/1204.

PATH variable updated by the `##path##` primitive does not get expanded correctly on windows. 

For example:

```
##path## $$EXT_BUILD_ROOT$$
```

gets expanded to 

```
export PATH=C:/users/me/bazel_cache/xxxxxx/execroot/myrepo:$PATH
```

At the beginning, the `C:` gets incorrectly interpreted as 2 paths under msys.

1. `C`
2. `/users/me/bazel_cache/xxxxxx/execroot/myrepo`

The desired expansion here is:

```
export PATH=/C/users/me/bazel_cache/xxxxxx/execroot/myrepo:$PATH
```

Which correctly gets interpreted as 1 path.