### PR TITLE
fix pkgconfig on windows

### DIFF
--- a/foreign_cc/built_tools/pkgconfig_build.bzl
+++ b/foreign_cc/built_tools/pkgconfig_build.bzl
@@ -160,10 +160,10 @@ def pkgconfig_tool(name, srcs, **kwargs):
         args = [
             "-f Makefile.vc",
             "CFG=release",
-            "GLIB_PREFIX=\"$$EXT_BUILD_ROOT/external/glib_dev\"",
+            "GLIB_PREFIX=\"$$EXT_BUILD_ROOT/external/%s\"" % Label("@glib_dev").workspace_name,
         ],
         out_binaries = ["pkg-config.exe"],
-        env = {"INCLUDE": "$$EXT_BUILD_ROOT/external/glib_src"},
+        env = {"INCLUDE": "$$EXT_BUILD_ROOT/external/%s" % Label("@glib_src").workspace_name},
         out_static_libs = [],
         out_shared_libs = [],
         deps = [
@@ -175,7 +175,7 @@ def pkgconfig_tool(name, srcs, **kwargs):
             "@platforms//os:windows": "cp release/x64/pkg-config.exe $$INSTALLDIR/bin",
             "//conditions:default": "",
         }),
-        toolchain = str(Label("//toolchains:preinstalled_nmake_toolchain")),
+        toolchain = Label("//toolchains:preinstalled_nmake_toolchain"),
         tags = tags,
         **kwargs
     )

--- a/foreign_cc/private/transitions.bzl
+++ b/foreign_cc/private/transitions.bzl
@@ -27,7 +27,7 @@ extra_toolchains_transitioned_foreign_cc_target = rule(
     cfg = _extra_toolchains_transition,
     attrs = {
         # This attr is singular to make it selectable when used for add make toolchain variant.
-        "extra_toolchain": attr.string(
+        "extra_toolchain": attr.label(
             doc = "Additional toolchain to consider. Note, this is singular.",
             mandatory = True,
         ),


### PR DESCRIPTION
I don't think we have a CI build that accurately represents the failure here, but this appears to work locally for me with both:
- `build --enable_bzlmod --noenable_workspace //toolchains/private:pkgconfig_tool` 
- `build --noenable_bzlmod --enable_workspace //toolchains/private:pkgconfig_tool`

Hopefully:
- Fixes #1437 
- Fixes #1455 
- Fixes #1359
- Replaces https://github.com/bazel-contrib/rules_foreign_cc/pull/1241