### PR TITLE
Stop using APPLE_SDK_VERSION_OVERRIDE

### DIFF
--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -340,15 +340,12 @@ def get_env_prelude(ctx, installdir, data_dependencies, tools_env):
 
     # This logic mirrors XcodeLocalEnvProvider#querySdkRoot in bazel itself
     if "APPLE_SDK_PLATFORM" in cc_env:
-        platform = cc_env["APPLE_SDK_PLATFORM"]
-        version = cc_env["APPLE_SDK_VERSION_OVERRIDE"]
-        sdk = "{}{}".format(platform.lower(), version)
         env_snippet.extend([
             # TODO: This path needs to take cc_env["XCODE_VERSION_OVERRIDE"] into account
             # Declare and export separately so bash doesn't ignore failures from the commands https://github.com/koalaman/shellcheck/wiki/SC2155
             "developer_dir_tmp=\"$(xcode-select --print-path)\"",
             "export DEVELOPER_DIR=\"$developer_dir_tmp\"",
-            "sdkroot_tmp=\"$(xcrun --sdk {} --show-sdk-path)\"".format(sdk),
+            "sdkroot_tmp=\"$(xcrun --sdk {} --show-sdk-path)\"".format(cc_env["APPLE_SDK_PLATFORM"].lower()),
             "export SDKROOT=\"$sdkroot_tmp\"",
             "export CMAKE_OSX_ARCHITECTURES={}".format(ctx.fragments.apple.single_arch_cpu),
         ])


### PR DESCRIPTION
Bazel is still setting it, but it's been deprecated for quite some time. Other tools like Buildbarn also no longer use it to resolve copies of Xcode during the build.

https://github.com/bazelbuild/bazel/commit/0af1cbae7c4e1b3a3fb9e141b08469e095901d2f https://github.com/buildbarn/bb-remote-execution/commit/97cfb2212ae6d952145e6584264cd74db78b74f7

The existing logic is a bit problematic when trying to use these rules in combination with SDKs that don't follow the '${name}${version}' structure.