### PR TITLE
Add support for `/` in rule names

### DIFF
--- a/examples/cmake_synthetic_in_subdir/BUILD.bazel
+++ b/examples/cmake_synthetic_in_subdir/BUILD.bazel
@@ -1,0 +1,50 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@rules_cc//cc:defs.bzl", "cc_test")
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
+
+cmake(
+    name = "liba",
+    generate_args = ["-GNinja"],
+    # Demonstrate non-alphanumeric name
+    lib_name = "liba++",
+    lib_source = "//cmake_synthetic/liba:a_srcs",
+    postfix_script = "cp -p $$INSTALLDIR$$/lib/liba.a $$INSTALLDIR$$/lib/liba++.a",
+)
+
+cmake(
+    name = "mylibs/libb",
+    generate_args = ["-GNinja"],
+    lib_source = "//cmake_synthetic/libb:b_srcs",
+    deps = [":liba"],
+)
+
+cmake(
+    name = "lib_with_duplicate_transitive_bazel_deps",
+    cache_entries = {
+        "LIBA_DIR": "$$EXT_BUILD_DEPS$$",
+        "LIBB_DIR": "$$EXT_BUILD_DEPS$$",
+    },
+    generate_args = ["-GNinja"],
+    lib_name = "libc",
+    lib_source = "//cmake_synthetic/libc:c_srcs",
+    deps = [
+        "//cmake_synthetic/liba:lib_a_bazel",
+        "//cmake_synthetic/libb:lib_b_bazel",
+    ],
+)
+
+build_test(
+    name = "test_bazel_transitive_deps",
+    targets = [":lib_with_duplicate_transitive_bazel_deps"],
+)
+
+cc_test(
+    name = "test_libs",
+    srcs = [
+        "test_libb.cpp",
+    ],
+    deps = [
+        # liba should come from transitive dependencies
+        ":mylibs/libb",
+    ],
+)

--- a/examples/cmake_synthetic_in_subdir/liba/BUILD.bazel
+++ b/examples/cmake_synthetic_in_subdir/liba/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+filegroup(
+    name = "a_srcs",
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "lib_a_bazel",
+    srcs = ["src/liba.cpp"],
+    hdrs = ["src/liba.h"],
+    includes = ["src"],
+    visibility = ["//visibility:public"],
+)

--- a/examples/cmake_synthetic_in_subdir/liba/CMakeLists.txt
+++ b/examples/cmake_synthetic_in_subdir/liba/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 2.8.4)
+
+project(liba)
+
+add_subdirectory(src)

--- a/examples/cmake_synthetic_in_subdir/liba/src/CMakeLists.txt
+++ b/examples/cmake_synthetic_in_subdir/liba/src/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 2.8.4)
+
+set(LIBA_SRC liba.cpp liba.h)
+
+add_library(liba_static STATIC ${LIBA_SRC})
+
+set_target_properties(liba_static PROPERTIES OUTPUT_NAME "liba")
+IF (WIN32)
+  set_target_properties(liba_static PROPERTIES ARCHIVE_OUTPUT_NAME "liba")
+ELSE()
+  set_target_properties(liba_static PROPERTIES ARCHIVE_OUTPUT_NAME "a")
+ENDIF()
+set_target_properties(liba_static PROPERTIES PUBLIC_HEADER "liba.h")
+
+set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
+
+install(FILES liba.h DESTINATION include)
+
+install(TARGETS liba_static
+  EXPORT liba_targets
+  ARCHIVE DESTINATION lib
+  INCLUDES DESTINATION include
+  PUBLIC_HEADER DESTINATION include
+  )
+target_include_directories(liba_static INTERFACE
+    $<INSTALL_INTERFACE:include>
+)
+
+install(EXPORT liba_targets
+  DESTINATION lib/cmake/liba
+  FILE liba-config.cmake)

--- a/examples/cmake_synthetic_in_subdir/liba/src/liba.cpp
+++ b/examples/cmake_synthetic_in_subdir/liba/src/liba.cpp
@@ -1,0 +1,5 @@
+#include "liba.h"
+
+std::string hello_liba(void) {
+	return "Hello from LIBA!";
+}

--- a/examples/cmake_synthetic_in_subdir/liba/src/liba.h
+++ b/examples/cmake_synthetic_in_subdir/liba/src/liba.h
@@ -1,0 +1,9 @@
+#ifndef LIBA_H_
+#define LIBA_H_ (1)
+
+#include <stdio.h>
+#include <string>
+
+std::string hello_liba(void);
+
+#endif

--- a/examples/cmake_synthetic_in_subdir/libb/BUILD.bazel
+++ b/examples/cmake_synthetic_in_subdir/libb/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+filegroup(
+    name = "b_srcs",
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "lib_b_bazel",
+    srcs = ["src/libb.cpp"],
+    hdrs = ["src/libb.h"],
+    includes = ["src"],
+    visibility = ["//visibility:public"],
+    deps = ["//cmake_synthetic/liba:lib_a_bazel"],
+)

