### PR TITLE
fix: work around problems with /Zi argument on windows.

### DIFF
--- a/foreign_cc/private/cmake_script.bzl
+++ b/foreign_cc/private/cmake_script.bzl
@@ -146,7 +146,7 @@ def create_cmake_script(
     if no_toolchain_file:
         params = _create_cache_entries_env_vars(toolchain_dict, user_cache, user_env)
     else:
-        params = _create_crosstool_file_text(toolchain_dict, user_cache, user_env)
+        params = _create_crosstool_file_text(toolchain_dict, user_cache, user_env, target_os)
 
     build_type = params.cache.get(
         "CMAKE_BUILD_TYPE",
@@ -158,6 +158,13 @@ def create_cmake_script(
         "CMAKE_PREFIX_PATH": merged_prefix_path,
         "PKG_CONFIG_ARGN": "--define-variable=EXT_BUILD_DEPS=$$EXT_BUILD_DEPS$$",
     })
+
+    # On Windows, default to embedded debug info (`/Z7`) so newer CMake versions
+    # do not force Program Database output (`/Zi`), which is more prone to flaky
+    # PDB failures. Older CMake versions may ignore this and rely on the fallback
+    # flag rewrite in the generated toolchain file instead.
+    if target_os == "windows" and params.cache.get("CMAKE_MSVC_DEBUG_INFORMATION_FORMAT") == None:
+        params.cache["CMAKE_MSVC_DEBUG_INFORMATION_FORMAT"] = "Embedded"
 
     # Give user the ability to suppress some value, taken from Bazel's toolchain,
     # or to suppress calculated CMAKE_BUILD_TYPE
@@ -251,7 +258,7 @@ _CMAKE_CACHE_ENTRIES_CROSSTOOL = {
     "CMAKE_SYSTEM_PROCESSOR": struct(value = "CMAKE_SYSTEM_PROCESSOR", replace = False),
 }
 
-def _create_crosstool_file_text(toolchain_dict, user_cache, user_env):
+def _create_crosstool_file_text(toolchain_dict, user_cache, user_env, target_os):
     cache_entries = _dict_copy(user_cache)
     env_vars = _dict_copy(user_env)
     _move_dict_values(toolchain_dict, env_vars, _CMAKE_ENV_VARS_FOR_CROSSTOOL)
@@ -280,8 +287,35 @@ def _create_crosstool_file_text(toolchain_dict, user_cache, user_env):
     cache_entries.update({
         "CMAKE_TOOLCHAIN_FILE": "$$BUILD_TMPDIR$$/crosstool_bazel.cmake",
     })
+
+    # When targeting Windows, CMake's default CMAKE_{C,CXX}_FLAGS_{DEBUG,RELWITHDEBINFO}
+    # include /Zi which uses a shared PDB file via mspdbsrv.exe. This causes
+    # "PDB API call failed" errors (C1090) when multiple targets build in parallel.
+    # Apply the fallback rewrite unconditionally for Windows because the toolchain
+    # file is evaluated before CMake has set MSVC=TRUE.
+    msvc_debug_fix_lines = []
+    if target_os == "windows":
+        msvc_debug_fix_lines = [
+            'set(_CMAKE_C_FLAGS_DEBUG "\\${CMAKE_C_FLAGS_DEBUG}")',
+            'string(REPLACE "/Zi" "/Z7" CMAKE_C_FLAGS_DEBUG_INIT "\\${CMAKE_C_FLAGS_DEBUG_INIT}")',
+            'string(REPLACE "/Zi" "/Z7" _CMAKE_C_FLAGS_DEBUG "\\${_CMAKE_C_FLAGS_DEBUG}")',
+            'set(CMAKE_C_FLAGS_DEBUG "\\${_CMAKE_C_FLAGS_DEBUG}" CACHE STRING "" FORCE)',
+            'set(_CMAKE_CXX_FLAGS_DEBUG "\\${CMAKE_CXX_FLAGS_DEBUG}")',
+            'string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_DEBUG_INIT "\\${CMAKE_CXX_FLAGS_DEBUG_INIT}")',
+            'string(REPLACE "/Zi" "/Z7" _CMAKE_CXX_FLAGS_DEBUG "\\${_CMAKE_CXX_FLAGS_DEBUG}")',
+            'set(CMAKE_CXX_FLAGS_DEBUG "\\${_CMAKE_CXX_FLAGS_DEBUG}" CACHE STRING "" FORCE)',
+            'set(_CMAKE_C_FLAGS_RELWITHDEBINFO "\\${CMAKE_C_FLAGS_RELWITHDEBINFO}")',
+            'string(REPLACE "/Zi" "/Z7" CMAKE_C_FLAGS_RELWITHDEBINFO_INIT "\\${CMAKE_C_FLAGS_RELWITHDEBINFO_INIT}")',
+            'string(REPLACE "/Zi" "/Z7" _CMAKE_C_FLAGS_RELWITHDEBINFO "\\${_CMAKE_C_FLAGS_RELWITHDEBINFO}")',
+            'set(CMAKE_C_FLAGS_RELWITHDEBINFO "\\${_CMAKE_C_FLAGS_RELWITHDEBINFO}" CACHE STRING "" FORCE)',
+            'set(_CMAKE_CXX_FLAGS_RELWITHDEBINFO "\\${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")',
+            'string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "\\${CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT}")',
+            'string(REPLACE "/Zi" "/Z7" _CMAKE_CXX_FLAGS_RELWITHDEBINFO "\\${_CMAKE_CXX_FLAGS_RELWITHDEBINFO}")',
+            'set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "\\${_CMAKE_CXX_FLAGS_RELWITHDEBINFO}" CACHE STRING "" FORCE)',
+        ]
+
     return struct(
-        commands = sorted(crosstool_vars) + ["cat > crosstool_bazel.cmake << EOF"] + sorted(lines) + ["EOF", ""],
+        commands = sorted(crosstool_vars) + ["cat > crosstool_bazel.cmake << EOF"] + sorted(lines) + msvc_debug_fix_lines + ["EOF", ""],
         env = env_vars,
         cache = cache_entries,
     )

--- a/test/cmake_text_tests.bzl
+++ b/test/cmake_text_tests.bzl
@@ -688,6 +688,133 @@ cmake -DCMAKE_AR="/cxx_linker_static" -DCMAKE_CXX_LINK_EXECUTABLE="became" -DCMA
 
     return unittest.end(env)
 
+def _create_cmake_script_windows_no_toolchain_file_test(ctx):
+    env = unittest.begin(ctx)
+
+    tools = CxxToolsInfo(
+        cc = "C:/toolchain/cl.exe",
+        cxx = "C:/toolchain/cl.exe",
+        cxx_linker_static = "C:/toolchain/lib.exe",
+        cxx_linker_executable = "C:/toolchain/cl.exe",
+    )
+    flags = CxxFlagsInfo(
+        cc = ["/Z7"],
+        cxx = ["/Z7"],
+        cxx_linker_shared = [],
+        cxx_linker_static = [],
+        cxx_linker_executable = [],
+        assemble = [],
+    )
+
+    script = create_cmake_script(
+        "ws",
+        ctx.label,
+        "windows",
+        "x86_64",
+        "windows",
+        "x86_64",
+        "Ninja",
+        "cmake",
+        tools,
+        flags,
+        "test_rule",
+        "external/test_rule",
+        True,
+        {},
+        {},
+        [],
+        cmake_commands = [],
+    )
+    expected = r"""export CC="C:/toolchain/cl.exe"
+export CXX="C:/toolchain/cl.exe"
+export CFLAGS="/Z7"
+export CXXFLAGS="/Z7"
+##define_absolute_paths## $$EXT_BUILD_DEPS$$ $$EXT_BUILD_DEPS$$
+##define_sandbox_paths## $$EXT_BUILD_DEPS$$ $$EXT_BUILD_ROOT$$
+##enable_tracing##
+cmake -DCMAKE_AR="C:/toolchain/lib.exe" -DCMAKE_BUILD_TYPE="Debug" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$$EXT_BUILD_DEPS$$" -DPKG_CONFIG_ARGN="--define-variable=EXT_BUILD_DEPS=$$EXT_BUILD_DEPS$$" -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT="Embedded" -DCMAKE_RANLIB=""  -G 'Ninja' $$EXT_BUILD_ROOT$$/external/test_rule
+##disable_tracing##
+"""
+    asserts.equals(env, expected.splitlines(), script)
+
+    return unittest.end(env)
+
+def _create_cmake_script_windows_toolchain_file_test(ctx):
+    env = unittest.begin(ctx)
+
+    tools = CxxToolsInfo(
+        cc = "C:/toolchain/cl.exe",
+        cxx = "C:/toolchain/cl.exe",
+        cxx_linker_static = "C:/toolchain/lib.exe",
+        cxx_linker_executable = "C:/toolchain/cl.exe",
+    )
+    flags = CxxFlagsInfo(
+        cc = ["/Z7"],
+        cxx = ["/Z7"],
+        cxx_linker_shared = [],
+        cxx_linker_static = [],
+        cxx_linker_executable = [],
+        assemble = [],
+    )
+
+    script = create_cmake_script(
+        "ws",
+        ctx.label,
+        "windows",
+        "x86_64",
+        "windows",
+        "x86_64",
+        "Ninja",
+        "cmake",
+        tools,
+        flags,
+        "test_rule",
+        "external/test_rule",
+        False,
+        {},
+        {},
+        [],
+        cmake_commands = [],
+    )
+    expected = r"""__var_CMAKE_AR="C:/toolchain/lib.exe"
+__var_CMAKE_CXX_COMPILER="C:/toolchain/cl.exe"
+__var_CMAKE_CXX_FLAGS_INIT="/Z7"
+__var_CMAKE_C_COMPILER="C:/toolchain/cl.exe"
+__var_CMAKE_C_FLAGS_INIT="/Z7"
+cat > crosstool_bazel.cmake << EOF
+set(CMAKE_AR "$$__var_CMAKE_AR$$" CACHE FILEPATH "Archiver")
+set(CMAKE_CXX_COMPILER "$$__var_CMAKE_CXX_COMPILER$$")
+set(CMAKE_CXX_FLAGS_INIT "$$__var_CMAKE_CXX_FLAGS_INIT$$")
+set(CMAKE_C_COMPILER "$$__var_CMAKE_C_COMPILER$$")
+set(CMAKE_C_FLAGS_INIT "$$__var_CMAKE_C_FLAGS_INIT$$")
+set(_CMAKE_C_FLAGS_DEBUG "\${CMAKE_C_FLAGS_DEBUG}")
+string(REPLACE "/Zi" "/Z7" CMAKE_C_FLAGS_DEBUG_INIT "\${CMAKE_C_FLAGS_DEBUG_INIT}")
+string(REPLACE "/Zi" "/Z7" _CMAKE_C_FLAGS_DEBUG "\${_CMAKE_C_FLAGS_DEBUG}")
+set(CMAKE_C_FLAGS_DEBUG "\${_CMAKE_C_FLAGS_DEBUG}" CACHE STRING "" FORCE)
+set(_CMAKE_CXX_FLAGS_DEBUG "\${CMAKE_CXX_FLAGS_DEBUG}")
+string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_DEBUG_INIT "\${CMAKE_CXX_FLAGS_DEBUG_INIT}")
+string(REPLACE "/Zi" "/Z7" _CMAKE_CXX_FLAGS_DEBUG "\${_CMAKE_CXX_FLAGS_DEBUG}")
+set(CMAKE_CXX_FLAGS_DEBUG "\${_CMAKE_CXX_FLAGS_DEBUG}" CACHE STRING "" FORCE)
+set(_CMAKE_C_FLAGS_RELWITHDEBINFO "\${CMAKE_C_FLAGS_RELWITHDEBINFO}")
+string(REPLACE "/Zi" "/Z7" CMAKE_C_FLAGS_RELWITHDEBINFO_INIT "\${CMAKE_C_FLAGS_RELWITHDEBINFO_INIT}")
+string(REPLACE "/Zi" "/Z7" _CMAKE_C_FLAGS_RELWITHDEBINFO "\${_CMAKE_C_FLAGS_RELWITHDEBINFO}")
+set(CMAKE_C_FLAGS_RELWITHDEBINFO "\${_CMAKE_C_FLAGS_RELWITHDEBINFO}" CACHE STRING "" FORCE)
+set(_CMAKE_CXX_FLAGS_RELWITHDEBINFO "\${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "\${CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT}")
+string(REPLACE "/Zi" "/Z7" _CMAKE_CXX_FLAGS_RELWITHDEBINFO "\${_CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "\${_CMAKE_CXX_FLAGS_RELWITHDEBINFO}" CACHE STRING "" FORCE)
+EOF
+
+##define_absolute_paths## $$EXT_BUILD_DEPS$$ $$EXT_BUILD_DEPS$$
+##define_sandbox_paths## $$EXT_BUILD_DEPS$$ $$EXT_BUILD_ROOT$$
+##enable_tracing##
+cmake -DCMAKE_TOOLCHAIN_FILE="$$BUILD_TMPDIR$$/crosstool_bazel.cmake" -DCMAKE_BUILD_TYPE="Debug" -DCMAKE_INSTALL_PREFIX="test_rule" -DCMAKE_PREFIX_PATH="$$EXT_BUILD_DEPS$$" -DPKG_CONFIG_ARGN="--define-variable=EXT_BUILD_DEPS=$$EXT_BUILD_DEPS$$" -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT="Embedded" -DCMAKE_RANLIB=""  -G 'Ninja' $$EXT_BUILD_ROOT$$/external/test_rule
+##disable_tracing##
+"""
+    asserts.equals(env, expected.splitlines(), script)
+
+    return unittest.end(env)
+
 def _create_cmake_script_toolchain_file_test(ctx):
     env = unittest.begin(ctx)
 
@@ -795,6 +922,8 @@ create_cmake_script_no_toolchain_file_test = unittest.make(_create_cmake_script_
 create_cmake_script_toolchain_file_test = unittest.make(_create_cmake_script_toolchain_file_test)
 create_cmake_script_android_test = unittest.make(_create_cmake_script_android_test)
 create_cmake_script_linux_test = unittest.make(_create_cmake_script_linux_test)
+create_cmake_script_windows_no_toolchain_file_test = unittest.make(_create_cmake_script_windows_no_toolchain_file_test)
+create_cmake_script_windows_toolchain_file_test = unittest.make(_create_cmake_script_windows_toolchain_file_test)
 merge_flag_values_no_toolchain_file_test = unittest.make(_merge_flag_values_no_toolchain_file_test)
 create_min_cmake_script_wipe_toolchain_test = unittest.make(_create_min_cmake_script_wipe_toolchain_test)
 
@@ -814,6 +943,8 @@ def cmake_script_test_suite():
         create_cmake_script_toolchain_file_test,
         create_cmake_script_android_test,
         create_cmake_script_linux_test,
+        create_cmake_script_windows_no_toolchain_file_test,
+        create_cmake_script_windows_toolchain_file_test,
         merge_flag_values_no_toolchain_file_test,
         create_min_cmake_script_wipe_toolchain_test,
     )


### PR DESCRIPTION
/Zi is not multiprocess-safe; it depends on spinning up an mspdbsrv.exe and interacting with it in unsafe ways. When multiple CMake targets build in parallel on Windows, this causes "PDB API call failed" (C1090) errors. 

CMake's default debug flags can include /Zi. Bazel's MSVC toolchain already passes /Z7 (embed debug info in .obj), but CMake's /Zi overrides it. CMake added a better way to interact with this configuration in 3.25 with [CMP0141](https://cmake.org/cmake/help/latest/policy/CMP0141.html).

So, my change does two things:
1. Sets the default `CMAKE_MSVC_DEBUG_INFORMATION_FORMAT` to `Embedded`, which is the equivalent of /Z7.
2. Replaces /Zi (if found) in cmake's flags for `Debug` and `RelWithDebInfo`. (/Zi should only be present here if a project overrides the DEBUG_INFORMATION_FORMAT or if they're on an older cmake).