### PR TITLE
meson: add missing tool paths

### DIFF
--- a/foreign_cc/meson.bzl
+++ b/foreign_cc/meson.bzl
@@ -81,6 +81,10 @@ def _create_meson_script(configureParameters):
         script.append("##export_var## CC {}".format(_absolutize(ctx.workspace_name, tools.cc)))
     if " " not in tools.cxx:
         script.append("##export_var## CXX {}".format(_absolutize(ctx.workspace_name, tools.cxx)))
+    if " " not in tools.cxx_linker_static and tools.cxx_linker_static.endswith("ar"):
+        script.append("##export_var## AR {}".format(_absolutize(ctx.workspace_name, tools.cxx_linker_static)))
+    if tools.strip and " " not in tools.strip:
+        script.append("##export_var## STRIP {}".format(_absolutize(ctx.workspace_name, tools.strip)))
 
     copts = flags.cc
     cxxopts = flags.cxx

--- a/foreign_cc/private/cc_toolchain_util.bzl
+++ b/foreign_cc/private/cc_toolchain_util.bzl
@@ -23,6 +23,7 @@ CxxToolsInfo = provider(
         cxx_linker_static = "C++ linker to link static library",
         cxx_linker_executable = "C++ linker to link executable",
         ld = "linker",
+        strip = "strip",
     ),
 )
 
@@ -194,12 +195,25 @@ def get_tools_info(ctx):
 
     Args:
         ctx: rule context
+
+    Returns:
+        CxxToolsInfo
     """
     cc_toolchain = find_cpp_toolchain(ctx)
     feature_configuration = _configure_features(
         ctx = ctx,
         cc_toolchain = cc_toolchain,
     )
+
+    strip = ""
+    if cc_common.action_is_enabled(
+        feature_configuration = feature_configuration,
+        action_name = ACTION_NAMES.strip,
+    ):
+        strip = cc_common.get_tool_for_action(
+            feature_configuration = feature_configuration,
+            action_name = ACTION_NAMES.strip,
+        )
 
     return CxxToolsInfo(
         cc = cc_common.get_tool_for_action(
@@ -219,6 +233,7 @@ def get_tools_info(ctx):
             action_name = ACTION_NAMES.cpp_link_executable,
         ),
         ld = cc_toolchain.ld_executable,
+        strip = strip,
     )
 
 def get_flags_info(ctx, link_output_file = None):


### PR DESCRIPTION
Adds `ar` and `strip` tool paths to meson

Previously, these were taken from the host.

Added some logic for platforms where `strip` does not exist, and also had to add a check to prevent `ar=libtool` on Darwin.