### PR TITLE
Update the broken URL on BCR

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,5 +1,5 @@
 {
-  "homepage": "https://github.com/bazel-contrib/rules_foreign_cc",
+  "homepage": "https://github.com/bazelbuild/rules_foreign_cc",
   "maintainers": [
     {
       "email": "james.sharpe@zenotech.com",


### PR DESCRIPTION
I noticed that the homepage URL for `rules_foreign_cc` is broken on BCR, and I *think* this PR is how to go about fixing this. See: https://registry.bazel.build/modules/rules_foreign_cc 