### PR TITLE
examples: enable libssh2 on windows

### DIFF
--- a/examples/third_party/libssh2/BUILD.libssh2.bazel
+++ b/examples/third_party/libssh2/BUILD.libssh2.bazel
@@ -27,13 +27,8 @@ cmake(
     }),
     lib_source = ":all_srcs",
     out_static_libs = select({
-        # TODO: I'm guessing at this name. Needs to be checked on windows.
-        "@platforms//os:windows": ["ssh2.lib"],
+        "@platforms//os:windows": ["libssh2.lib"],
         "//conditions:default": ["libssh2.a"],
-    }),
-    target_compatible_with = select({
-        "@platforms//os:windows": ["@rules_foreign_cc_examples_third_party//:broken"],
-        "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],
     deps = ["@openssl"],


### PR DESCRIPTION
The static library name on Windows is libssh2.lib, not ssh2.lib.