### PR TITLE
Apply expand_locations_and_make_variables to cache_entries

### DIFF
--- a/foreign_cc/cmake.bzl
+++ b/foreign_cc/cmake.bzl
@@ -263,7 +263,7 @@ def _create_configure_script(configureParameters):
         install_prefix = "$$INSTALLDIR$$",
         root = root,
         no_toolchain_file = no_toolchain_file,
-        user_cache = dict(ctx.attr.cache_entries),
+        user_cache = expand_locations_and_make_variables(ctx, ctx.attr.cache_entries, "cache_entries", data),
         user_env = expand_locations_and_make_variables(ctx, ctx.attr.env, "env", data),
         options = attrs.generate_args,
         cmake_commands = cmake_commands,


### PR DESCRIPTION
When building proj I need to pass the sqlite3 binary via a cache entry, like `{"EXE_SQLITE3": "$(execpath @sqlite3//:shell)"}` but that requires that cache entries are also expanded.