### PR TITLE
Bazel CI config: explicitly enable workspace wherever Bzlmod is disabled

### DIFF
--- a/.bazelci/config.yaml
+++ b/.bazelci/config.yaml
@@ -29,8 +29,10 @@ tasks:
       - "-//test:shell_script_inner_fun_test"
     build_flags:
       - "--noenable_bzlmod"
+      - "--enable_workspace"
     test_flags:
       - "--noenable_bzlmod"
+      - "--enable_workspace"
   ubuntu1804_examples_standalone:
     name: Examples (spawn_strategy=standalone)
     platform: ubuntu1804
@@ -44,12 +46,14 @@ tasks:
       - "dbg"
       - "--spawn_strategy=standalone"
       - "--noenable_bzlmod"
+      - "--enable_workspace"
     test_targets: *linux_targets_standalone
     test_flags:
       - "-c"
       - "dbg"
       - "--spawn_strategy=standalone"
       - "--noenable_bzlmod"
+      - "--enable_workspace"
   ubuntu2004_examples:
     name: Examples
     platform: ubuntu2004
@@ -61,8 +65,10 @@ tasks:
     test_targets: *linux_targets
     build_flags:
       - "--noenable_bzlmod"
+      - "--enable_workspace"
     test_flags:
       - "--noenable_bzlmod"
+      - "--enable_workspace"
   ubuntu2004_examples_bzlmod:
     name: Examples (bzlmod)
     platform: ubuntu2004
@@ -107,6 +113,7 @@ tasks:
       - "--spawn_strategy=standalone"
       - "--noincompatible_enable_cc_toolchain_resolution"
       - "--noenable_bzlmod"
+      - "--enable_workspace"
     test_targets: *macos_targets_standalone
     test_flags:
       - "-c"
@@ -114,6 +121,7 @@ tasks:
       - "--spawn_strategy=standalone"
       - "--noincompatible_enable_cc_toolchain_resolution"
       - "--noenable_bzlmod"
+      - "--enable_workspace"
   macos_examples:
     name: Examples
     platform: macos
@@ -129,10 +137,12 @@ tasks:
     build_flags:
       - "--noincompatible_enable_cc_toolchain_resolution"
       - "--noenable_bzlmod"
+      - "--enable_workspace"
     test_targets: *macos_targets
     test_flags:
       - "--noincompatible_enable_cc_toolchain_resolution"
       - "--noenable_bzlmod"
+      - "--enable_workspace"
   windows_examples:
     name: Examples
     platform: windows
@@ -163,8 +173,10 @@ tasks:
     test_targets: *windows_targets
     build_flags:
       - "--noenable_bzlmod"
+      - "--enable_workspace"
     test_flags:
       - "--noenable_bzlmod"
+      - "--enable_workspace"
   rbe_ubuntu2004_flags:
     name: Flags
     platform: rbe_ubuntu2004


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/rules_foreign_cc/issues/1274