--- a/examples/cmake_synthetic_in_subdir/libb/CMakeLists.txt
+++ b/examples/cmake_synthetic_in_subdir/libb/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 2.8.4)
+
+project(libb)
+
+add_subdirectory(src)

--- a/examples/cmake_synthetic_in_subdir/libb/src/CMakeLists.txt
+++ b/examples/cmake_synthetic_in_subdir/libb/src/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 2.8.4)
+
+set(LIBB_SRC libb.cpp libb.h)
+
+add_library(libb_static STATIC ${LIBB_SRC})
+set_target_properties(libb_static PROPERTIES OUTPUT_NAME "libb")
+IF (WIN32)
+  set_target_properties(libb_static PROPERTIES ARCHIVE_OUTPUT_NAME "libb")
+ELSE()
+  set_target_properties(libb_static PROPERTIES ARCHIVE_OUTPUT_NAME "b")
+ENDIF()
+
+find_package(LIBA REQUIRED NAMES alib liba libliba)
+
+# LIBA_INCLUDE_DIRS is not set, so giving the path relative to liba_config.cmake
+# would be happy to improve that
+target_link_libraries(libb_static PUBLIC ${LIBA_DIR}/../../../lib/liba.a)
+target_include_directories(libb_static PUBLIC ${LIBA_DIR}/../../../include)
+
+set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
+
+install(TARGETS libb_static ARCHIVE DESTINATION lib)
+
+install(FILES libb.h DESTINATION include)

--- a/examples/cmake_synthetic_in_subdir/libb/src/libb.cpp
+++ b/examples/cmake_synthetic_in_subdir/libb/src/libb.cpp
@@ -1,0 +1,5 @@
+#include "libb.h"
+
+std::string hello_libb(void) {
+  return hello_liba() + " Hello from LIBB!";
+}

--- a/examples/cmake_synthetic_in_subdir/libb/src/libb.h
+++ b/examples/cmake_synthetic_in_subdir/libb/src/libb.h
@@ -1,0 +1,10 @@
+#ifndef LIBB_H_
+#define LIBB_H_ (1)
+
+#include <stdio.h>
+#include <string>
+#include "liba.h"
+
+std::string hello_libb(void);
+
+#endif

--- a/examples/cmake_synthetic_in_subdir/libc/BUILD.bazel
+++ b/examples/cmake_synthetic_in_subdir/libc/BUILD.bazel
@@ -1,0 +1,5 @@
+filegroup(
+    name = "c_srcs",
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)

--- a/examples/cmake_synthetic_in_subdir/libc/CMakeLists.txt
+++ b/examples/cmake_synthetic_in_subdir/libc/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 2.8.4)
+
+project(libc)
+
+add_subdirectory(src)

--- a/examples/cmake_synthetic_in_subdir/libc/src/CMakeLists.txt
+++ b/examples/cmake_synthetic_in_subdir/libc/src/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 2.8.4)
+
+set(libc_SRC libc.cpp libc.h)
+
+add_library(libc_static STATIC ${libc_SRC})
+set_target_properties(libc_static PROPERTIES OUTPUT_NAME "libc")
+IF (WIN32)
+  set_target_properties(libc_static PROPERTIES ARCHIVE_OUTPUT_NAME "libc")
+ELSE()
+  set_target_properties(libc_static PROPERTIES ARCHIVE_OUTPUT_NAME "c")
+ENDIF()
+
+#find_package(LIBA NAMES alib liba libliba liba++)
+#find_package(LIBB NAMES blib libb liblibb)
+
+# LIBA_INCLUDE_DIRS is not set, so giving the path relative to liba_config.cmake
+# would be happy to improve that
+target_link_libraries(libc_static PUBLIC ${LIBA_DIR}/lib/liblib_a_bazel.a)
+target_include_directories(libc_static PUBLIC ${LIBA_DIR}/include)
+
+target_link_libraries(libc_static PUBLIC ${LIBB_DIR}/lib/liblib_b_bazel.a)
+target_include_directories(libc_static PUBLIC ${LIBB_DIR}/include)
+
+set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
+
+install(TARGETS libc_static ARCHIVE DESTINATION lib)
+
+install(FILES libc.h DESTINATION include)

--- a/examples/cmake_synthetic_in_subdir/libc/src/libc.cpp
+++ b/examples/cmake_synthetic_in_subdir/libc/src/libc.cpp
@@ -1,0 +1,5 @@
+#include "libc.h"
+
+std::string hello_libc(void) {
+  return hello_liba() + " " + hello_libb() + " Hello from LIBC!";
+}

