### PR TITLE
feat: add MSBuild rule to build MSBuild projects.

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -69,6 +69,16 @@ stardoc(
 )
 
 stardoc(
+    name = "msbuild_docs",
+    out = "src/msbuild.md",
+    input = "@rules_foreign_cc//foreign_cc:msbuild.bzl",
+    deps = [
+        ":rules_cc_deps",
+        "@rules_foreign_cc//foreign_cc:msbuild",
+    ],
+)
+
+stardoc(
     name = "providers_docs",
     out = "src/providers.md",
     input = "@rules_foreign_cc//foreign_cc:providers.bzl",
@@ -84,6 +94,7 @@ DOCS_TARGETS = [
     ":make_docs",
     ":configure_make_docs",
     ":meson_docs",
+    ":msbuild_docs",
     ":providers_docs",
 ]
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -6,4 +6,5 @@
         - [configure_make](configure_make.md)
         - [make](make.md)
         - [meson](meson.md)
+        - [msbuild](msbuild.md)
         - [ninja](ninja.md)

--- a/examples/msbuild_simple/BUILD.bazel
+++ b/examples/msbuild_simple/BUILD.bazel
@@ -6,6 +6,10 @@ msbuild(
     lib_source = "//msbuild_simple/code:srcs",
     out_lib_dir = "",
     out_static_libs = ["mylib.lib"],
+    # Configuration defaults to Debug/Release based on compilation mode.
+    # Platform must match a pair declared in the solution; the solution
+    # declares x64 and Win32, so pin x64 here.
+    platform = "x64",
     sln_file_path = "mysolution.sln",
     target_compatible_with = ["@platforms//os:windows"],
     targets = ["Build"],

--- a/examples/msbuild_simple/BUILD.bazel
+++ b/examples/msbuild_simple/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "msbuild")
+
+msbuild(
+    name = "mylib",
+    lib_source = "//msbuild_simple/code:srcs",
+    out_lib_dir = "",
+    out_static_libs = ["mylib.lib"],
+    sln_file_path = "mysolution.sln",
+    target_compatible_with = ["@platforms//os:windows"],
+    targets = ["Build"],
+)
+
+cc_test(
+    name = "mylib_test",
+    srcs = ["test_mylib.cpp"],
+    target_compatible_with = ["@platforms//os:windows"],
+    deps = [":mylib"],
+)

--- a/examples/msbuild_simple/code/BUILD.bazel
+++ b/examples/msbuild_simple/code/BUILD.bazel
@@ -1,0 +1,10 @@
+filegroup(
+    name = "srcs",
+    srcs = [
+        "mylib.cpp",
+        "mylib.h",
+        "mylib.vcxproj",
+        "mysolution.sln",
+    ],
+    visibility = ["//msbuild_simple:__subpackages__"],
+)

--- a/examples/msbuild_simple/code/mylib.cpp
+++ b/examples/msbuild_simple/code/mylib.cpp
@@ -1,0 +1,5 @@
+#include "mylib.h"
+
+std::string hello_mylib(void) { return "Hello from MyLib!"; }
+
+int add_numbers(int a, int b) { return a + b; }

--- a/examples/msbuild_simple/code/mylib.h
+++ b/examples/msbuild_simple/code/mylib.h
@@ -1,0 +1,9 @@
+#ifndef MYLIB_H_
+#define MYLIB_H_ (1)
+
+#include <string>
+
+std::string hello_mylib(void);
+int add_numbers(int a, int b);
+
+#endif

--- a/examples/msbuild_simple/code/mylib.vcxproj
+++ b/examples/msbuild_simple/code/mylib.vcxproj
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="17.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <ProjectGuid>{B2C3D4E5-F6A7-8901-BCDE-F01234567890}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>mylib</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <IntDir>$(ProjectDir)obj\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>mylib</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <IntDir>$(ProjectDir)obj\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>mylib</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <IntDir>$(ProjectDir)obj\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>mylib</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <IntDir>$(ProjectDir)obj\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>mylib</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <Lib>
+      <AdditionalDependencies></AdditionalDependencies>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <Lib>
+      <AdditionalDependencies></AdditionalDependencies>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <Lib>
+      <AdditionalDependencies></AdditionalDependencies>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <Lib>
+      <AdditionalDependencies></AdditionalDependencies>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="mylib.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="mylib.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+  <Target Name="CopyHeaders" AfterTargets="Build">
+    <MakeDir Directories="$(OutDir)include" />
+    <Copy SourceFiles="mylib.h" DestinationFolder="$(OutDir)include" />
+  </Target>
+</Project>

--- a/examples/msbuild_simple/code/mysolution.sln
+++ b/examples/msbuild_simple/code/mysolution.sln
@@ -1,0 +1,30 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mylib", "mylib.vcxproj", "{B2C3D4E5-F6A7-8901-BCDE-F01234567890}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|x64 = Debug|x64
+        Debug|Win32 = Debug|Win32
+        Release|x64 = Release|x64
+        Release|Win32 = Release|Win32
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {B2C3D4E5-F6A7-8901-BCDE-F01234567890}.Debug|x64.ActiveCfg = Debug|x64
+        {B2C3D4E5-F6A7-8901-BCDE-F01234567890}.Debug|x64.Build.0 = Debug|x64
+        {B2C3D4E5-F6A7-8901-BCDE-F01234567890}.Debug|Win32.ActiveCfg = Debug|Win32
+        {B2C3D4E5-F6A7-8901-BCDE-F01234567890}.Debug|Win32.Build.0 = Debug|Win32
+        {B2C3D4E5-F6A7-8901-BCDE-F01234567890}.Release|x64.ActiveCfg = Release|x64
+        {B2C3D4E5-F6A7-8901-BCDE-F01234567890}.Release|x64.Build.0 = Release|x64
+        {B2C3D4E5-F6A7-8901-BCDE-F01234567890}.Release|Win32.ActiveCfg = Release|Win32
+        {B2C3D4E5-F6A7-8901-BCDE-F01234567890}.Release|Win32.Build.0 = Release|Win32
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
+    GlobalSection(ExtensibilityGlobals) = postSolution
+        SolutionGuid = {B5C6D7E8-F9A0-1234-5678-90ABCDEF0123}
+    EndGlobalSection
+EndGlobal

--- a/examples/msbuild_simple/test_mylib.cpp
+++ b/examples/msbuild_simple/test_mylib.cpp
@@ -1,0 +1,23 @@
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+#include "mylib.h"
+
+int main(int argc, char* argv[]) {
+    // Test the hello_mylib function
+    std::string result = hello_mylib();
+    if (result != "Hello from MyLib!") {
+        throw std::runtime_error("Wrong result from hello_mylib: " + result);
+    }
+
+    // Test the add_numbers function
+    int math_result = add_numbers(5, 3);
+    if (math_result != 8) {
+        throw std::runtime_error("Wrong math_result from add_numbers: " +
+                                 std::to_string(math_result));
+    }
+
+    std::cout << "Everything's fine!";
+    return 0;
+}

--- a/foreign_cc/BUILD.bazel
+++ b/foreign_cc/BUILD.bazel
@@ -61,6 +61,7 @@ bzl_library(
         ":configure",
         ":make",
         ":meson",
+        ":msbuild",
         ":ninja",
         ":utils",
     ],
@@ -110,6 +111,22 @@ bzl_library(
         "@rules_cc//cc/common",
         "@rules_cc//cc/toolchains:toolchain_rules",
         "@rules_python//python:features_bzl",
+    ],
+)
+
+bzl_library(
+    name = "msbuild",
+    srcs = ["msbuild.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//foreign_cc/private:cc_toolchain_util",
+        "//foreign_cc/private:detect_root",
+        "//foreign_cc/private:framework",
+        "//foreign_cc/private:msbuild_script",
+        "//toolchains/native_tools:tool_access",
+        "@rules_cc//cc:bzl_srcs",
+        "@rules_cc//cc/common",
+        "@rules_cc//cc/toolchains:toolchain_rules",
     ],
 )
 

