### PR TITLE
Update framework.bzl to account for externalIncludes

### DIFF
--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -926,7 +926,8 @@ def get_foreign_cc_dep(dep):
 # consider optimization here to do not iterate both collections
 def _get_headers(compilation_info):
     include_dirs = compilation_info.system_includes.to_list() + \
-                   compilation_info.includes.to_list()
+                   compilation_info.includes.to_list() + \
+                   getattr(compilation_info, "external_includes", depset()).to_list()
 
     # do not use quote includes, currently they do not contain
     # library-specific information


### PR DESCRIPTION
During our migration to Bazel 7, some of our cmake() rules broke. It turns out there is a new field in CcCompilationContext to account for external includes, as opposed to internal system_includes.

See https://github.com/bazelbuild/bazel/commit/a6ef0b341a8ffe8ab27e5ace79d8eaae158c422b