### PR TITLE
examples: enable libgit2 on windows

### DIFF
--- a/examples/third_party/libgit2/BUILD.libgit2.bazel
+++ b/examples/third_party/libgit2/BUILD.libgit2.bazel
@@ -30,13 +30,8 @@ cmake(
     }),
     lib_source = ":all_srcs",
     out_static_libs = select({
-        # TODO: I'm guessing at this name. Needs to be checked on windows.
         "@platforms//os:windows": ["git2.lib"],
         "//conditions:default": ["libgit2.a"],
-    }),
-    target_compatible_with = select({
-        "@platforms//os:windows": ["@rules_foreign_cc_examples_third_party//:broken"],
-        "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],
     deps = [


### PR DESCRIPTION
All of libgit2's deps (zlib, libssh2, openssl) already build on
Windows. The pcre dep is Linux-only. Remove the broken marker and
the guessed-name TODO — git2.lib is the correct MSVC output name.