### PR TITLE
Use bzl mirror over pkgconfig.freedesktop.org

### DIFF
--- a/toolchains/built_toolchains.bzl
+++ b/toolchains/built_toolchains.bzl
@@ -358,8 +358,8 @@ cc_import(
                 Label("//toolchains/patches:pkgconfig-builtin-glib-int-conversion.patch"),
             ],
             urls = [
-                "https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz",
                 "https://mirror.bazel.build/pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz",
+                "https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz",
             ],
         )
         return


### PR DESCRIPTION
The pkgconfig.freedesktop.org mirror is listed above the bazel mirror of same for pkg-config, but pkgconfig.freedesktop.org is not very reliable. A few months ago it was down for a week and, lately, it is timing out frequently.

Even it does work it is 20-50 _times_ slower than the bazel mirror (measured locally, 25s vs < 1s for mirror).

Flip the order which is already the case for many other deps.