### PR TITLE
framework: shorten build paths on Windows to avoid MAX_PATH failures

### DIFF
--- a/.bazelrc.common
+++ b/.bazelrc.common
@@ -14,6 +14,7 @@ build:windows --enable_runfiles
 startup --windows_enable_symlinks
 build:windows --action_env=MSYS=winsymlinks:nativestrict
 test:windows --action_env=MSYS=winsymlinks:nativestrict
+build:windows --@rules_foreign_cc//foreign_cc/settings:allow_building_in_tmp=True
 
 # Enable CC toolchain that supports iOS from https://github.com/bazelbuild/apple_support
 build:macos --apple_crosstool_top=@local_config_apple_cc//:toolchain

--- a/examples/cc_wrapper.sh
+++ b/examples/cc_wrapper.sh
@@ -40,6 +40,7 @@ compile() {
 
     local cxx
     cxx="$(ensure_absolute "$CXX")"
+    mkdir -p "$(dirname "$2")"
 
     case "$cxx" in
         */cl.exe)
@@ -58,6 +59,7 @@ static_link() {
 
     local ar
     ar="$(ensure_absolute "$AR")"
+    mkdir -p "$(dirname "$2")"
 
     case "$ar" in
         */lib.exe)

--- a/foreign_cc/built_tools/private/built_tools_framework.bzl
+++ b/foreign_cc/built_tools/private/built_tools_framework.bzl
@@ -1,5 +1,6 @@
 """A module defining a common framework for "built_tools" rules"""
 
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("//foreign_cc/private:cc_toolchain_util.bzl", "absolutize_path_in_str")
 load("//foreign_cc/private:detect_root.bzl", "detect_root")
@@ -23,6 +24,10 @@ FOREIGN_CC_BUILT_TOOLS_ATTRS = {
     "srcs": attr.label(
         doc = "The target containing the build tool's sources",
         mandatory = True,
+    ),
+    "_allow_building_in_tmp": attr.label(
+        default = Label("@rules_foreign_cc//foreign_cc/settings:allow_building_in_tmp"),
+        providers = [BuildSettingInfo],
     ),
     "_cc_toolchain": attr.label(
         default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),

--- a/foreign_cc/ninja.bzl
+++ b/foreign_cc/ninja.bzl
@@ -71,7 +71,9 @@ def _create_ninja_script(configureParameters):
     ])
 
     # Set the directory location for the build commands
-    directory = "$$EXT_BUILD_ROOT$$/{}".format(root)
+    # Ninja builds are staged into BUILD_TMPDIR, so the default -C target
+    # needs to point there rather than the original source tree.
+    directory = "$$BUILD_TMPDIR$$"
     if ctx.attr.directory:
         directory = ctx.expand_location(ctx.attr.directory, data)
 

--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -5,6 +5,7 @@
 load("@bazel_features//:features.bzl", "bazel_features")
 load("@bazel_skylib//lib:collections.bzl", "collections")
 load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("@rules_cc//cc:defs.bzl", "CcInfo", "cc_common")
 load("//foreign_cc:providers.bzl", "ForeignCcArtifactInfo", "ForeignCcDepsInfo")
@@ -247,6 +248,10 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
         cfg = "exec",
         default = [],
     ),
