### PR TITLE
examples: enable libpng on windows

### DIFF
--- a/examples/third_party/libpng/BUILD.bazel
+++ b/examples/third_party/libpng/BUILD.bazel
@@ -4,10 +4,6 @@ load("@rules_shell//shell:sh_test.bzl", "sh_test")
 cc_binary(
     name = "libpng_usage_example",
     srcs = ["libpng_usage_example.cpp"],
-    target_compatible_with = select({
-        "@platforms//os:windows": ["@rules_foreign_cc_examples_third_party//:broken"],
-        "//conditions:default": [],
-    }),
     deps = [
         "@examples_zlib//:zlib",
         "@libpng",
@@ -19,13 +15,14 @@ sh_test(
     size = "small",
     srcs = ["test_libpng.sh"],
     args = [
-        "$(location :libpng_usage_example)",
-        "$(location bazel_icon_transparent.png)",
+        "$(rlocationpath :libpng_usage_example)",
+        "$(rlocationpath bazel_icon_transparent.png)",
         "out.png",
     ],
     data = [
         "bazel_icon_transparent.png",
         ":libpng_usage_example",
+        "@bazel_tools//tools/bash/runfiles",
     ],
     visibility = ["//:__pkg__"],
 )

--- a/examples/third_party/libpng/BUILD.libpng.bazel
+++ b/examples/third_party/libpng/BUILD.libpng.bazel
@@ -19,6 +19,9 @@ cmake(
     },
     lib_source = "//:all_srcs",
     out_include_dir = "include/libpng16",
-    out_static_libs = ["libpng16.a"],
+    out_static_libs = select({
+        "@platforms//os:windows": ["libpng16_static.lib"],
+        "//conditions:default": ["libpng16.a"],
+    }),
     deps = ["@examples_zlib//:zlib"],
 )

--- a/examples/third_party/libpng/test_libpng.sh
+++ b/examples/third_party/libpng/test_libpng.sh
@@ -2,4 +2,20 @@
 
 set -e
 
-$1 $2 $3
+# --- begin runfiles.bash initialization ---
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || {
+    echo>&2 "ERROR: cannot find $f"
+    exit 1
+  }
+# --- end runfiles.bash initialization ---
+
+output_dir="${TEST_TMPDIR:-$PWD}"
+output_path="${output_dir}/$3"
+
+"$(rlocation "$1")" "$(rlocation "$2")" "$output_path"
+test -f "$output_path"


### PR DESCRIPTION
- the static library name on Windows is libpng16_static.lib
- the test script was using bare positional args which break on
  Windows; switch to rlocationpath and the runfiles.bash helper so
  the test can locate its inputs through the runfiles manifest