### PR TITLE
Merge user provided CPPFLAGS with build system CPPFLAGS

### DIFF
--- a/foreign_cc/private/make_env_vars.bzl
+++ b/foreign_cc/private/make_env_vars.bzl
@@ -85,9 +85,9 @@ _MAKE_FLAGS = {
     "AR_FLAGS": "cxx_linker_static",
     "ASFLAGS": "assemble",
     "CFLAGS": "cc",
+    "CPPFLAGS": "",
     "CXXFLAGS": "cxx",
     "LDFLAGS": "cxx_linker_executable",
-    "CPPFLAGS": "",
     # missing: cxx_linker_shared
 }
 

--- a/foreign_cc/private/make_env_vars.bzl
+++ b/foreign_cc/private/make_env_vars.bzl
@@ -99,15 +99,14 @@ def _get_make_variables(workspace_name, tools, flags, user_env_vars, make_comman
     vars = {}
 
     for flag in _MAKE_FLAGS:
-        flag_value = getattr(flags, _MAKE_FLAGS[flag])
-        if flag_value:
-            vars[flag] = flag_value
-
-    # Merge flags lists
-    for user_var in user_env_vars:
-        toolchain_val = vars.get(user_var)
-        if toolchain_val:
-            vars[user_var] = toolchain_val + [user_env_vars[user_var]]
+        toolchain_flags = getattr(flags, _MAKE_FLAGS[flag], [])
+        user_flags = [
+            user_flag
+            for user_flag in user_env_vars.get(flag, "").split(" ")
+            if user_flag
+        ]
+        if toolchain_flags or user_flags:
+            vars[flag] = toolchain_flags + user_flags
 
     tools_dict = {}
     for tool in _MAKE_TOOLS:

--- a/foreign_cc/private/make_env_vars.bzl
+++ b/foreign_cc/private/make_env_vars.bzl
@@ -85,7 +85,6 @@ _MAKE_FLAGS = {
     "AR_FLAGS": "cxx_linker_static",
     "ASFLAGS": "assemble",
     "CFLAGS": "cc",
-    "CPPFLAGS": "",
     "CXXFLAGS": "cxx",
     "LDFLAGS": "cxx_linker_executable",
     # missing: cxx_linker_shared
@@ -111,6 +110,11 @@ def _get_make_variables(workspace_name, tools, flags, user_env_vars, make_comman
         ]
         if toolchain_flags or user_flags:
             vars[flag] = toolchain_flags + user_flags
+
+    # Add user defined CPPFLAGS
+    user_cpp_flags = [flag for flag in user_env_vars.get("CPPFLAGS", "").split(" ") if flag]
+    if user_cpp_flags:
+        vars["CPPFLAGS"] = user_cpp_flags
 
     tools_dict = {}
     for tool in _MAKE_TOOLS:

--- a/foreign_cc/private/make_env_vars.bzl
+++ b/foreign_cc/private/make_env_vars.bzl
@@ -26,7 +26,10 @@ def get_make_env_vars(
 
     # -I flags should be put into preprocessor flags, CPPFLAGS
     # https://www.gnu.org/software/autoconf/manual/autoconf-2.63/html_node/Preset-Output-Variables.html
-    vars["CPPFLAGS"] = deps_flags.flags
+    if "CPPFLAGS" in vars.keys():
+        vars["CPPFLAGS"] = vars["CPPFLAGS"] + deps_flags.flags
+    else:
+        vars["CPPFLAGS"] = deps_flags.flags
 
     return " ".join(["{}=\"{}\""
         .format(key, _join_flags_list(workspace_name, vars[key])) for key in vars])
@@ -84,6 +87,7 @@ _MAKE_FLAGS = {
     "CFLAGS": "cc",
     "CXXFLAGS": "cxx",
     "LDFLAGS": "cxx_linker_executable",
+    "CPPFLAGS": "",
     # missing: cxx_linker_shared
 }
 


### PR DESCRIPTION
Another PR regarding flags being set in `env`. Currently there is no solution to set `CPPFLAGS` via `configure_make`. If you set them in the environment, they will be clobbered by the build system flags. If you set them via `configure_options` or `configure_prefix` (I saw someone doing that somewhere), then they clobber the build system `CPPFLAGS` meaning you cannot use dependencies (since this is how header files from dependencies are made during the build).