### PR TITLE
Revert "cmake: use variable expansion on generator args"

### DIFF
--- a/foreign_cc/cmake.bzl
+++ b/foreign_cc/cmake.bzl
@@ -265,7 +265,7 @@ def _create_configure_script(configureParameters):
         no_toolchain_file = no_toolchain_file,
         user_cache = dict(ctx.attr.cache_entries),
         user_env = expand_locations_and_make_variables(ctx, ctx.attr.env, "env", data),
-        options = expand_locations_and_make_variables(ctx, ctx.attr.generate_args, "generate_args", data),
+        options = attrs.generate_args,
         cmake_commands = cmake_commands,
         cmake_prefix = prefix,
         include_dirs = inputs.include_dirs,


### PR DESCRIPTION
Reverts bazelbuild/rules_foreign_cc#1087