### PR TITLE
Add -isystem to make / pkgconfig flags

### DIFF
--- a/foreign_cc/built_tools/make_build.bzl
+++ b/foreign_cc/built_tools/make_build.bzl
@@ -8,8 +8,7 @@ load(
     "FOREIGN_CC_BUILT_TOOLS_HOST_FRAGMENTS",
     "absolutize",
     "built_tool_rule_impl",
-    "extract_non_sysroot_flags",
-    "extract_sysroot_flags",
+    "split_system_include_flags",
 )
 load(
     "//foreign_cc/private:cc_toolchain_util.bzl",
@@ -52,22 +51,20 @@ def _make_tool_impl(ctx):
 
         cc_path = tools_info.cc
         cflags = flags_info.cc
-        sysroot_cflags = extract_sysroot_flags(cflags)
-        non_sysroot_cflags = extract_non_sysroot_flags(cflags)
+        system_include_cflags, non_system_include_cflags = split_system_include_flags(cflags)
 
         ld_path = tools_info.cxx_linker_executable
         ldflags = flags_info.cxx_linker_executable
-        sysroot_ldflags = extract_sysroot_flags(ldflags)
-        non_sysroot_ldflags = extract_non_sysroot_flags(ldflags)
+        system_include_ldflags, non_system_include_ldflags = split_system_include_flags(ldflags)
 
         # Make's build script does not forward CFLAGS to all compiler and linker
-        # invocations, so we append --sysroot flags directly to CC and LD.
+        # invocations, so we append --sysroot and -isystem flags directly to CC and LD.
         absolute_cc = absolutize(ctx.workspace_name, cc_path, True)
-        if sysroot_cflags:
-            absolute_cc += " " + _join_flags_list(ctx.workspace_name, sysroot_cflags)
+        if system_include_cflags:
+            absolute_cc += " " + _join_flags_list(ctx.workspace_name, system_include_cflags)
         absolute_ld = absolutize(ctx.workspace_name, ld_path, True)
-        if sysroot_ldflags:
-            absolute_ld += " " + _join_flags_list(ctx.workspace_name, sysroot_ldflags)
+        if system_include_ldflags:
+            absolute_ld += " " + _join_flags_list(ctx.workspace_name, system_include_ldflags)
 
         # If libtool is used as AR, the output file has to be prefixed with
         # "-o". Since the make Makefile only uses ar-style invocations, the
@@ -79,7 +76,7 @@ def _make_tool_impl(ctx):
             arflags.append("-o")
 
         if os_name(ctx) == "macos":
-            non_sysroot_ldflags += ["-undefined", "error"]
+            non_system_include_ldflags += ["-undefined", "error"]
 
             # On macOS, remove "-lm".
             # During compilation, the ./configure script disables USE_SYSTEM_GLOB,
@@ -88,7 +85,7 @@ def _make_tool_impl(ctx):
             # However, at link time, "-lm" appears before "-lgnu".
             # This linker commandline is like this: LINKER ... -lm -L./lib -o xxx ... -lgnu
             # So the system glob is linked instead, causing ABI conflicts.
-            non_sysroot_ldflags = [x for x in non_sysroot_ldflags if x != "-lm"]
+            non_system_include_ldflags = [x for x in non_system_include_ldflags if x != "-lm"]
 
         configure_options = [
             "--without-guile",
@@ -113,9 +110,9 @@ def _make_tool_impl(ctx):
             "AR": absolute_ar,
             "ARFLAGS": _join_flags_list(ctx.workspace_name, arflags),
             "CC": absolute_cc,
-            "CFLAGS": _join_flags_list(ctx.workspace_name, non_sysroot_cflags),
+            "CFLAGS": _join_flags_list(ctx.workspace_name, non_system_include_cflags),
             "LD": absolute_ld,
-            "LDFLAGS": _join_flags_list(ctx.workspace_name, non_sysroot_ldflags),
+            "LDFLAGS": _join_flags_list(ctx.workspace_name, non_system_include_ldflags),
         })
 
         configure_env = " ".join(["%s=\"%s\"" % (key, value) for key, value in env.items()])