--- a/foreign_cc/defs.bzl
+++ b/foreign_cc/defs.bzl
@@ -9,6 +9,7 @@ load(
 )
 load(":make.bzl", _make = "make", _make_variant = "make_variant")
 load(":meson.bzl", _meson = "meson", _meson_with_requirements = "meson_with_requirements")
+load(":msbuild.bzl", _msbuild = "msbuild")
 load(":ninja.bzl", _ninja = "ninja")
 load(":utils.bzl", _runnable_binary = "runnable_binary")
 
@@ -20,6 +21,7 @@ configure_make_variant = _configure_make_variant
 make_variant = _make_variant
 make = _make
 meson = _meson
-ninja = _ninja
 meson_with_requirements = _meson_with_requirements
+msbuild = _msbuild
+ninja = _ninja
 runnable_binary = _runnable_binary

--- a/foreign_cc/msbuild.bzl
+++ b/foreign_cc/msbuild.bzl
@@ -1,0 +1,283 @@
+"""# [MSBuild](#msbuild)
+
+This rule is tailored for MSBuild.exe from the Visual Studio installation. It does not support
+the dotnet msbuild execution path. MSBuild determines it own compile and linker flags based
+on the project/solution file configuration. This cannot be fully controlled from bazel like
+other rules (e.g. cmake). We do our best by generating a `msbuild.props` file that is used by
+specifying `-p:ForceImportAfterCppTargets=msbuild.props` to append bazel flags and override
+existing flags where possible.
+
+Since MSBuild is closed source project from Microsoft, there is no prebuilt toolchain available
+and we cannot build it from source. The default is a pre-installed toolchain which assumes
+MSBuild.exe is installed as a part of Visual Studio and locateable by bazel. If you want to
+implement your own MSBuild toolchain you will need to define a toolchain that implements the
+toolchain type `@rules_foreign_cc//toolchains:msbuild_toolchain`. E.g.
+
+```bzl
+toolchain(
+    name = "msbuild_toolchain",
+    exec_compatible_with = [
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_64",
+    ],
+    target_compatible_with = [
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_64",
+    ],
+    toolchain = ":_msbuild_toolchain",
+    toolchain_type = "@rules_foreign_cc//toolchains:msbuild_toolchain",
+)
+
+native_tool_toolchain(
+    name = "_msbuild_toolchain",
+    path = "<Path to MSBuild.exe inside target>",
+    target = "<Label to toolchain target>",
+    env = {
+        "MSBUILD": "$(execpath <Label for MSBuild.exe>)",
+    },
+)
+```
+
+`native_tool_toolchain` should refer to the target where your MSBuild binary/files reside.
+
+When using your own toolchain, it may also be necessary to set the following properties
+for MSBuild:
+
+```bzl
+# Use env from bazel toolchain, don't override it.
+"-p:UseEnv=true",
+"-p:SetEnvOverride=false",
+
+# Toolchain config
+"-p:PlatformToolset=", # e.g "v143" for Visual Studio 2022
+"-p:VCToolsRedistVersion=",
+"-p:VCInstallDir=<path to Visual C++ install dir>",
+"-p:VCInstallDir_170=<path to Visual C++ install dir for Visual Studios 2022>",
+
+# SDK configuration
+"-p:WindowsSdkDir_10=<path to windows sdk>",
+"-p:WindowsKitsRoot=<path to windows sdk>",
+
+# Skip the problematic SDK check target
+"-p:_CheckWindowsSDKInstalled=",
+
+# Bypass Windows SDK validation checks
+"-p:WindowsSDKInstalled=true",
+"-p:WindowsSDK_Desktop_Support=true",
+```
+
+The MSBuild `Configuration` property is controlled by the `configuration`
+attribute.
+
+MSBuild projects must copy their outputs into `$(OutDir)` using the layout
+declared on the rule. For example, with the default include directory and
+`out_static_libs = ["mylib.lib"]`, the project should produce
+`$(OutDir)mylib.lib` and copy public headers under `$(OutDir)include`.
+"""
+
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
+load("//foreign_cc/private:cc_toolchain_util.bzl", "get_flags_info")
+load("//foreign_cc/private:detect_root.bzl", "detect_root")
+load(
+    "//foreign_cc/private:framework.bzl",
+    "CC_EXTERNAL_RULE_ATTRIBUTES",
+    "CC_EXTERNAL_RULE_FRAGMENTS",
+    "cc_external_rule_impl",
+    "create_attrs",
+    "expand_locations_and_make_variables",
+    "get_foreign_cc_dep",
+)
+load("//foreign_cc/private:msbuild_script.bzl", "create_msbuild_script")
+load("//toolchains/native_tools:tool_access.bzl", "get_msbuild_data")
+
+def _msbuild(ctx):
+    msbuild_data = get_msbuild_data(ctx)
+
+    tools_data = [msbuild_data]
+
+    attrs = create_attrs(
+        ctx.attr,
+        configure_name = "MSBuild",
+        create_configure_script = _create_msbuild_script,
+        tools_data = tools_data,
+        msbuild_path = msbuild_data.path,
+    )
+
+    return cc_external_rule_impl(ctx, attrs)
+
+def _create_msbuild_script(configureParameters):
+    ctx = configureParameters.ctx
+    attrs = configureParameters.attrs
+    inputs = configureParameters.inputs
+
+    data = attrs.data + attrs.build_data
+
+    user_properties = ctx.attr.properties
+    args = ctx.attr.args
+    configuration = ctx.attr.configuration
+    targets = ctx.attr.targets
+    verbosity = ctx.attr.verbosity
+
+    root = detect_root(attrs.lib_source)
+    flags = get_flags_info(ctx)
+
+    all_properties = _msbuild_properties(user_properties, configuration)
+
+    all_args = _properties_to_args(all_properties)
+    all_args.append("-v:{}".format(verbosity))
+    if args:
+        all_args.extend(args)
+    if targets:
+        all_args.append("-t:{}".format(",".join(targets)))
+
+    expanded_args = expand_locations_and_make_variables(ctx, all_args, "args", data)
+    dep_paths = _msbuild_dep_paths(attrs.deps, inputs)
+
+    return create_msbuild_script(
+        workspace_name = ctx.workspace_name,
+        flags = flags,
+        root = root,
+        msbuild_path = attrs.msbuild_path,
+        msbuild_sln_path = _sln_file_path(
+            sln_file_path = ctx.attr.sln_file_path,
+            lib_source_files = attrs.lib_source.files.to_list(),
+            root = root,
+        ),
+        msbuild_args = expanded_args,
+        dep_include_dirs = dep_paths.include_dirs,
+        dep_lib_dirs = dep_paths.lib_dirs,
+    )
+
+def _attrs():
+    attrs = dict(CC_EXTERNAL_RULE_ATTRIBUTES)
+    attrs.update({
+        "args": attr.string_list(
+            doc = "Args for MSBuild.exe. e.g. '-p:PlatformToolset=v143'",
+            mandatory = False,
+            default = [],
+        ),
+        "configuration": attr.string(
+            doc = "Configuration of the build. Usually either `Debug` or `Release`.",
+            mandatory = False,
+            default = "Release",
+        ),
+        "properties": attr.string_dict(
+            doc = "A map of properties (`-p:`) for MSBuild. Do not set `Configuration`; use the dedicated attribute instead.",
+            mandatory = False,
+            default = {},
+        ),
+        "sln_file_path": attr.string(
+            doc = "Solution or project file path, relative to the detected `lib_source` root.",
+            mandatory = True,
+        ),
+        "targets": attr.string_list(
+            doc = "List of MSBuild targets in the project",
+            mandatory = False,
+            default = [],
+        ),
+        "verbosity": attr.string(
+            doc = "VerbosityLevel of msbuild logs. One of 'quiet', 'minimal', 'normal', 'detailed', 'diagnostic'.",
+            mandatory = False,
+            default = "normal",
+            values = ["quiet", "minimal", "normal", "detailed", "diagnostic"],
+        ),
+    })
+    return attrs
+
+msbuild = rule(
+    doc = "Rule for building external library with MSBuild.",
+    attrs = _attrs(),
+    fragments = CC_EXTERNAL_RULE_FRAGMENTS,
+    output_to_genfiles = True,
+    provides = [CcInfo],
+    implementation = _msbuild,
+
+    # Only msbuild from MSVC is supported so make it windows only.
+    exec_compatible_with = ["@platforms//os:windows"],
+    toolchains = [
+        "@rules_foreign_cc//toolchains:msbuild_toolchain",
+        "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
+        "@bazel_tools//tools/cpp:toolchain_type",
+    ],
+)
+
+def _properties_to_args(properties):
+    args = []
+    for k, v in properties.items():
+        args.append("-p:{}={}".format(k, v))
+    return args
+
+def _msbuild_properties(user_properties, configuration):
+    _fail_if_reserved_property(user_properties, "Configuration", "configuration")
+
+    properties = {
+        # We generate a props file to add our compile and linker.
+        "ForceImportAfterCppTargets": "$$BUILD_TMPDIR/msbuild.props",
+        "OutDir": "$$INSTALLDIR/",
+
+        # This is used for incremental builds in MSBuild, we don't want it.
+        "TrackFileAccess": "false",
+    } | user_properties
+
+    properties.update({
+        "Configuration": configuration,
+    })
+
+    return properties
+
+def _fail_if_reserved_property(properties, property_name, attr_name):
+    if property_name in properties:
+        fail("MSBuild property `{}` must be set with the `{}` attribute, not `properties`.".format(property_name, attr_name))
+
+def _sln_file_path(sln_file_path, lib_source_files, root):
+    _fail_if_absolute_or_parent_relative_sln_file_path(sln_file_path)
+
+    expected_path = root + "/" + sln_file_path
+    for source_file in lib_source_files:
+        if source_file.path == expected_path:
+            return sln_file_path
+    fail("`sln_file_path` must name a file included in `lib_source`; got `{}`.".format(sln_file_path))
+
+def _fail_if_absolute_or_parent_relative_sln_file_path(sln_file_path):
+    if sln_file_path.startswith("/") or sln_file_path.startswith("../") or sln_file_path == ".." or "/../" in sln_file_path:
+        fail("`sln_file_path` must be relative to the detected `lib_source` root; got `{}`.".format(sln_file_path))
+
+# Include and linker search paths are order-sensitive, so keep first-seen order.
+def _append_dedup(values, value):
+    if value not in values:
+        values.append(value)
+
+def _msbuild_dep_paths(deps, inputs):
+    include_dirs = []
+    lib_dirs = []
+
+    if inputs.headers or inputs.include_dirs:
+        _append_dedup(include_dirs, "$$EXT_BUILD_DEPS$$/include")
+    if inputs.libs:
+        _append_dedup(lib_dirs, "$$EXT_BUILD_DEPS$$/lib")
+
+    for dep in deps:
+        foreign_dep = get_foreign_cc_dep(dep)
+        if not foreign_dep:
+            continue
+        for artifact in foreign_dep.artifacts.to_list():
+            gen_dir_name = artifact.gen_dir.basename
+            _append_dedup(
+                include_dirs,
+                "$$EXT_BUILD_DEPS$$/{}/{}".format(gen_dir_name, artifact.include_dir_name),
+            )
+            _append_dedup(
+                lib_dirs,
+                "$$EXT_BUILD_DEPS$$/{}/{}".format(gen_dir_name, artifact.lib_dir_name),
+            )
+
+    return struct(
+        include_dirs = include_dirs,
+        lib_dirs = lib_dirs,
+    )
+
+export_for_test = struct(
+    msbuild_properties = _msbuild_properties,
+    msbuild_dep_paths = _msbuild_dep_paths,
+    sln_file_path = _sln_file_path,
+)

