### PR TITLE
feat: extend the extension to support more version pins

### DIFF
--- a/foreign_cc/extensions.bzl
+++ b/foreign_cc/extensions.bzl
@@ -2,20 +2,41 @@
 
 load("@bazel_features//:features.bzl", "bazel_features")
 load("//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
+load("//foreign_cc/private:default_versions.bzl", _DEFAULT_VERSIONS = "DEFAULT_VERSIONS")
 load("//toolchains:prebuilt_toolchains.bzl", "prebuilt_toolchains")
 
-_DEFAULT_CMAKE_VERSION = "3.31.8"
-_DEFAULT_NINJA_VERSION = "1.13.0"
-
 cmake_toolchain_version = tag_class(attrs = {
-    "version": attr.string(doc = "The cmake version", default = _DEFAULT_CMAKE_VERSION),
+    "version": attr.string(doc = "The cmake version", default = _DEFAULT_VERSIONS["cmake"]),
+})
+
+make_toolchain_version = tag_class(attrs = {
+    "version": attr.string(doc = "The make version", default = _DEFAULT_VERSIONS["make"]),
+})
+
+meson_toolchain_version = tag_class(attrs = {
+    "version": attr.string(doc = "The meson version", default = _DEFAULT_VERSIONS["meson"]),
 })
 
 ninja_toolchain_version = tag_class(attrs = {
-    "version": attr.string(doc = "The ninja version", default = _DEFAULT_NINJA_VERSION),
+    "version": attr.string(doc = "The ninja version", default = _DEFAULT_VERSIONS["ninja"]),
+})
+
+pkgconfig_toolchain_version = tag_class(attrs = {
+    "version": attr.string(doc = "The pkgconfig version", default = _DEFAULT_VERSIONS["pkgconfig"]),
 })
 
 def _init(module_ctx):
+    versions = dict(_DEFAULT_VERSIONS)
+
+    pinned_kw = {}
+
+    for mod in module_ctx.modules:
+        if not mod.is_root:
+            for toolchain_type in versions.keys():
+                for toolchain in getattr(mod.tags, toolchain_type):
+                    versions[toolchain_type] = toolchain.version
+                    pinned_kw[toolchain_type + "_version"] = toolchain.version
+
     rules_foreign_cc_dependencies(
         register_toolchains = False,
         register_built_tools = True,
@@ -24,20 +45,8 @@ def _init(module_ctx):
         register_built_pkgconfig_toolchain = True,
         # These should be registered via bzlmod entries instead
         register_repos = False,
+        **pinned_kw
     )
-
-    versions = {
-        "cmake": _DEFAULT_CMAKE_VERSION,
-        "ninja": _DEFAULT_NINJA_VERSION,
-    }
-
-    for mod in module_ctx.modules:
-        if not mod.is_root:
-            for toolchain in mod.tags.cmake:
-                versions["cmake"] = toolchain.version
-
-            for toolchain in mod.tags.ninja:
-                versions["ninja"] = toolchain.version
 
     prebuilt_toolchains(
         cmake_version = versions["cmake"],
@@ -54,6 +63,9 @@ tools = module_extension(
     implementation = _init,
     tag_classes = {
         "cmake": cmake_toolchain_version,
+        "make": make_toolchain_version,
+        "meson": meson_toolchain_version,
         "ninja": ninja_toolchain_version,
+        "pkgconfig": pkgconfig_toolchain_version,
     },
 )

--- a/foreign_cc/private/default_versions.bzl
+++ b/foreign_cc/private/default_versions.bzl
@@ -1,0 +1,8 @@
+""" contains the default versions of the prebuilt and built toolchains"""
+DEFAULT_VERSIONS = {
+    "cmake": "3.31.8",
+    "make": "4.4.1",
+    "meson": "1.5.1",
+    "ninja": "1.13.0",
+    "pkgconfig": "0.29.2",
+}

--- a/foreign_cc/repositories.bzl
+++ b/foreign_cc/repositories.bzl
@@ -2,6 +2,7 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("//foreign_cc/private:default_versions.bzl", _DEFAULT_VERSIONS = "DEFAULT_VERSIONS")
 load("//foreign_cc/private/framework:toolchain.bzl", "register_framework_toolchains")
 load("//toolchains:toolchains.bzl", "built_toolchains", "prebuilt_toolchains", "preinstalled_toolchains")
 
@@ -9,11 +10,11 @@ load("//toolchains:toolchains.bzl", "built_toolchains", "prebuilt_toolchains", "
 def rules_foreign_cc_dependencies(
         native_tools_toolchains = [],
         register_default_tools = True,
-        cmake_version = "3.31.8",
-        make_version = "4.4.1",
-        ninja_version = "1.13.0",
-        meson_version = "1.5.1",
-        pkgconfig_version = "0.29.2",
+        cmake_version = _DEFAULT_VERSIONS["cmake"],
+        make_version = _DEFAULT_VERSIONS["make"],
+        ninja_version = _DEFAULT_VERSIONS["ninja"],
+        meson_version = _DEFAULT_VERSIONS["meson"],
+        pkgconfig_version = _DEFAULT_VERSIONS["pkgconfig"],
         register_preinstalled_tools = True,
         register_built_tools = True,
         register_toolchains = True,


### PR DESCRIPTION
This makes it possible to pin meson, make, and pkgconfig in the same way it was possible with workspaces. I should say: I don't actually know if this is the correct way to do this, I was just following the existing example and it Seems To Work.