### PR TITLE
runnable_binary: avoid using > on the output file

### DIFF
--- a/foreign_cc/utils.bzl
+++ b/foreign_cc/utils.bzl
@@ -44,7 +44,7 @@ def runnable_binary(name, binary, foreign_cc_target, match_binary_name = False, 
 
     wrapper_cmd = """
     sed s@EXECUTABLE@$(rlocationpath {name})@g $(location @rules_foreign_cc//foreign_cc/private:runnable_binary_wrapper.sh) > tmp
-    sed s@SH_BINARY_FILENAME@{sh_binary_filename}@g tmp > $@
+    cp tmp $@
     """
 
     if hasattr(native, "package_relative_label"):
@@ -57,10 +57,7 @@ def runnable_binary(name, binary, foreign_cc_target, match_binary_name = False, 
         name = name + "_wrapper",
         srcs = ["@rules_foreign_cc//foreign_cc/private:runnable_binary_wrapper.sh", name + "_fg"],
         outs = [name + "_wrapper.sh"],
-        cmd = select({
-            "@platforms//os:windows": wrapper_cmd.format(name = fg_label, sh_binary_filename = binary + ".exe" if match_binary_name else name),
-            "//conditions:default": wrapper_cmd.format(name = fg_label, sh_binary_filename = binary if match_binary_name else name),
-        }),
+        cmd = wrapper_cmd.format(name = fg_label),
         tags = tags + ["manual"],
     )
 


### PR DESCRIPTION
In #1267 there was an issue where, somehow, the wrapper script ended up as a zero-length file but the action succeeded (resulting in storing a zero-length file instead of the script in the caches). genrules are documented as running inside `-ueo pipefail` so it seems like this should be impossible...

In any case, this avoids using >$@ because the > runs before the command itself does, creating a zero-length file before populating it, and is the only way I could think of that this ends up as an empty file. Hopefully, if the problem repeats, genrule will notice that the file didn't get created and fail.

SH_BINARY_FILENAME also wasn't used, so this skips a step.