--- a/examples/cmake_synthetic_in_subdir/libc/src/libc.h
+++ b/examples/cmake_synthetic_in_subdir/libc/src/libc.h
@@ -1,0 +1,11 @@
+#ifndef LIBC_H_
+#define LIBC_H_ (1)
+
+#include <stdio.h>
+#include <string>
+#include "liba.h"
+#include "libb.h"
+
+std::string hello_libc(void);
+
+#endif

--- a/examples/cmake_synthetic_in_subdir/test_libb.cpp
+++ b/examples/cmake_synthetic_in_subdir/test_libb.cpp
@@ -1,0 +1,14 @@
+#include "libb.h"
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+int main(int argc, char* argv[])
+{
+  std:: string result = hello_libb();
+  if (result != "Hello from LIBA! Hello from LIBB!") {
+    throw std::runtime_error("Wrong result: " + result);
+  }
+  std::cout << "Everything's fine!";
+}

--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -281,12 +281,12 @@ dependencies.""",
 def _is_msvc_var(var):
     return var == "INCLUDE" or var == "LIB"
 
-def get_env_prelude(ctx, lib_name, data_dependencies, target_root):
+def get_env_prelude(ctx, lib_basename, data_dependencies, target_root):
     """Generate a bash snippet containing environment variable definitions
 
     Args:
         ctx (ctx): The rule's context object
-        lib_name (str): The name of the target being built
+        lib_basename (str): The basename of the target being built
         data_dependencies (list): A list of targets representing dependencies
         target_root (str): The path from the root target's directory in the build output
 
@@ -296,7 +296,7 @@ def get_env_prelude(ctx, lib_name, data_dependencies, target_root):
     """
     env_snippet = [
         "export EXT_BUILD_ROOT=##pwd##",
-        "export INSTALLDIR=$$EXT_BUILD_ROOT$$/" + target_root + "/" + lib_name,
+        "export INSTALLDIR=$$EXT_BUILD_ROOT$$/" + target_root + "/" + lib_basename,
         "export BUILD_TMPDIR=$$INSTALLDIR$$.build_tmpdir",
         "export EXT_BUILD_DEPS=$$INSTALLDIR$$.ext_build_deps",
     ]
@@ -405,6 +405,7 @@ def cc_external_rule_impl(ctx, attrs):
     """
     _print_deprecation_warnings(ctx)
     lib_name = attrs.lib_name or ctx.attr.name
+    lib_dirname, lib_separator, lib_basename = lib_name.rpartition("/")
 
     inputs = _define_inputs(attrs)
     outputs = _define_outputs(ctx, attrs, lib_name)
@@ -418,8 +419,8 @@ def cc_external_rule_impl(ctx, attrs):
     # and the install directory as a whole (which is mostly nessesary for chained external builds).
     #
     # We want the install directory output of this rule to have the same name as the library,
-    # so symlink it under the same name but in a subdirectory
-    installdir_copy = copy_directory(ctx.actions, "$$INSTALLDIR$$", "copy_{}/{}".format(lib_name, lib_name))
+    # so symlink it under the same name but in a subdirectory.
+    installdir_copy = copy_directory(ctx.actions, "$$INSTALLDIR$$", "{}{}copy_{}/{}".format(lib_dirname, lib_separator, lib_basename, lib_basename))
     target_root = paths.dirname(installdir_copy.file.dirname)
 
     data_dependencies = ctx.attr.data + ctx.attr.build_data + ctx.attr.toolchains
@@ -430,7 +431,7 @@ def cc_external_rule_impl(ctx, attrs):
     # Also add legacy dependencies while they're still available
     data_dependencies += ctx.attr.tools_deps + ctx.attr.additional_tools
 
-    env_prelude = get_env_prelude(ctx, lib_name, data_dependencies, target_root)
+    env_prelude = get_env_prelude(ctx, lib_basename, data_dependencies, target_root)
 
     postfix_script = [attrs.postfix_script]
     if not attrs.postfix_script:
@@ -776,14 +777,15 @@ def _define_outputs(ctx, attrs, lib_name):
     attr_shared_libs = attrs.out_shared_libs
     attr_static_libs = attrs.out_static_libs
 
+    _, _, lib_basename = lib_name.rpartition("/")
     static_libraries = []
     if not attr_headers_only:
         if not attr_static_libs and not attr_shared_libs and not attr_binaries_libs and not attr_interface_libs:
-            static_libraries = [lib_name + (".lib" if targets_windows(ctx, None) else ".a")]
+            static_libraries = [lib_basename + (".lib" if targets_windows(ctx, None) else ".a")]
         else:
             static_libraries = attr_static_libs
 
-    _check_file_name(lib_name)
+    _check_file_name(lib_basename)
 
     out_include_dir = ctx.actions.declare_directory(lib_name + "/" + attrs.out_include_dir)
 


### PR DESCRIPTION
It can be necessary to have rules with the same basename in the same package, which requires specifying a rule name such as `subdir/my_rule`. This change adds support for such names to `cmake`.