### PR TITLE
Fix variant toolchains

### DIFF
--- a/foreign_cc/private/transitions.bzl
+++ b/foreign_cc/private/transitions.bzl
@@ -4,7 +4,11 @@ load("@rules_cc//cc:defs.bzl", "CcInfo")
 load("//foreign_cc:providers.bzl", "ForeignCcDepsInfo")
 
 def _extra_toolchains_transition_impl(settings, attrs):
-    return {"//command_line_option:extra_toolchains": [attrs.extra_toolchain] + settings["//command_line_option:extra_toolchains"]}
+    t = getattr(attrs, "extra_toolchain", None)
+    if not t:
+        return {}
+
+    return {"//command_line_option:extra_toolchains": [t] + settings["//command_line_option:extra_toolchains"]}
 
 _extra_toolchains_transition = transition(
     implementation = _extra_toolchains_transition_impl,
@@ -29,7 +33,6 @@ extra_toolchains_transitioned_foreign_cc_target = rule(
         # This attr is singular to make it selectable when used for add make toolchain variant.
         "extra_toolchain": attr.label(
             doc = "Additional toolchain to consider. Note, this is singular.",
-            mandatory = True,
         ),
         "target": attr.label(
             doc = "The target to build after considering the extra toolchains",


### PR DESCRIPTION
In https://github.com/bazel-contrib/rules_foreign_cc/pull/1459, `extra_toolchain` was changed from a string to a Label. This was necessary (it's no longer safe to pass labels as strings in the post-bzlmod world) but it created a problem: the ability to do

```
cmake_variant(toolchain=select({"A": "footoolchain", "B": ""}))
```

kind of worked before, and no longer does (since "" is not a valid label). This change makes it so you can pass None instead of "" and it will do roughly what "" did.