--- a/foreign_cc/msbuild.bzl
+++ b/foreign_cc/msbuild.bzl
@@ -67,7 +67,14 @@ for MSBuild:
 ```
 
 The MSBuild `Configuration` property is controlled by the `configuration`
-attribute.
+attribute. When left unset it follows the Bazel compilation mode, defaulting
+to `Debug` under `-c dbg` and `Release` otherwise (matching the `cmake` rule).
+
+The MSBuild `Platform` property is controlled by the `platform` attribute. It
+is left unset by default so MSBuild picks the platform declared in the
+solution or project file. A `.sln` only builds the `Configuration|Platform`
+pairs it declares, so forcing a platform that the solution does not declare
+fails with `MSB4126`; set `platform` only when the project supports it.
 
 MSBuild projects must copy their outputs into `$(OutDir)` using the layout
 declared on the rule. For example, with the default include directory and
@@ -76,7 +83,11 @@ declared on the rule. For example, with the default include directory and
 """
 
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
-load("//foreign_cc/private:cc_toolchain_util.bzl", "get_flags_info")
+load(
+    "//foreign_cc/private:cc_toolchain_util.bzl",
+    "get_flags_info",
+    "is_debug_mode",
+)
 load("//foreign_cc/private:detect_root.bzl", "detect_root")
 load(
     "//foreign_cc/private:framework.bzl",
@@ -114,14 +125,15 @@ def _create_msbuild_script(configureParameters):
 
     user_properties = ctx.attr.properties
     args = ctx.attr.args
-    configuration = ctx.attr.configuration
+    configuration = ctx.attr.configuration or ("Debug" if is_debug_mode(ctx) else "Release")
+    platform = ctx.attr.platform
     targets = ctx.attr.targets
     verbosity = ctx.attr.verbosity
 
     root = detect_root(attrs.lib_source)
     flags = get_flags_info(ctx)
 
-    all_properties = _msbuild_properties(user_properties, configuration)
+    all_properties = _msbuild_properties(user_properties, configuration, platform)
 
     all_args = _properties_to_args(all_properties)
     all_args.append("-v:{}".format(verbosity))
@@ -157,12 +169,27 @@ def _attrs():
             default = [],
         ),
         "configuration": attr.string(
-            doc = "Configuration of the build. Usually either `Debug` or `Release`.",
+            doc = (
+                "MSBuild `Configuration` to build. When unset, defaults to `Debug` in " +
+                "`-c dbg` compilation mode and `Release` otherwise, mirroring the `cmake` rule. " +
+                "Usually either `Debug` or `Release`."
+            ),
             mandatory = False,
-            default = "Release",
+            default = "",
+        ),
+        "platform": attr.string(
+            doc = (
+                "MSBuild `Platform` to build (e.g. `x64`, `Win32`, `ARM64`). When unset, the " +
+                "`-p:Platform` flag is omitted and MSBuild selects the platform from the solution " +
+                "or project file. This is deliberately not derived from the target CPU: a `.sln` " +
+                "only builds `Configuration|Platform` pairs it declares, so forcing a mismatched " +
+                "platform fails with MSB4126. Set this explicitly when the project supports it."
+            ),
+            mandatory = False,
+            default = "",
         ),
         "properties": attr.string_dict(
-            doc = "A map of properties (`-p:`) for MSBuild. Do not set `Configuration`; use the dedicated attribute instead.",
+            doc = "A map of properties (`-p:`) for MSBuild. Do not set `Configuration` or `Platform`; use the dedicated attributes instead.",
             mandatory = False,
             default = {},
         ),
@@ -207,8 +234,9 @@ def _properties_to_args(properties):
         args.append("-p:{}={}".format(k, v))
     return args
 
-def _msbuild_properties(user_properties, configuration):
+def _msbuild_properties(user_properties, configuration, platform):
     _fail_if_reserved_property(user_properties, "Configuration", "configuration")
+    _fail_if_reserved_property(user_properties, "Platform", "platform")
 
     properties = {
         # We generate a props file to add our compile and linker.
@@ -222,6 +250,12 @@ def _msbuild_properties(user_properties, configuration):
     properties.update({
         "Configuration": configuration,
     })
+
+    # Only force Platform when the user asked for one. A solution only builds the
+    # Configuration|Platform pairs it declares, so a mismatched -p:Platform fails
+    # with MSB4126; omitting it lets MSBuild pick the solution's own platform.
+    if platform:
+        properties["Platform"] = platform
 
     return properties
 

--- a/foreign_cc/msbuild.bzl
+++ b/foreign_cc/msbuild.bzl
@@ -218,9 +218,6 @@ msbuild = rule(
     output_to_genfiles = True,
     provides = [CcInfo],
     implementation = _msbuild,
-
-    # Only msbuild from MSVC is supported so make it windows only.
-    exec_compatible_with = ["@platforms//os:windows"],
     toolchains = [
         "@rules_foreign_cc//toolchains:msbuild_toolchain",
         "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",

--- a/foreign_cc/private/BUILD.bazel
+++ b/foreign_cc/private/BUILD.bazel
@@ -64,11 +64,18 @@ bzl_library(
 )
 
 bzl_library(
+    name = "flag_utils",
+    srcs = ["flag_utils.bzl"],
+    visibility = ["//foreign_cc:__subpackages__"],
+    deps = [":cc_toolchain_util"],
+)
+
+bzl_library(
     name = "make_env_vars",
     srcs = ["make_env_vars.bzl"],
     visibility = ["//foreign_cc:__subpackages__"],
     deps = [
-        ":cc_toolchain_util",
+        ":flag_utils",
         ":framework",
     ],
 )
@@ -78,6 +85,13 @@ bzl_library(
     srcs = ["make_script.bzl"],
     visibility = ["//foreign_cc:__subpackages__"],
     deps = [":make_env_vars"],
+)
+
+bzl_library(
+    name = "msbuild_script",
+    srcs = ["msbuild_script.bzl"],
+    visibility = ["//foreign_cc:__subpackages__"],
+    deps = [":flag_utils"],
 )
 
 bzl_library(

--- a/foreign_cc/private/flag_utils.bzl
+++ b/foreign_cc/private/flag_utils.bzl
@@ -1,0 +1,12 @@
+"""Helpers for rendering foreign build flag lists."""
+
+load(":cc_toolchain_util.bzl", "absolutize_path_in_str")
+
+def absolutize_path_for_build_root(workspace_name, text, force = False):
+    return absolutize_path_in_str(workspace_name, "$$EXT_BUILD_ROOT$$/", text, force)
+
+def join_flags_list(workspace_name, flags):
+    return " ".join([
+        absolutize_path_for_build_root(workspace_name, flag)
+        for flag in flags
+    ])

--- a/foreign_cc/private/make_env_vars.bzl
+++ b/foreign_cc/private/make_env_vars.bzl
@@ -1,6 +1,6 @@
 """Helper methods to assemble make env variables from Bazel information."""
 
-load(":cc_toolchain_util.bzl", "absolutize_path_in_str")
+load(":flag_utils.bzl", "absolutize_path_for_build_root", _join_flags_list = "join_flags_list")
 load(":framework.bzl", "get_foreign_cc_dep")
 
 # buildifier: disable=function-docstring
@@ -140,7 +140,7 @@ def _get_make_variables(workspace_name, tools, flags, user_env_vars, make_comman
         tool_value = getattr(tools, _MAKE_TOOLS[tool])
         if tool_value:
             # Force absolutize of tool paths, which may relative to the exec root (e.g. hermetic toolchains built from source)
-            tool_value_absolute = _absolutize(workspace_name, tool_value, True)
+            tool_value_absolute = absolutize_path_for_build_root(workspace_name, tool_value, True)
 
             # There are 2 conditions where we need to wrap the tool path in double quotes:
             # 1. If the tool path contains whitespaces (e.g. C:\Program Files\...),
@@ -192,12 +192,6 @@ def _merge_env_vars(flags, make_flags, user_env_vars):
         if toolchain_flags or user_flags:
             vars[flag] = toolchain_flags + user_flags
     return vars
-
-def _absolutize(workspace_name, text, force = False):
-    return absolutize_path_in_str(workspace_name, "$$EXT_BUILD_ROOT$$/", text, force)
-
-def _join_flags_list(workspace_name, flags):
-    return " ".join([_absolutize(workspace_name, flag) for flag in flags])
 
 def _nmake_in_make_commands(make_commands):
     return make_commands and "nmake.exe" in make_commands[0]

--- a/foreign_cc/private/msbuild_script.bzl
+++ b/foreign_cc/private/msbuild_script.bzl
@@ -1,0 +1,84 @@
+"""A module for creating the build script for `msbuild` builds"""
+
+load(":flag_utils.bzl", "join_flags_list")
+
+def create_msbuild_script(
+        workspace_name,
+        root,
+        flags,
+        msbuild_path,
+        msbuild_sln_path,
+        msbuild_args,
+        dep_include_dirs = [],
+        dep_lib_dirs = []):
+    """Constructs MSBuild script to be passed to cc_external_rule_impl.
+
+    Args:
+        workspace_name: current workspace name
+        root: sources root relative to the $EXT_BUILD_ROOT
+        flags: cc_toolchain flags (CxxFlagsInfo)
+        msbuild_path: path to msbuild.exe.
+        msbuild_sln_path: path to msbuild's solution file to be built.
+        msbuild_args: msbuild arguments.
+        dep_include_dirs: Optional dependency include directories. Defaults to [].
+        dep_lib_dirs: Optional dependency library directories. Defaults to [].
+
+    Returns:
+        list: Lines of bash which make up the build script.
+    """
+    script = []
+
+    script.append("##symlink_contents_to_dir## $$EXT_BUILD_ROOT$$/{} $$BUILD_TMPDIR$$ False".format(root))
+    script.append("##enable_tracing##")
+    script.extend(["cat > msbuild.props << EOF"] + [_create_props_file_text(flags, dep_include_dirs, dep_lib_dirs, workspace_name)] + ["EOF", ""])
+
+    msbuild_command = " ".join([
+        _shell_quote(arg)
+        for arg in [msbuild_path, msbuild_sln_path] + msbuild_args
+    ])
+
+    script.append(msbuild_command)
+    script.append("##disable_tracing##")
+    return script
+
+def _create_props_file_text(flags, dep_include_dirs, dep_lib_dirs, workspace_name):
+    props_template = """<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <ItemDefinitionGroup>
+        <ClCompile>
+            <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);{include_dirs}</AdditionalIncludeDirectories>
+            <AdditionalOptions>%(AdditionalOptions) {cxx_flags}</AdditionalOptions>
+        </ClCompile>
+        <Link>
+            <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories);{lib_dirs}</AdditionalLibraryDirectories>
+            <AdditionalOptions>%(AdditionalOptions) {linker_flags}</AdditionalOptions>
+        </Link>
+        <Lib>
+            <AdditionalOptions>%(AdditionalOptions) {static_linker_flags}</AdditionalOptions>
+        </Lib>
+    </ItemDefinitionGroup>
+</Project>
+"""
+
+    return props_template.format(
+        include_dirs = _xml_escape(";".join(dep_include_dirs)),
+        lib_dirs = _xml_escape(";".join(dep_lib_dirs)),
+        cxx_flags = _xml_escape(join_flags_list(workspace_name, flags.cxx)),
+        linker_flags = _xml_escape(join_flags_list(workspace_name, flags.cxx_linker_executable)),
+        static_linker_flags = _xml_escape(join_flags_list(workspace_name, flags.cxx_linker_static)),
+    )
+
+def _shell_quote(value):
+    # MSBuild argv words are interpreted by bash before reaching MSBuild.exe.
+    # Double-quote each word to preserve spaces while still allowing normal
+    # $VAR/${VAR} expansion. Escape double-quote syntax and shell substitution
+    # forms so they are passed literally to MSBuild.
+    escaped = value.replace("\\", "\\\\")
+    escaped = escaped.replace("\"", "\\\"")
+    escaped = escaped.replace("`", "\\`")
+    escaped = escaped.replace("$(", "\\$(")
+    escaped = escaped.replace("$[", "\\$[")
+    return "\"" + escaped + "\""
+
+def _xml_escape(value):
+    return value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;").replace("'", "&apos;")

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -4,6 +4,7 @@ load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tools/lint:linters.bzl", "shellcheck_test")
 load(":cmake_text_tests.bzl", "cmake_script_test_suite")
 load(":convert_shell_script_test.bzl", "shell_script_conversion_suite")
+load(":msbuild_text_tests.bzl", "msbuild_script_test_suite")
 load(":shell_script_helper_test_rule.bzl", "shell_script_helper_test_rule")
 load(":symlink_contents_to_dir_test_rule.bzl", "symlink_contents_to_dir_test_rule")
 load(":utils_test.bzl", "utils_test_suite")
@@ -53,6 +54,8 @@ shellcheck_test(
 )
 
 cmake_script_test_suite()
+
+msbuild_script_test_suite()
 
 shell_script_conversion_suite()
 

--- a/test/msbuild_text_tests.bzl
+++ b/test/msbuild_text_tests.bzl
@@ -119,6 +119,7 @@ def _msbuild_properties_test(ctx):
             "CustomProperty": "custom-value",
         },
         "Debug",
+        "",
     )
 
     asserts.equals(env, "custom-value", properties["CustomProperty"])
@@ -126,6 +127,26 @@ def _msbuild_properties_test(ctx):
     asserts.equals(env, "$$INSTALLDIR/", properties["OutDir"])
     asserts.equals(env, "false", properties["TrackFileAccess"])
     asserts.equals(env, "Debug", properties["Configuration"])
+
+    return unittest.end(env)
+
+# An empty platform omits the Platform property entirely.
+def _msbuild_properties_no_platform_test(ctx):
+    env = unittest.begin(ctx)
+
+    properties = export_for_test.msbuild_properties({}, "Release", "")
+
+    asserts.false(env, "Platform" in properties)
+
+    return unittest.end(env)
+
+# A non-empty platform is emitted as the Platform property.
+def _msbuild_properties_platform_test(ctx):
+    env = unittest.begin(ctx)
+
+    properties = export_for_test.msbuild_properties({}, "Release", "x64")
+
+    asserts.equals(env, "x64", properties["Platform"])
 
     return unittest.end(env)
 
@@ -279,6 +300,8 @@ bazel_headers_and_include_dirs_test = unittest.make(_bazel_headers_and_include_d
 bazel_libraries_test = unittest.make(_bazel_libraries_test)
 foreign_artifacts_deduped_in_order_test = unittest.make(_foreign_artifacts_deduped_in_order_test)
 msbuild_properties_test = unittest.make(_msbuild_properties_test)
+msbuild_properties_no_platform_test = unittest.make(_msbuild_properties_no_platform_test)
+msbuild_properties_platform_test = unittest.make(_msbuild_properties_platform_test)
 sln_file_path_relative_to_root_test = unittest.make(_sln_file_path_relative_to_root_test)
 create_msbuild_script_include_dirs_test = unittest.make(_create_msbuild_script_include_dirs_test)
 create_msbuild_script_lib_dirs_test = unittest.make(_create_msbuild_script_lib_dirs_test)
@@ -292,6 +315,8 @@ def msbuild_script_test_suite():
         partial.make(bazel_libraries_test, size = "small"),
         partial.make(foreign_artifacts_deduped_in_order_test, size = "small"),
         partial.make(msbuild_properties_test, size = "small"),
+        partial.make(msbuild_properties_no_platform_test, size = "small"),
+        partial.make(msbuild_properties_platform_test, size = "small"),
         partial.make(sln_file_path_relative_to_root_test, size = "small"),
         partial.make(create_msbuild_script_include_dirs_test, size = "small"),
         partial.make(create_msbuild_script_lib_dirs_test, size = "small"),

--- a/test/msbuild_text_tests.bzl
+++ b/test/msbuild_text_tests.bzl
@@ -1,0 +1,300 @@
+"""Unit tests for MSBuild script creation."""
+
+load("@bazel_skylib//lib:partial.bzl", "partial")
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//foreign_cc:msbuild.bzl", "export_for_test")
+load("//foreign_cc:providers.bzl", "ForeignCcArtifactInfo", "ForeignCcDepsInfo")
+
+# buildifier: disable=bzl-visibility
+load("//foreign_cc/private:cc_toolchain_util.bzl", "CxxFlagsInfo")
+
+# buildifier: disable=bzl-visibility
+load("//foreign_cc/private:msbuild_script.bzl", "create_msbuild_script")
+
+def _inputs(headers = [], include_dirs = [], libs = []):
+    return struct(
+        headers = headers,
+        include_dirs = include_dirs,
+        libs = libs,
+    )
+
+def _foreign_dep(artifacts):
+    return {
+        ForeignCcDepsInfo: ForeignCcDepsInfo(artifacts = depset(artifacts)),
+    }
+
+def _artifact(gen_dir, include_dir_name = "include", lib_dir_name = "lib"):
+    return ForeignCcArtifactInfo(
+        gen_dir = struct(basename = gen_dir),
+        bin_dir_name = "bin",
+        dll_dir_name = "bin",
+        include_dir_name = include_dir_name,
+        lib_dir_name = lib_dir_name,
+    )
+
+def _empty_flags():
+    return _flags()
+
+def _flags(cxx = [], cxx_linker_executable = [], cxx_linker_static = []):
+    return CxxFlagsInfo(
+        cc = [],
+        cxx = cxx,
+        cxx_linker_shared = [],
+        cxx_linker_static = cxx_linker_static,
+        cxx_linker_executable = cxx_linker_executable,
+        assemble = [],
+    )
+
+# Bazel-provided headers and include directories are exposed through the shared include root.
+def _bazel_headers_and_include_dirs_test(ctx):
+    env = unittest.begin(ctx)
+
+    dep_paths = export_for_test.msbuild_dep_paths(
+        [],
+        _inputs(
+            headers = [struct()],
+            include_dirs = ["external/include"],
+        ),
+    )
+
+    asserts.equals(env, ["$$EXT_BUILD_DEPS$$/include"], dep_paths.include_dirs)
+    asserts.equals(env, [], dep_paths.lib_dirs)
+
+    return unittest.end(env)
+
+# Bazel-provided libraries are exposed through the shared library root.
+def _bazel_libraries_test(ctx):
+    env = unittest.begin(ctx)
+
+    dep_paths = export_for_test.msbuild_dep_paths(
+        [],
+        _inputs(libs = [struct()]),
+    )
+
+    asserts.equals(env, [], dep_paths.include_dirs)
+    asserts.equals(env, ["$$EXT_BUILD_DEPS$$/lib"], dep_paths.lib_dirs)
+
+    return unittest.end(env)
+
+# Foreign-cc artifact include and library paths are deduped while preserving first-seen order.
+def _foreign_artifacts_deduped_in_order_test(ctx):
+    env = unittest.begin(ctx)
+
+    first = _artifact("first_dep", include_dir_name = "first_include", lib_dir_name = "first_lib")
+    duplicate = _artifact("first_dep", include_dir_name = "first_include", lib_dir_name = "first_lib")
+    second = _artifact("second_dep", include_dir_name = "second_include", lib_dir_name = "second_lib")
+    dep_paths = export_for_test.msbuild_dep_paths(
+        [
+            _foreign_dep([first, second]),
+            _foreign_dep([duplicate]),
+        ],
+        _inputs(),
+    )
+
+    asserts.equals(
+        env,
+        [
+            "$$EXT_BUILD_DEPS$$/first_dep/first_include",
+            "$$EXT_BUILD_DEPS$$/second_dep/second_include",
+        ],
+        dep_paths.include_dirs,
+    )
+    asserts.equals(
+        env,
+        [
+            "$$EXT_BUILD_DEPS$$/first_dep/first_lib",
+            "$$EXT_BUILD_DEPS$$/second_dep/second_lib",
+        ],
+        dep_paths.lib_dirs,
+    )
+
+    return unittest.end(env)
+
+# MSBuild Configuration is controlled by its attribute
+def _msbuild_properties_test(ctx):
+    env = unittest.begin(ctx)
+
+    properties = export_for_test.msbuild_properties(
+        {
+            "CustomProperty": "custom-value",
+        },
+        "Debug",
+    )
+
+    asserts.equals(env, "custom-value", properties["CustomProperty"])
+    asserts.equals(env, "$$BUILD_TMPDIR/msbuild.props", properties["ForceImportAfterCppTargets"])
+    asserts.equals(env, "$$INSTALLDIR/", properties["OutDir"])
+    asserts.equals(env, "false", properties["TrackFileAccess"])
+    asserts.equals(env, "Debug", properties["Configuration"])
+
+    return unittest.end(env)
+
+# The solution path is selected from lib_source without a separately visible file label.
+def _sln_file_path_relative_to_root_test(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(
+        env,
+        "nested/project.custom",
+        export_for_test.sln_file_path(
+            sln_file_path = "nested/project.custom",
+            lib_source_files = [
+                struct(path = "external/repo/src/nested/project.custom"),
+                struct(path = "external/repo/src/nested/project.vcxproj"),
+            ],
+            root = "external/repo/src",
+        ),
+    )
+
+    return unittest.end(env)
+
+# The generated props file serializes precomputed dependency include directories.
+def _create_msbuild_script_include_dirs_test(ctx):
+    env = unittest.begin(ctx)
+
+    script = create_msbuild_script(
+        workspace_name = "ws",
+        root = "external/test_rule",
+        flags = _empty_flags(),
+        msbuild_path = "MSBuild.exe",
+        msbuild_sln_path = "project.sln",
+        msbuild_args = ["-p:Configuration=Release"],
+        dep_include_dirs = [
+            "$$EXT_BUILD_DEPS$$/include",
+            "$$EXT_BUILD_DEPS$$/foreign_dep/generated/include",
+        ],
+        dep_lib_dirs = [],
+    )
+
+    asserts.true(
+        env,
+        "<AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$$EXT_BUILD_DEPS$$/include;$$EXT_BUILD_DEPS$$/foreign_dep/generated/include</AdditionalIncludeDirectories>" in script[3],
+    )
+
+    return unittest.end(env)
+
+# The generated props file serializes precomputed dependency library directories.
+def _create_msbuild_script_lib_dirs_test(ctx):
+    env = unittest.begin(ctx)
+
+    script = create_msbuild_script(
+        workspace_name = "ws",
+        root = "external/test_rule",
+        flags = _empty_flags(),
+        msbuild_path = "MSBuild.exe",
+        msbuild_sln_path = "project.sln",
+        msbuild_args = ["-p:Configuration=Release"],
+        dep_include_dirs = [],
+        dep_lib_dirs = [
+            "$$EXT_BUILD_DEPS$$/lib",
+            "$$EXT_BUILD_DEPS$$/foreign_dep/generated/lib",
+        ],
+    )
+
+    asserts.true(
+        env,
+        "<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories);$$EXT_BUILD_DEPS$$/lib;$$EXT_BUILD_DEPS$$/foreign_dep/generated/lib</AdditionalLibraryDirectories>" in script[3],
+    )
+
+    return unittest.end(env)
+
+# The generated command quotes each argv word independently.
+def _create_msbuild_script_command_quoting_test(ctx):
+    env = unittest.begin(ctx)
+
+    script = create_msbuild_script(
+        workspace_name = "ws",
+        root = "external/test_rule",
+        flags = _empty_flags(),
+        msbuild_path = "C:/Program Files/MSBuild/Current/Bin/MSBuild.exe",
+        msbuild_sln_path = "solutions/my project.sln",
+        msbuild_args = [
+            "-p:ForceImportAfterCppTargets=$BUILD_TMPDIR/msbuild.props",
+            "-p:VCInstallDir=C:/Program Files/Microsoft Visual Studio/VC/",
+            "-p:Owner=O'Brien",
+            "-p:OutDir=$INSTALLDIR/",
+            "-p:Literal=$HOME",
+            "-p:LiteralInstall=$INSTALLDIR_BACKUP",
+            "-p:Brace=${CUSTOM_ENV}/value",
+            "-p:NotCommand=$(whoami)",
+            "-p:NotBacktick=`whoami`",
+            "-p:NotArithmetic=$[1+2]",
+            "-t:Build App",
+        ],
+        dep_include_dirs = [],
+        dep_lib_dirs = [],
+    )
+
+    asserts.equals(
+        env,
+        "\"C:/Program Files/MSBuild/Current/Bin/MSBuild.exe\" \"solutions/my project.sln\" \"-p:ForceImportAfterCppTargets=$BUILD_TMPDIR/msbuild.props\" \"-p:VCInstallDir=C:/Program Files/Microsoft Visual Studio/VC/\" \"-p:Owner=O'Brien\" \"-p:OutDir=$INSTALLDIR/\" \"-p:Literal=$HOME\" \"-p:LiteralInstall=$INSTALLDIR_BACKUP\" \"-p:Brace=${CUSTOM_ENV}/value\" \"-p:NotCommand=\\$(whoami)\" \"-p:NotBacktick=\\`whoami\\`\" \"-p:NotArithmetic=\\$[1+2]\" \"-t:Build App\"",
+        script[6],
+    )
+
+    return unittest.end(env)
+
+# The generated props file XML-escapes dependency paths and toolchain flags.
+def _create_msbuild_script_props_xml_escaping_test(ctx):
+    env = unittest.begin(ctx)
+
+    script = create_msbuild_script(
+        workspace_name = "ws",
+        root = "external/test_rule",
+        flags = _flags(
+            cxx = ["/DNAME=<value>", "/DAMP=a&b"],
+            cxx_linker_executable = ["/DEF:\"exports.def\""],
+            cxx_linker_static = ["/MACHINE:'x64'"],
+        ),
+        msbuild_path = "MSBuild.exe",
+        msbuild_sln_path = "project.sln",
+        msbuild_args = ["-p:Configuration=Release"],
+        dep_include_dirs = ["$$EXT_BUILD_DEPS$$/alpha & beta/include"],
+        dep_lib_dirs = ["$$EXT_BUILD_DEPS$$/alpha & beta/lib"],
+    )
+
+    asserts.true(
+        env,
+        "<AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$$EXT_BUILD_DEPS$$/alpha &amp; beta/include</AdditionalIncludeDirectories>" in script[3],
+    )
+    asserts.true(
+        env,
+        "<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories);$$EXT_BUILD_DEPS$$/alpha &amp; beta/lib</AdditionalLibraryDirectories>" in script[3],
+    )
+    asserts.true(
+        env,
+        "<AdditionalOptions>%(AdditionalOptions) /DNAME=&lt;value&gt; /DAMP=a&amp;b</AdditionalOptions>" in script[3],
+    )
+    asserts.true(
+        env,
+        "<AdditionalOptions>%(AdditionalOptions) /DEF:&quot;exports.def&quot;</AdditionalOptions>" in script[3],
+    )
+    asserts.true(
+        env,
+        "<AdditionalOptions>%(AdditionalOptions) /MACHINE:&apos;x64&apos;</AdditionalOptions>" in script[3],
+    )
+
+    return unittest.end(env)
+
+bazel_headers_and_include_dirs_test = unittest.make(_bazel_headers_and_include_dirs_test)
+bazel_libraries_test = unittest.make(_bazel_libraries_test)
+foreign_artifacts_deduped_in_order_test = unittest.make(_foreign_artifacts_deduped_in_order_test)
+msbuild_properties_test = unittest.make(_msbuild_properties_test)
+sln_file_path_relative_to_root_test = unittest.make(_sln_file_path_relative_to_root_test)
+create_msbuild_script_include_dirs_test = unittest.make(_create_msbuild_script_include_dirs_test)
+create_msbuild_script_lib_dirs_test = unittest.make(_create_msbuild_script_lib_dirs_test)
+create_msbuild_script_command_quoting_test = unittest.make(_create_msbuild_script_command_quoting_test)
+create_msbuild_script_props_xml_escaping_test = unittest.make(_create_msbuild_script_props_xml_escaping_test)
+
+def msbuild_script_test_suite():
+    unittest.suite(
+        "msbuild_script_test_suite",
+        partial.make(bazel_headers_and_include_dirs_test, size = "small"),
+        partial.make(bazel_libraries_test, size = "small"),
+        partial.make(foreign_artifacts_deduped_in_order_test, size = "small"),
+        partial.make(msbuild_properties_test, size = "small"),
+        partial.make(sln_file_path_relative_to_root_test, size = "small"),
+        partial.make(create_msbuild_script_include_dirs_test, size = "small"),
+        partial.make(create_msbuild_script_lib_dirs_test, size = "small"),
+        partial.make(create_msbuild_script_command_quoting_test, size = "small"),
+        partial.make(create_msbuild_script_props_xml_escaping_test, size = "small"),
+    )

--- a/toolchains/BUILD.bazel
+++ b/toolchains/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("//toolchains:toolchains.bzl", "current_autoconf_toolchain", "current_automake_toolchain", "current_cmake_toolchain", "current_m4_toolchain", "current_make_toolchain", "current_meson_toolchain", "current_ninja_toolchain", "current_pkgconfig_toolchain")
+load("//toolchains:toolchains.bzl", "current_autoconf_toolchain", "current_automake_toolchain", "current_cmake_toolchain", "current_m4_toolchain", "current_make_toolchain", "current_meson_toolchain", "current_msbuild_toolchain", "current_ninja_toolchain", "current_pkgconfig_toolchain")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -35,6 +35,13 @@ toolchain_type(
     name = "automake_toolchain",
 )
 
+toolchain_type(
+    name = "msbuild_toolchain",
+    target_compatible_with = [
+        "@platforms//os:windows",
+    ],
+)
+
 current_cmake_toolchain(
     name = "current_cmake_toolchain",
 )
@@ -65,6 +72,13 @@ current_automake_toolchain(
 
 current_autoconf_toolchain(
     name = "current_autoconf_toolchain",
+)
+
+current_msbuild_toolchain(
+    name = "current_msbuild_toolchain",
+    target_compatible_with = [
+        "@platforms//os:windows",
+    ],
 )
 
 toolchain(
@@ -158,6 +172,13 @@ toolchain(
     name = "preinstalled_pkgconfig_toolchain",
     toolchain = "//toolchains/private:preinstalled_pkgconfig",
     toolchain_type = ":pkgconfig_toolchain",
+)
+
+toolchain(
+    name = "preinstalled_msbuild_toolchain",
+    target_compatible_with = ["@platforms//os:windows"],
+    toolchain = "//toolchains/private:preinstalled_msbuild",
+    toolchain_type = ":msbuild_toolchain",
 )
 
 bzl_library(

--- a/toolchains/BUILD.bazel
+++ b/toolchains/BUILD.bazel
@@ -176,6 +176,7 @@ toolchain(
 
 toolchain(
     name = "preinstalled_msbuild_toolchain",
+    exec_compatible_with = ["@platforms//os:windows"],
     target_compatible_with = ["@platforms//os:windows"],
     toolchain = "//toolchains/private:preinstalled_msbuild",
     toolchain_type = ":msbuild_toolchain",

--- a/toolchains/native_tools/tool_access.bzl
+++ b/toolchains/native_tools/tool_access.bzl
@@ -41,6 +41,9 @@ def get_meson_data(ctx):
 def get_pkgconfig_data(ctx):
     return _access_and_expect_label_copied(Label("//toolchains:pkgconfig_toolchain"), ctx)
 
+def get_msbuild_data(ctx):
+    return _access_and_expect_label_copied(Label("//toolchains:msbuild_toolchain"), ctx)
+
 def _access_and_expect_label_copied(toolchain_type_, ctx):
     tool_data = access_tool(toolchain_type_, ctx)
     if tool_data.target:

--- a/toolchains/private/BUILD.bazel
+++ b/toolchains/private/BUILD.bazel
@@ -188,6 +188,17 @@ native_tool_toolchain(
     }),
 )
 
+native_tool_toolchain(
+    name = "preinstalled_msbuild",
+    env = {
+        "MSBUILD": "MSBuild.exe",
+    },
+    path = "MSBuild.exe",
+    target_compatible_with = [
+        "@platforms//os:windows",
+    ],
+)
+
 pkgconfig_tool(
     name = "pkgconfig_tool",
     srcs = "@pkgconfig_src//:all_srcs",

--- a/toolchains/toolchains.bzl
+++ b/toolchains/toolchains.bzl
@@ -21,6 +21,7 @@ def preinstalled_toolchains():
         "@rules_foreign_cc//toolchains:preinstalled_automake_toolchain",
         "@rules_foreign_cc//toolchains:preinstalled_m4_toolchain",
         "@rules_foreign_cc//toolchains:preinstalled_pkgconfig_toolchain",
+        "@rules_foreign_cc//toolchains:preinstalled_msbuild_toolchain",
     )
 
 def _current_toolchain_impl(ctx):
@@ -124,5 +125,15 @@ current_pkgconfig_toolchain = rule(
     },
     toolchains = [
         str(Label("//toolchains:pkgconfig_toolchain")),
+    ],
+)
+
+current_msbuild_toolchain = rule(
+    implementation = _current_toolchain_impl,
+    attrs = {
+        "_toolchain": attr.string(default = str(Label("//toolchains:msbuild_toolchain"))),
+    },
+    toolchains = [
+        str(Label("//toolchains:msbuild_toolchain")),
     ],
 )


### PR DESCRIPTION
This is an attempt to add a rule to build MSBuild project from bazel. This rule only supports `MSBuild.exe` from MSVC. `dotnet msbuild` is not supported.

[MSBuild, aka Microsoft Build Engine](https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild?view=vs-2022) is a platform for building applications. This engine provides an XML schema for a project file that controls how the build platform processes and builds software. 

There are no source code to build from for MSBuild. There are also no prebuilt binaries that is available. Therefore, this rule is only availabe for pre-installed toolchain. This usually involves installing MSBuild along side MSVC.

MSBuild generates compile and link flags from project configuration and solution files. I have not been able to find a definitve way to override that so we can applied only the bazel generated flags. As a compromised, the generated bazel flags from cc_toolchain are added to a `msbuild.props` files and passed to MSBuild via the `-p:ForceImportAfterCppTargets` property. This at the minimum confirms bazel flags are applied.