### PR TITLE
examples: switch zlib source to GitHub release URL

### DIFF
--- a/examples/third_party/zlib/zlib_repositories.bzl
+++ b/examples/third_party/zlib/zlib_repositories.bzl
@@ -16,7 +16,6 @@ def zlib_repositories():
             Label("//zlib:zlib.patch"),
         ],
         urls = [
-            "https://zlib.net/zlib-1.3.1.tar.gz",
-            "https://zlib.net/archive/zlib-1.3.1.tar.gz",
+            "https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz",
         ],
     )


### PR DESCRIPTION
The zlib.net upstream intentionally breaks zlib.net urls on every zlib release. Therefore, switch to the github url for the package instead, so our CI doesn't automatically break on every zlib release. (The hash for this url is indeed the same).