### PR TITLE
examples: enable gn and libjpeg_turbo on windows

### DIFF
--- a/examples/third_party/gn/BUILD.gn.bazel
+++ b/examples/third_party/gn/BUILD.gn.bazel
@@ -27,18 +27,19 @@ ninja(
     }),
     # gn has no install step, manually grab the artifacts
     postfix_script = select({
-        "@platforms//os:windows": " && ".join([
-            "cp -a out/gn_lib.lib $$INSTALLDIR/lib",
-            "cp -a out/gn.exe $$INSTALLDIR/bin",
+        "@platforms//os:windows": "\n".join([
+            "mkdir -p \"$$INSTALLDIR/lib\" \"$$INSTALLDIR/bin\"",
+            "cp -p ./out/gn_lib.lib \"$$INSTALLDIR/lib/gn_lib.lib\"",
+            "cp -p ./out/gn.exe \"$$INSTALLDIR/bin/gn.exe\"",
         ]),
         "//conditions:default": " && ".join([
             "cp -a out/gn_lib.a $$INSTALLDIR/lib",
             "cp -a out/gn $$INSTALLDIR/bin",
         ]),
     }),
-    target_compatible_with = select({
-        "@platforms//os:windows": ["@rules_foreign_cc_examples_third_party//:broken"],
-        "//conditions:default": [],
+    targets = select({
+        "@platforms//os:windows": ["gn.exe"],
+        "//conditions:default": [""],
     }),
 )
 

--- a/examples/third_party/gn/gn_test.sh
+++ b/examples/third_party/gn/gn_test.sh
@@ -5,4 +5,4 @@ if [[ ! -e "$GN" ]]; then
     exit 1
 fi
 
-exec $GN --help
+exec "$GN" --help

--- a/examples/third_party/libjpeg_turbo/BUILD.libjpeg_turbo.bazel
+++ b/examples/third_party/libjpeg_turbo/BUILD.libjpeg_turbo.bazel
@@ -22,13 +22,9 @@ cmake(
             "libturbojpeg.dylib",
         ],
         "@platforms//os:windows": [
-            "libjpeg.dll",
-            "libturbojpeg.dll",
+            "jpeg62.dll",
+            "turbojpeg.dll",
         ],
-    }),
-    target_compatible_with = select({
-        "@platforms//os:windows": ["@rules_foreign_cc_examples_third_party//:broken"],
-        "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
gn:
- gn's own build system emits gn_lib.a on all platforms, so make
  out_static_libs unconditional instead of expecting gn_lib.lib
- the postfix_script needs to mkdir the install dirs and copy both
  the lib and the binary
- set targets to gn.exe so ninja builds the right default on Windows
- quote $GN in the test script

libjpeg_turbo:
- the actual DLL names on Windows are jpeg62.dll and turbojpeg.dll,
  not libjpeg.dll and libturbojpeg.dll