+    "_allow_building_in_tmp": attr.label(
+        default = Label("@rules_foreign_cc//foreign_cc/settings:allow_building_in_tmp"),
+        providers = [BuildSettingInfo],
+    ),
     # we need to declare this attribute to access cc_toolchain
     "_cc_toolchain": attr.label(
         default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
@@ -392,6 +397,45 @@ def get_env_prelude(ctx, installdir, data_dependencies, tools_env):
 
     return env_snippet
 
+def _use_short_paths(ctx):
+    """Returns True if the build should use shortened paths on Windows."""
+    if not targets_windows(ctx, None):
+        return False
+    return ctx.attr._allow_building_in_tmp[BuildSettingInfo].value
+
+def _short_path_wrapper_setup(ctx):
+    """Set up short-path temp directory in the wrapper script.
+
+    Creates the temp directory and exports two variables:
+      RFCC_SHORT_PATH_ROOT      - UNIX path for shell operations (rm, mkdir, etc.)
+      RFCC_SHORT_PATH_ROOT_WIN  - mixed Windows path for tools (CMake, MSVC, etc.)
+
+    This runs in the wrapper so the cleanup trap can access RFCC_SHORT_PATH_ROOT.
+    """
+    if not _use_short_paths(ctx):
+        return []
+
+    return [
+        "export RFCC_SHORT_PATH_ROOT=\"$(mktemp -d \"${TMP:-/tmp}/rfcc.XXXXXX\")\"",
+        "export RFCC_SHORT_PATH_ROOT_WIN=\"$(to_mixed_path \"$RFCC_SHORT_PATH_ROOT\")\"",
+    ]
+
+def _short_path_env_aliases(ctx):
+    """Redirect BUILD_TMPDIR/EXT_BUILD_DEPS to short paths under RFCC_SHORT_PATH_ROOT_WIN.
+
+    Uses the mixed Windows path form so that downstream tools (CMake, pkg-config,
+    etc.) receive paths they understand. Must run after env_prelude in any script
+    that sets BUILD_TMPDIR/EXT_BUILD_DEPS, since env_prelude sets them to the
+    original long paths.
+    """
+    if not _use_short_paths(ctx):
+        return []
+
+    return [
+        "export BUILD_TMPDIR=\"$RFCC_SHORT_PATH_ROOT_WIN/b\"",
+        "export EXT_BUILD_DEPS=\"$RFCC_SHORT_PATH_ROOT_WIN/d\"",
+    ]
+
 def cc_external_rule_impl(ctx, attrs):
     """Framework function for performing external C/C++ building.
 
@@ -495,6 +539,7 @@ def cc_external_rule_impl(ctx, attrs):
         "##script_prelude##",
     ] + env_prelude + [
         "##path## $$EXT_BUILD_ROOT$$",
+    ] + _short_path_env_aliases(ctx) + [
         "##rm_rf## $$BUILD_TMPDIR$$",
         "##rm_rf## $$EXT_BUILD_DEPS$$",
         "##mkdirs## $$INSTALLDIR$$",
@@ -666,6 +711,12 @@ def wrap_outputs(ctx, lib_name, configure_name, script_text, env_prelude, build_
         "\n".join([
             "##rm_rf## $$BUILD_TMPDIR$$",
             "##rm_rf## $$EXT_BUILD_DEPS$$",
+            # On Windows with short paths, BUILD_TMPDIR and EXT_BUILD_DEPS are
+            # inside RFCC_SHORT_PATH_ROOT (already removed above). Clean up the
+            # parent temp dir too. On non-Windows this var is unset.
+            "if [ -n \"${RFCC_SHORT_PATH_ROOT:-}\" ]; then",
+            "##rm_rf## ${RFCC_SHORT_PATH_ROOT}",
+            "fi",
         ]),
     )
     cleanup_on_failure_function = create_function(
@@ -697,7 +748,7 @@ def wrap_outputs(ctx, lib_name, configure_name, script_text, env_prelude, build_
         # the call trap is defined inside, in a way how the shell function should be called
         # see, for instance, linux_commands.bzl
         trap_function,
-    ] + env_prelude + [
+    ] + env_prelude + _short_path_wrapper_setup(ctx) + _short_path_env_aliases(ctx) + [
         "export BUILD_WRAPPER_SCRIPT=\"{}\"".format(wrapper_script_file.path),
         "export BUILD_SCRIPT=\"{}\"".format(build_script_file.path),
         "export BUILD_LOG=\"{}\"".format(build_log_file.path),

--- a/foreign_cc/private/framework/toolchains/windows_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/windows_commands.bzl
@@ -217,8 +217,7 @@ fi
     return FunctionAndCallInfo(text = text)
 
 def script_prelude():
-    return """\
-set -euo pipefail
+    return """set -euo pipefail
 if [ -f /usr/bin/find ]; then
   REAL_FIND="/usr/bin/find"
 else
@@ -226,6 +225,9 @@ else
 fi
 find() {
   "$REAL_FIND" "$@"
+}
+to_mixed_path() {
+  cygpath -am "$1"
 }
 export MSYS_NO_PATHCONV=1
 export MSYS2_ARG_CONV_EXCL="*"

--- a/foreign_cc/settings/BUILD.bazel
+++ b/foreign_cc/settings/BUILD.bazel
@@ -1,3 +1,10 @@
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("//foreign_cc/private:resource_sets.bzl", _create_settings = "create_settings")
 
 _create_settings()
+
+bool_flag(
+    name = "allow_building_in_tmp",
+    build_setting_default = True,
+    visibility = ["//visibility:public"],
+)

--- a/foreign_cc/settings/BUILD.bazel
+++ b/foreign_cc/settings/BUILD.bazel
@@ -5,6 +5,6 @@ _create_settings()
 
 bool_flag(
     name = "allow_building_in_tmp",
-    build_setting_default = True,
+    build_setting_default = False,
     visibility = ["//visibility:public"],
 )

--- a/test/env_test/BUILD.bazel
+++ b/test/env_test/BUILD.bazel
@@ -12,8 +12,8 @@ _NOT_WINDOWS = select({
 })
 
 STANDARD_VARS = {
-    "BUILD_TMPDIR": "{{INSTALLDIR}}.build_tmpdir",
-    "EXT_BUILD_DEPS": "{{INSTALLDIR}}.ext_build_deps",
+    "BUILD_TMPDIR": "{{BUILD_TMPDIR}}",
+    "EXT_BUILD_DEPS": "{{EXT_BUILD_DEPS}}",
     "EXT_BUILD_ROOT": "{{EXT_BUILD_ROOT}}",
     "INSTALLDIR": "{{INSTALLDIR}}",
 }

--- a/test/env_test/CMakeLists.txt.tmpl
+++ b/test/env_test/CMakeLists.txt.tmpl
@@ -14,6 +14,8 @@ function(post _filename)
     # EXT_BUILD_ROOT and we want the replacement to be the most specific
     string(REPLACE "${CMAKE_BINARY_DIR}" "{{CMAKE_BINARY_DIR}}" RAW "${RAW}")
     string(REPLACE "${CMAKE_SOURCE_DIR}" "{{CMAKE_SOURCE_DIR}}" RAW "${RAW}")
+    string(REPLACE "$ENV{BUILD_TMPDIR}" "{{BUILD_TMPDIR}}" RAW "${RAW}")
+    string(REPLACE "$ENV{EXT_BUILD_DEPS}" "{{EXT_BUILD_DEPS}}" RAW "${RAW}")
     string(REPLACE "$ENV{INSTALLDIR}" "{{INSTALLDIR}}" RAW "${RAW}")
     string(REPLACE "$ENV{EXT_BUILD_ROOT}" "{{EXT_BUILD_ROOT}}" RAW "${RAW}")
 

--- a/test/env_test/Makefile.am.tmpl
+++ b/test/env_test/Makefile.am.tmpl
@@ -8,6 +8,8 @@ all:
 		$(SED) -i.bak \
 			-e 's|$(abs_srcdir)|{{abs_srcdir}}|g' \
 			-e 's|$(abs_builddir)|{{abs_builddir}}|g' \
+			-e 's|$(BUILD_TMPDIR)|{{BUILD_TMPDIR}}|g' \
+			-e 's|$(EXT_BUILD_DEPS)|{{EXT_BUILD_DEPS}}|g' \
 			-e 's|$(INSTALLDIR)|{{INSTALLDIR}}|g' \
 			-e 's|$(EXT_BUILD_ROOT)|{{EXT_BUILD_ROOT}}|g' \
 			"$${filename}"; \

--- a/test/env_test/Makefile.in.tmpl
+++ b/test/env_test/Makefile.in.tmpl
@@ -563,6 +563,8 @@ all:
 		$(SED) -i.bak \
 			-e 's|$(abs_srcdir)|{{abs_srcdir}}|g' \
 			-e 's|$(abs_builddir)|{{abs_builddir}}|g' \
+			-e 's|$(BUILD_TMPDIR)|{{BUILD_TMPDIR}}|g' \
+			-e 's|$(EXT_BUILD_DEPS)|{{EXT_BUILD_DEPS}}|g' \
 			-e 's|$(INSTALLDIR)|{{INSTALLDIR}}|g' \
 			-e 's|$(EXT_BUILD_ROOT)|{{EXT_BUILD_ROOT}}|g' \
 			"$${filename}"; \

--- a/test/env_test/Makefile.tmpl
+++ b/test/env_test/Makefile.tmpl
@@ -6,6 +6,8 @@ all:
 		# Note that this is order-sensitive, since INSTALLDIR is a subdir of \
 		# EXT_BUILD_ROOT and we want the replacement to be most specific first. \
 		sed -i.bak \
+			-e 's|$(BUILD_TMPDIR)|{{BUILD_TMPDIR}}|g' \
+			-e 's|$(EXT_BUILD_DEPS)|{{EXT_BUILD_DEPS}}|g' \
 			-e 's|$(INSTALLDIR)|{{INSTALLDIR}}|g' \
 			-e 's|$(EXT_BUILD_ROOT)|{{EXT_BUILD_ROOT}}|g' \
 			"$${filename}"; \

--- a/test/env_test/build.ninja.tmpl
+++ b/test/env_test/build.ninja.tmpl
@@ -1,5 +1,5 @@
 rule collect_env
-  command = sh -c 'rm -f "$$SHELLVARS_FILE" "$out" && touch "$$SHELLVARS_FILE" && {{VARIABLES}} && sed -i.bak -e "s|$$INSTALLDIR|{{INSTALLDIR}}|g" -e "s|$$EXT_BUILD_ROOT|{{EXT_BUILD_ROOT}}|g" "$$SHELLVARS_FILE" && touch "$out"'
+  command = sh -c 'rm -f "$$SHELLVARS_FILE" "$out" && touch "$$SHELLVARS_FILE" && {{VARIABLES}} && sed -i.bak -e "s|$$BUILD_TMPDIR|{{BUILD_TMPDIR}}|g" -e "s|$$EXT_BUILD_DEPS|{{EXT_BUILD_DEPS}}|g" -e "s|$$INSTALLDIR|{{INSTALLDIR}}|g" -e "s|$$EXT_BUILD_ROOT|{{EXT_BUILD_ROOT}}|g" "$$SHELLVARS_FILE" && touch "$out"'
 
 build out: collect_env
 

--- a/test/env_test/meson.build.tmpl
+++ b/test/env_test/meson.build.tmpl
@@ -4,4 +4,4 @@ run_command('sh', '-c', 'rm -f "$SHELLVARS_FILE" && touch "$SHELLVARS_FILE"', ch
 
 {{VARIABLES}}
 
-run_command('sh', '-c', 'sed -i.bak -e "s|$INSTALLDIR|{{INSTALLDIR}}|g" -e "s|$EXT_BUILD_ROOT|{{EXT_BUILD_ROOT}}|g" "$SHELLVARS_FILE"', check: true)
+run_command('sh', '-c', 'sed -i.bak -e "s|$BUILD_TMPDIR|{{BUILD_TMPDIR}}|g" -e "s|$EXT_BUILD_DEPS|{{EXT_BUILD_DEPS}}|g" -e "s|$INSTALLDIR|{{INSTALLDIR}}|g" -e "s|$EXT_BUILD_ROOT|{{EXT_BUILD_ROOT}}|g" "$SHELLVARS_FILE"', check: true)


### PR DESCRIPTION
### Summary
On Windows, Bazel sandbox paths can easily exceed the 260-character MAX_PATH limit, causing builds to fail with opaque permission or file-not-found errors. This PR redirects BUILD_TMPDIR and EXT_BUILD_DEPS into $TMP when building on Windows, controlled by a new bool_flag (which defaults to False). For normal values of $TMP, this should result in a consistently-shorter build path, even if you're using configuration like `--output_user_root=F:/`; using $TMP also removes the execroot and your internal project paths from the path.

### Implementation Notes
- This code is disabled by default and gated behind the setting `@rules_foreign_cc//foreign_cc/settings:allow_building_in_tmp`; set it to true to use it.
- If enabled, and you're on windows:
    - BUILD_TMPDIR and EXT_BUILD_DEPS will be set to temp directory paths (`$TMP/rfcc.XXXXXX/{b,d}`) when building on Windows.
    - INSTALLDIR and the bazel source dirs are still potentially long; this can help during build, but it can't fix everything. Maybe someday Microsoft will bother to fix Visual Studio to support long paths.
    - The temp directory is cleaned up on success; but left on failure for debugging.  **Note** using this means you need to be prepared for manual $TMP cleanup.
    - **Note** if you use a configuration like `--output_user_root=F:/ --action_env=TMP=C:/Temp` then the build will span disks. This can cause odd behavior, and you might want to avoid that.