### PR TITLE
Align block-network behavior with rest of bazel

### DIFF
--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -525,8 +525,6 @@ def cc_external_rule_impl(ctx, attrs):
     cc_toolchain = find_cpp_toolchain(ctx)
 
     execution_requirements = {tag: "" for tag in ctx.attr.tags}
-    if "requires-network" not in execution_requirements:
-        execution_requirements["block-network"] = ""
 
     # TODO: `additional_tools` is deprecated, remove.
     legacy_tools = ctx.files.additional_tools + ctx.files.tools_deps


### PR DESCRIPTION
Bazel has a default wether to allow network access which can be switched via CLI. So if not listed in the tags we should not overrule it.

Use cases might be commercial compilers which need access to the license server but that should not be hardcoded into the call to call to the foreignCC rule because it is a toolchain dependency.