### PR TITLE
examples: use the gnu ftp mirror instead

### DIFF
--- a/examples/third_party/autotools/autotools_repositories.bzl
+++ b/examples/third_party/autotools/autotools_repositories.bzl
@@ -12,7 +12,7 @@ def autotools_repositories():
         strip_prefix = "m4-1.4.19",
         urls = [
             "https://mirror.bazel.build/ftp.gnu.org/gnu/m4/m4-1.4.19.tar.xz",
-            "https://ftp.gnu.org/gnu/m4/m4-1.4.19.tar.xz",
+            "https://ftpmirror.gnu.org/gnu/m4/m4-1.4.19.tar.xz",
         ],
         sha256 = "63aede5c6d33b6d9b13511cd0be2cac046f2e70fd0a07aa9573a04a82783af96",
     )
@@ -24,7 +24,7 @@ def autotools_repositories():
         strip_prefix = "autoconf-2.71",
         urls = [
             "https://mirror.bazel.build/ftp.gnu.org/gnu/autoconf/autoconf-2.71.tar.gz",
-            "https://ftp.gnu.org/gnu/autoconf/autoconf-2.71.tar.gz",
+            "https://ftpmirror.gnu.org/gnu/autoconf/autoconf-2.71.tar.gz",
         ],
         sha256 = "431075ad0bf529ef13cb41e9042c542381103e80015686222b8a9d4abef42a1c",
     )
@@ -36,7 +36,7 @@ def autotools_repositories():
         strip_prefix = "automake-1.16.4",
         urls = [
             "https://mirror.bazel.build/ftp.gnu.org/gnu/automake/automake-1.16.4.tar.gz",
-            "https://ftp.gnu.org/gnu/automake/automake-1.16.4.tar.gz",
+            "https://ftpmirror.gnu.org/gnu/automake/automake-1.16.4.tar.gz",
         ],
         sha256 = "8a0f0be7aaae2efa3a68482af28e5872d8830b9813a6a932a2571eac63ca1794",
     )

--- a/examples/third_party/bison/bison_repositories.bzl
+++ b/examples/third_party/bison/bison_repositories.bzl
@@ -12,7 +12,7 @@ def bison_repositories():
         strip_prefix = "bison-3.8.2",
         urls = [
             "https://mirror.bazel.build/ftp.gnu.org/gnu/bison/bison-3.8.2.tar.gz",
-            "https://ftp.gnu.org/gnu/bison/bison-3.8.2.tar.gz",
+            "https://ftpmirror.gnu.org/gnu/bison/bison-3.8.2.tar.gz",
         ],
         sha256 = "",
     )

--- a/examples/third_party/glib/glib_repositories.bzl
+++ b/examples/third_party/glib/glib_repositories.bzl
@@ -26,7 +26,7 @@ def glib_repositories():
         build_file = Label("//glib:BUILD.gettext.bazel"),
         strip_prefix = "gettext-0.21.1",
         sha256 = "e8c3650e1d8cee875c4f355642382c1df83058bd5a11ee8555c0cf276d646d45",
-        url = "https://ftp.gnu.org/gnu/gettext/gettext-0.21.1.tar.gz",
+        url = "https://ftpmirror.gnu.org/gnu/gettext/gettext-0.21.1.tar.gz",
     )
     maybe(
         http_archive,

--- a/examples/third_party/iconv/iconv_repositories.bzl
+++ b/examples/third_party/iconv/iconv_repositories.bzl
@@ -8,7 +8,7 @@ def iconv_repositories():
         http_archive,
         name = "iconv",
         urls = [
-            "https://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.16.tar.gz",
+            "https://ftpmirror.gnu.org/gnu/libiconv/libiconv-1.16.tar.gz",
         ],
         type = "tar.gz",
         sha256 = "e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04",


### PR DESCRIPTION
ftp.gnu.org is extremely unreliable