### PR TITLE
Bump APR version to 1.7.5. Make CI/CD green again.

### DIFF
--- a/examples/third_party/apr/apr_repositories.bzl
+++ b/examples/third_party/apr/apr_repositories.bzl
@@ -15,10 +15,10 @@ def apr_repositories():
             Label("//apr:windows_winnt.patch"),
         ],
         sha256 = "",
-        strip_prefix = "apr-1.7.4",
+        strip_prefix = "apr-1.7.5",
         urls = [
-            "https://mirror.bazel.build/www-eu.apache.org/dist/apr/apr-1.7.4.tar.gz",
-            "https://dlcdn.apache.org/apr/apr-1.7.4.tar.gz",
-            "https://www-eu.apache.org/dist/apr/apr-1.7.4.tar.gz",
+            "https://mirror.bazel.build/www-eu.apache.org/dist/apr/apr-1.7.5.tar.gz",
+            "https://dlcdn.apache.org/apr/apr-1.7.5.tar.gz",
+            "https://www-eu.apache.org/dist/apr/apr-1.7.5.tar.gz",
         ],
     )


### PR DESCRIPTION
Inspired by https://github.com/foundationrobotics/rules_foreign_cc/commit/0bf2b360ef22d05189fdae1672a6a2223854706f 
But instead of using vulnerable version 1.7.4 with CVE-2023-49582 we use 1.7.5
Check https://downloads.apache.org/apr/CHANGES-APR-1.7