### PR TITLE
Portable copy_dir_contents_to_dir

### DIFF
--- a/foreign_cc/private/framework/toolchains/freebsd_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/freebsd_commands.bzl
@@ -95,7 +95,7 @@ fi
     )
 
 def copy_dir_contents_to_dir(source, target):
-    # Beause FreeBSD `cp` doesn't have `--no-copy-directory`, we have to
+    # Beause FreeBSD `cp` doesn't have `--no-target-directory`, we have to
     # do something more complex for this environment.
     return """\
 if [[ -d "{source}" ]]; then

--- a/foreign_cc/private/framework/toolchains/freebsd_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/freebsd_commands.bzl
@@ -99,7 +99,7 @@ def copy_dir_contents_to_dir(source, target):
     # do something more complex for this environment.
     return """\
 if [[ -d "{source}" ]]; then
-  cp -L -R "{source}"/* "{target}"
+  cp -L -R "{source}"/. "{target}"
 else
   cp -L -R "{source}" "{target}"
 fi

--- a/foreign_cc/private/framework/toolchains/macos_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/macos_commands.bzl
@@ -90,7 +90,7 @@ def copy_dir_contents_to_dir(source, target):
     # do something more complext for this environment.
     return """\
 if [[ -d "{source}" ]]; then
-  cp -L -R "{source}"/ "{target}"
+  cp -L -R "{source}"/. "{target}"
 else
   cp -L -R "{source}" "{target}"
 fi

--- a/foreign_cc/private/framework/toolchains/macos_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/macos_commands.bzl
@@ -86,7 +86,7 @@ fi
     )
 
 def copy_dir_contents_to_dir(source, target):
-    # Beause macos `cp` doesn't have `--no-copy-directory`, we have to
+    # Beause macos `cp` doesn't have `--no-target-directory`, we have to
     # do something more complext for this environment.
     return """\
 if [[ -d "{source}" ]]; then


### PR DESCRIPTION
On BSD-based distro/MacOS, using `cp -L -R {source}/` ignores files or directories with a leading dot. If users have GNU-based coreutils installed on their BSD/Mac system (via Nix for e.g.), `cp -L -R {source}/` would also copy the source directory _underneath_ the target directory, which is not what we want.

This PR changes both the `copy_dir_contents_to_dir` implementation for BSD and MacOS such that it works regardless of whether user has GNU or BSD coreutils installed.