--- a/foreign_cc/built_tools/pkgconfig_build.bzl
+++ b/foreign_cc/built_tools/pkgconfig_build.bzl
@@ -8,8 +8,7 @@ load(
     "FOREIGN_CC_BUILT_TOOLS_HOST_FRAGMENTS",
     "absolutize",
     "built_tool_rule_impl",
-    "extract_non_sysroot_flags",
-    "extract_sysroot_flags",
+    "split_system_include_flags",
 )
 load(
     "//foreign_cc/private:cc_toolchain_util.bzl",
@@ -35,22 +34,20 @@ def _pkgconfig_tool_impl(ctx):
 
     cc_path = tools_info.cc
     cflags = flags_info.cc + ["-Wno-int-conversion", "-std=gnu90"]  # Fix building with clang 15+
-    sysroot_cflags = extract_sysroot_flags(cflags)
-    non_sysroot_cflags = extract_non_sysroot_flags(cflags)
+    system_include_cflags, non_system_include_cflags = split_system_include_flags(cflags)
 
     ld_path = tools_info.cxx_linker_executable
     ldflags = flags_info.cxx_linker_executable
-    sysroot_ldflags = extract_sysroot_flags(ldflags)
-    non_sysroot_ldflags = extract_non_sysroot_flags(ldflags)
+    system_include_ldflags, non_system_include_ldflags = split_system_include_flags(ldflags)
 
     # Make's build script does not forward CFLAGS to all compiler and linker
-    # invocations, so we append --sysroot flags directly to CC and LD.
+    # invocations, so we append --sysroot and -isystem flags directly to CC and LD.
     absolute_cc = absolutize(ctx.workspace_name, cc_path, True)
-    if sysroot_cflags:
-        absolute_cc += " " + _join_flags_list(ctx.workspace_name, sysroot_cflags)
+    if system_include_cflags:
+        absolute_cc += " " + _join_flags_list(ctx.workspace_name, system_include_cflags)
     absolute_ld = absolutize(ctx.workspace_name, ld_path, True)
-    if sysroot_ldflags:
-        absolute_ld += " " + _join_flags_list(ctx.workspace_name, sysroot_ldflags)
+    if system_include_ldflags:
+        absolute_ld += " " + _join_flags_list(ctx.workspace_name, system_include_ldflags)
 
     # If libtool is used as AR, the output file has to be prefixed with
     # "-o". Since the make Makefile only uses ar-style invocations, the
@@ -60,7 +57,7 @@ def _pkgconfig_tool_impl(ctx):
 
     if os_name(ctx) == "macos":
         absolute_ar = ""
-        non_sysroot_ldflags += ["-undefined", "error"]
+        non_system_include_ldflags += ["-undefined", "error"]
 
     arflags = [e for e in frozen_arflags]
     if absolute_ar == "libtool" or absolute_ar.endswith("/libtool"):
@@ -81,9 +78,9 @@ def _pkgconfig_tool_impl(ctx):
         "AR": absolute_ar,
         "ARFLAGS": _join_flags_list(ctx.workspace_name, arflags),
         "CC": absolute_cc,
-        "CFLAGS": _join_flags_list(ctx.workspace_name, non_sysroot_cflags),
+        "CFLAGS": _join_flags_list(ctx.workspace_name, non_system_include_cflags),
         "LD": absolute_ld,
-        "LDFLAGS": _join_flags_list(ctx.workspace_name, non_sysroot_ldflags),
+        "LDFLAGS": _join_flags_list(ctx.workspace_name, non_system_include_ldflags),
         "MAKE": make_data.path,
     })
 

--- a/foreign_cc/built_tools/private/built_tools_framework.bzl
+++ b/foreign_cc/built_tools/private/built_tools_framework.bzl
@@ -50,47 +50,32 @@ FOREIGN_CC_BUILT_TOOLS_HOST_FRAGMENTS = [
 def absolutize(workspace_name, text, force = False):
     return absolutize_path_in_str(workspace_name, "$$EXT_BUILD_ROOT$$/", text, force)
 
-def extract_sysroot_flags(flags):
-    """Function to return sysroot args from list of flags like cflags or ldflags
+def split_system_include_flags(flags):
+    """Splits flags into system include flags and remaining flags.
 
-    sysroot args are either '--sysroot=</path/to/sysroot>' or '--sysroot </path/to/sysroot>'
+    System include flags are --sysroot and -isystem args, in both
+    '--sysroot=<path>' / '--sysroot <path>' and '-isystem<path>' / '-isystem <path>' forms.
 
     Args:
         flags (list): list of flags
 
     Returns:
-        List of sysroot flags
+        Tuple of (system_include_flags, other_flags)
     """
-    ret_flags = []
+    system = []
+    other = []
     for i in range(len(flags)):
-        if flags[i] == "--sysroot":
+        if flags[i] in ("--sysroot", "-isystem"):
             if i + 1 < len(flags):
-                ret_flags.append(flags[i])
-                ret_flags.append(flags[i + 1])
-        elif flags[i].startswith("--sysroot="):
-            ret_flags.append(flags[i])
-    return ret_flags
-
-def extract_non_sysroot_flags(flags):
-    """Function to return non sysroot args from list of flags like cflags or ldflags
-
-    sysroot args are either '--sysroot=</path/to/sysroot>' or '--sysroot </path/to/sysroot>'
-
-    Args:
-        flags (list): list of flags
-
-    Returns:
-        List of non sysroot flags
-    """
-    ret_flags = []
-    for i in range(len(flags)):
-        if flags[i] == "--sysroot" or \
-           flags[i].startswith("--sysroot=") or \
-           (i != 0 and flags[i - 1] == "--sysroot"):
-            continue
+                system.append(flags[i])
+                system.append(flags[i + 1])
+        elif flags[i].startswith(("--sysroot=", "-isystem")):
+            system.append(flags[i])
+        elif i != 0 and flags[i - 1] in ("--sysroot", "-isystem"):
+            pass
         else:
-            ret_flags.append(flags[i])
-    return ret_flags
+            other.append(flags[i])
+    return system, other
 
 def built_tool_rule_impl(ctx, script_lines, out_dir, mnemonic, additional_tools = None):
     """Framework function for bootstrapping C/C++ build tools.


### PR DESCRIPTION
Previously this logic special cased `--sysroot` as an arugment that had
to be passed with the compiler because some configure scripts didn't add
CFLAGS to the configure steps. This same logic needs to apply to any
`-isystem` flags set by the toolchain for the same reason. Headers that
the toolchain requires with `-isystem` (without any deps) can contain
things needed for configure scripts to produce valid results. For
example they can contain glibc + sys/types.h etc, which is used by
make's build scripts to determine if it needs to typedef any standard
types.
