### PR TITLE
pkgconfig: use the -std=gnu90 flag to compile

### DIFF
--- a/foreign_cc/built_tools/pkgconfig_build.bzl
+++ b/foreign_cc/built_tools/pkgconfig_build.bzl
@@ -34,7 +34,7 @@ def _pkgconfig_tool_impl(ctx):
     frozen_arflags = flags_info.cxx_linker_static
 
     cc_path = tools_info.cc
-    cflags = flags_info.cc + ["-Wno-int-conversion"]  # Fix building with clang 15+
+    cflags = flags_info.cc + ["-Wno-int-conversion", "-std=gnu90"]  # Fix building with clang 15+
     sysroot_cflags = extract_sysroot_flags(cflags)
     non_sysroot_cflags = extract_non_sysroot_flags(cflags)
 


### PR DESCRIPTION
... otherwise, the compilation of pkgconfig may fail with the following error when compiling glib:

```
  CC       libglib_2_0_la-goption.lo
goption.c:169:14: error: two or more data types in declaration specifiers
  169 |     gboolean bool;
      |              ^~~~
```