### PR TITLE
Revert "Apply expand_locations_and_make_variables to cache_entries"

### DIFF
--- a/foreign_cc/cmake.bzl
+++ b/foreign_cc/cmake.bzl
@@ -263,7 +263,7 @@ def _create_configure_script(configureParameters):
         install_prefix = "$$INSTALLDIR$$",
         root = root,
         no_toolchain_file = no_toolchain_file,
-        user_cache = expand_locations_and_make_variables(ctx, ctx.attr.cache_entries, "cache_entries", data),
+        user_cache = dict(ctx.attr.cache_entries),
         user_env = expand_locations_and_make_variables(ctx, ctx.attr.env, "env", data),
         options = attrs.generate_args,
         cmake_commands = cmake_commands,


### PR DESCRIPTION
Reverts bazelbuild/rules_foreign_cc#1240