### PR TITLE
Remove dependencies on rules_cc

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,7 +15,6 @@ bazel_dep(name = "rules_python", version = "0.23.1")
 bazel_dep(name = "gazelle", version = "0.34.0", dev_dependency = True, repo_name = "bazel_gazelle")
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.5.0", dev_dependency = True)
 bazel_dep(name = "stardoc", version = "0.5.6", dev_dependency = True, repo_name = "io_bazel_stardoc")
-bazel_dep(name = "rules_cc", version = "0.0.9", dev_dependency = True)
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(python_version = "3.9")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,6 +15,7 @@ bazel_dep(name = "rules_python", version = "0.23.1")
 bazel_dep(name = "gazelle", version = "0.34.0", dev_dependency = True, repo_name = "bazel_gazelle")
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.5.0", dev_dependency = True)
 bazel_dep(name = "stardoc", version = "0.5.6", dev_dependency = True, repo_name = "io_bazel_stardoc")
+bazel_dep(name = "bazel_ci_rules", version = "1.0.0", dev_dependency = True)
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(python_version = "3.9")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,6 +16,9 @@ bazel_dep(name = "gazelle", version = "0.34.0", dev_dependency = True, repo_name
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.5.0", dev_dependency = True)
 bazel_dep(name = "stardoc", version = "0.5.6", dev_dependency = True, repo_name = "io_bazel_stardoc")
 bazel_dep(name = "bazel_ci_rules", version = "1.0.0", dev_dependency = True)
+# note that this dev_dependency is only needed because bazel_ci_rules
+# depends on it. If you are not using bazel_ci_rules; ideally we'd be able to remove this.
+bazel_dep(name = "rules_cc", version = "0.0.9", dev_dependency = True)
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(python_version = "3.9")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,6 +16,7 @@ bazel_dep(name = "gazelle", version = "0.34.0", dev_dependency = True, repo_name
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.5.0", dev_dependency = True)
 bazel_dep(name = "stardoc", version = "0.5.6", dev_dependency = True, repo_name = "io_bazel_stardoc")
 bazel_dep(name = "bazel_ci_rules", version = "1.0.0", dev_dependency = True)
+
 # note that this dev_dependency is only needed because bazel_ci_rules
 # depends on it. If you are not using bazel_ci_rules; ideally we'd be able to remove this.
 bazel_dep(name = "rules_cc", version = "0.0.9", dev_dependency = True)

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -1,15 +1,6 @@
 workspace(name = "rules_foreign_cc")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-http_archive(
-    name = "bazelci_rules",
-    sha256 = "eca21884e6f66a88c358e580fd67a6b148d30ab57b1680f62a96c00f9bc6a07e",
-    strip_prefix = "bazelci_rules-1.0.0",
-    url = "https://github.com/bazelbuild/continuous-integration/releases/download/rules-1.0.0/bazelci_rules-1.0.0.tar.gz",
-)
-
-load("@bazelci_rules//:rbe_repo.bzl", "rbe_preconfig")
+load("@bazel_ci_rules//:rbe_repo.bzl", "rbe_preconfig")
 
 # Creates a default toolchain config for RBE.
 # Use this as is if you are using the rbe_ubuntu16_04 container,

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -17,6 +17,7 @@ bazel_dep(name = "rules_swift", version = "1.6.0", repo_name = "build_bazel_rule
 bazel_dep(name = "rules_apple", version = "3.4.0", repo_name = "build_bazel_rules_apple")
 bazel_dep(name = "apple_support", version = "1.12.0", repo_name = "build_bazel_apple_support")
 bazel_dep(name = "rules_python", version = "0.23.0")
+bazel_dep(name = "rules_cc", version = "0.9.0")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(

--- a/toolchains/built_toolchains.bzl
+++ b/toolchains/built_toolchains.bzl
@@ -260,8 +260,6 @@ def _pkgconfig_toolchain(version, register_toolchains):
         http_archive,
         name = "glib_dev",
         build_file_content = '''
-load("@rules_cc//cc:defs.bzl", "cc_library")
-
 cc_import(
     name = "glib_dev",
     hdrs = glob(["include/**"]),


### PR DESCRIPTION
`glib_dev` was incorrectly loading a symbol from `rules_cc` which causes visibility issues on windows bzlmod.
