### PR TITLE
fix meson tests for macOS CI

### DIFF
--- a/examples/third_party/BUILD.bazel
+++ b/examples/third_party/BUILD.bazel
@@ -86,8 +86,7 @@ test_suite(
         "//cares:test_c_ares",
         "//cares:test_c_ares_ios",
         "//curl:curl_test_suite",
-        # Fails due to linker error in ffi (https://github.com/mesonbuild/meson/issues/12282)
-        # "//glib:glib_build_test",
+        "//glib:glib_build_test",
         "//gn:gn_launch_test",
         "//gperftools:test",
         "//iconv:iconv_macos_build_test",
@@ -96,8 +95,7 @@ test_suite(
         "//libpng:test_libpng",
         "//libssh2:libssh2_build_test",
         "//log4cxx:log4cxx_build_test",
-        # Fails due to linker argument error (https://github.com/mesonbuild/meson/issues/12282)
-        # "//mesa:mesa_build_test",
+        "//mesa:mesa_build_test",
         "//openssl:openssl_test_suite",
         "//pcre:pcre_build_test",
         "//python:python_tests",

--- a/examples/third_party/glib/glib_repositories.bzl
+++ b/examples/third_party/glib/glib_repositories.bzl
@@ -8,9 +8,9 @@ def glib_repositories():
         http_archive,
         name = "glib",
         build_file = Label("//glib:BUILD.glib.bazel"),
-        strip_prefix = "glib-2.75.0",
-        sha256 = "6dde8e55cc4a2c83d96797120b08bcffb5f645b2e212164ae22d63c40e0e6360",
-        url = "https://download.gnome.org/sources/glib/2.75/glib-2.75.0.tar.xz",
+        strip_prefix = "glib-2.77.0",
+        sha256 = "1897fd8ad4ebb523c32fabe7508c3b0b039c089661ae1e7917df0956a320ac4d",
+        url = "https://download.gnome.org/sources/glib/2.77/glib-2.77.0.tar.xz",
     )
     maybe(
         http_archive,

--- a/foreign_cc/repositories.bzl
+++ b/foreign_cc/repositories.bzl
@@ -12,7 +12,7 @@ def rules_foreign_cc_dependencies(
         cmake_version = "3.23.2",
         make_version = "4.4.1",
         ninja_version = "1.12.1",
-        meson_version = "1.1.1",
+        meson_version = "1.5.1",
         pkgconfig_version = "0.29.2",
         register_preinstalled_tools = True,
         register_built_tools = True,

--- a/toolchains/built_toolchains.bzl
+++ b/toolchains/built_toolchains.bzl
@@ -208,6 +208,19 @@ def _meson_toolchain(version, register_toolchains):
         native.register_toolchains(
             "@rules_foreign_cc//toolchains:built_meson_toolchain",
         )
+    if version == "1.5.1":
+        maybe(
+            http_archive,
+            name = "meson_src",
+            build_file_content = _MESON_BUILD_FILE_CONTENT,
+            sha256 = "567e533adf255de73a2de35049b99923caf872a455af9ce03e01077e0d384bed",
+            strip_prefix = "meson-1.5.1",
+            urls = [
+                "https://mirror.bazel.build/github.com/mesonbuild/meson/releases/download/1.5.1/meson-1.5.1.tar.gz",
+                "https://github.com/mesonbuild/meson/releases/download/1.5.1/meson-1.5.1.tar.gz",
+            ],
+        )
+        return
     if version == "1.1.1":
         maybe(
             http_archive,


### PR DESCRIPTION
This is an attempt to fix the macOS CI issues mentioned in https://github.com/bazelbuild/rules_foreign_cc/issues/1244.

Also noting https://github.com/bazelbuild/rules_foreign_cc/pull/1251 disabled the broken tests. Whereas this MR should fix the tests.

The original problem should be a meson issue and not a foreign_cc one. see https://github.com/mesonbuild/meson/pull/12574. Although, I couldn't track down what introduced the problem.

I got the idea that it is a meson problem, given `-Wl,--version` is not generated as a part of our `cxx_linker_executable` or `cxx_linker_shared`.

The quick solution is to update our default meson version to a version that includes the fix.

Had to also update glib, as after the meson fix it was running to this an issue similar to https://gitlab.gnome.org/GNOME/glib/-/issues/2995.