### PR TITLE
examples: enable cares on windows

### DIFF
--- a/examples/third_party/cares/BUILD.bazel
+++ b/examples/third_party/cares/BUILD.bazel
@@ -6,6 +6,10 @@ cc_test(
     name = "test",
     size = "small",
     srcs = ["c-ares-test.cpp"],
+    local_defines = select({
+        "@platforms//os:windows": ["CARES_STATICLIB"],
+        "//conditions:default": [],
+    }),
     visibility = ["//:__pkg__"],
     deps = ["@cares"],
 )
@@ -13,6 +17,10 @@ cc_test(
 cc_library(
     name = "lib",
     srcs = ["c-ares-test.cpp"],
+    local_defines = select({
+        "@platforms//os:windows": ["CARES_STATICLIB"],
+        "//conditions:default": [],
+    }),
     deps = ["@cares"],
 )
 

--- a/examples/third_party/cares/BUILD.cares.bazel
+++ b/examples/third_party/cares/BUILD.cares.bazel
@@ -23,8 +23,4 @@ cmake(
         "@platforms//os:windows": ["cares.lib"],
         "//conditions:default": ["libcares.a"],
     }),
-    target_compatible_with = select({
-        "@platforms//os:windows": ["@rules_foreign_cc_examples_third_party//:broken"],
-        "//conditions:default": [],
-    }),
 )


### PR DESCRIPTION
c-ares builds fine on Windows with the existing cmake rule, it just needed CARES_STATICLIB defined when consuming the static library so the headers use the right calling convention.