### PR TITLE
add support for cc_shared_library deps

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,6 +6,7 @@ module(
     compatibility_level = 1,
 )
 
+bazel_dep(name = "bazel_features", version = "1.15.0")
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(name = "platforms", version = "0.0.5")
 bazel_dep(name = "rules_python", version = "0.23.1")

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -10,6 +10,10 @@ local_repository(
     path = "examples",
 )
 
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()

--- a/docs/WORKSPACE.bazel
+++ b/docs/WORKSPACE.bazel
@@ -9,6 +9,10 @@ load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_depende
 
 rules_foreign_cc_dependencies()
 
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+
 load("//:stardoc_repository.bzl", "stardoc_repository")
 
 stardoc_repository()

--- a/examples/third_party/zlib/BUILD.bazel
+++ b/examples/third_party/zlib/BUILD.bazel
@@ -1,8 +1,18 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake", "runnable_binary")
 
 exports_files(
     [
         "BUILD.zlib.bazel",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "shared_usage_srcs",
+    srcs = [
+        "CMakeLists.txt",
+        "zlib-example.cpp",
     ],
     visibility = ["//visibility:public"],
 )
@@ -17,5 +27,26 @@ sh_test(
     name = "test_zlib",
     srcs = ["test_zlib.sh"],
     data = [":zlib_usage_example"],
+    visibility = ["//:__pkg__"],
+)
+
+cmake(
+    name = "zlib_shared_usage_example",
+    dynamic_deps = ["@zlib//:zlib_shared"],
+    lib_source = "shared_usage_srcs",
+    out_binaries = ["zlib-example"],
+    deps = ["@zlib//:zlib_static"],
+)
+
+runnable_binary(
+    name = "run-zlib-example",
+    binary = "zlib-example",
+    foreign_cc_target = ":zlib_shared_usage_example",
+)
+
+sh_test(
+    name = "test_shared_zlib",
+    srcs = ["test_shared_zlib.sh"],
+    data = [":run-zlib-example"],
     visibility = ["//:__pkg__"],
 )

--- a/examples/third_party/zlib/BUILD.zlib.bazel
+++ b/examples/third_party/zlib/BUILD.zlib.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
 
 package(default_visibility = ["//visibility:public"])
@@ -27,4 +28,54 @@ cmake(
         "@platforms//os:windows": ["z.lib"],
         "//conditions:default": ["libz.a"],
     }),
+)
+
+cc_library(
+    name = "zlib_static",
+    srcs = [
+        "adler32.c",
+        "compress.c",
+        "crc32.c",
+        "deflate.c",
+        "gzclose.c",
+        "gzlib.c",
+        "gzread.c",
+        "gzwrite.c",
+        "infback.c",
+        "inffast.c",
+        "inflate.c",
+        "inftrees.c",
+        "trees.c",
+        "uncompr.c",
+        "zutil.c",
+    ],
+    hdrs = [
+        "crc32.h",
+        "deflate.h",
+        "gzguts.h",
+        "inffast.h",
+        "inffixed.h",
+        "inflate.h",
+        "inftrees.h",
+        "trees.h",
+        "zconf.h",
+        "zlib.h",
+        "zutil.h",
+    ],
+    copts = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": [
+            "-Wno-deprecated-non-prototype",
+            "-Wno-unused-variable",
+            "-Wno-implicit-function-declaration",
+        ],
+    }),
+    includes = ["."],
+    linkstatic = True,
+)
+
+cc_shared_library(
+    name = "zlib_shared",
+    shared_lib_name = "libz.so",
+    deps = ["zlib_static"],
 )

--- a/examples/third_party/zlib/CMakeLists.txt
+++ b/examples/third_party/zlib/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(zlib-example)
+
+find_package(ZLIB REQUIRED)
+
+set(SRCS zlib-example.cpp)
+
+add_executable(${PROJECT_NAME} ${SRCS})
+
+target_link_libraries(${PROJECT_NAME} ZLIB::ZLIB)
+
+install(TARGETS ${PROJECT_NAME} DESTINATION bin)

--- a/examples/third_party/zlib/test_shared_zlib.sh
+++ b/examples/third_party/zlib/test_shared_zlib.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+$(rlocation rules_foreign_cc/examples/cmake/zlib_shared_usage_example)

--- a/foreign_cc/private/BUILD.bazel
+++ b/foreign_cc/private/BUILD.bazel
@@ -44,6 +44,7 @@ bzl_library(
         "//foreign_cc:providers",
         "//foreign_cc/private/framework:helpers",
         "//foreign_cc/private/framework:platform",
+        "@bazel_features//:features",
         "@bazel_skylib//lib:collections",
         "@bazel_skylib//lib:paths",
         "@bazel_tools//tools/cpp:toolchain_utils.bzl",

--- a/foreign_cc/repositories.bzl
+++ b/foreign_cc/repositories.bzl
@@ -85,6 +85,14 @@ def rules_foreign_cc_dependencies(
 
     maybe(
         http_archive,
+        name = "bazel_features",
+        sha256 = "ba1282c1aa1d1fffdcf994ab32131d7c7551a9bc960fbf05f42d55a1b930cbfb",
+        strip_prefix = "bazel_features-1.15.0",
+        url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.15.0/bazel_features-v1.15.0.tar.gz",
+    )
+
+    maybe(
+        http_archive,
         name = "bazel_skylib",
         urls = [
             "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",


### PR DESCRIPTION
This MR adds a new `dynamic_deps` attr that allows the libs created by cc_shared_library targets to be added as deps.

Closes https://github.com/bazelbuild/rules_foreign_cc/issues/1242