### PR TITLE
Re-export runfiles env vars so that dependencies can use them

### DIFF
--- a/foreign_cc/private/runnable_binary_wrapper.sh
+++ b/foreign_cc/private/runnable_binary_wrapper.sh
@@ -1,15 +1,17 @@
 #!/usr/bin/env bash
 
-# --- begin runfiles.bash initialization v2 ---
-# Copy-pasted from the Bazel Bash runfiles library v2. (@bazel_tools//tools/bash/runfiles)
-set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library v3.
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
 source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-source "$0.runfiles/$f" 2>/dev/null || \
-source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-{ echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
-# --- end runfiles.bash initialization v2 ---
+    source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+    source "$0.runfiles/$f" 2>/dev/null || \
+    source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+    source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+    { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
+
+runfiles_export_envvars
 
 if [[ ! -d "${RUNFILES_DIR}" ]]; then
     >&2 echo "RUNFILES_DIR is set to '${RUNFILES_DIR}' which does not exist";


### PR DESCRIPTION
I've ran into a bug where a top-level target is able to use runfiles, but if a target is in the dependencies of the top-level target, it is not able to detect them. To fix this, I patched `rules_foreign_cc` to re-export the env cars used to find runfiles, and that seems to work