### PR TITLE
examples: enable winflexbison on windows

### DIFF
--- a/examples/third_party/mesa/BUILD.mesa.bazel
+++ b/examples/third_party/mesa/BUILD.mesa.bazel
@@ -1,4 +1,5 @@
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "meson_with_requirements")
+load("@rules_foreign_cc_examples_third_party//:bzlmod_enabled.bzl", "BZLMOD_ENABLED")
 load("@third_party_pip//:requirements.bzl", "requirement")
 
 filegroup(
@@ -102,6 +103,13 @@ meson_with_requirements(
     requirements = [
         requirement("mako"),
     ],
+    # Meson's Python runtime lands in a deeply-nested runfiles tree under the
+    # exec root. On bzlmod the module-path segments make this exceed MAX_PATH,
+    # so Python can't load its own DLLs. Needs tool-staging work to resolve.
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@rules_foreign_cc_examples_third_party//:broken"] if BZLMOD_ENABLED else [],
+        "//conditions:default": [],
+    }),
     toolchains = ["@rules_python//python:current_py_toolchain"],
     visibility = ["//visibility:public"],
     deps = ["@examples_zlib//:zlib"] + select({

--- a/examples/third_party/mesa/BUILD.winflexbison.bazel
+++ b/examples/third_party/mesa/BUILD.winflexbison.bazel
@@ -1,5 +1,4 @@
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
-load("@rules_foreign_cc_examples_third_party//:bzlmod_enabled.bzl", "BZLMOD_ENABLED")
 
 filegroup(
     name = "all_srcs",
@@ -24,9 +23,7 @@ cmake(
         "win_bison.exe",
     ],
     target_compatible_with = select({
-        # In bazel 7 (at least) the bzlmod paths are too long to build this.
-        # TODO: reevaluate with bazel 8
-        "@platforms//os:windows": ["@rules_foreign_cc_examples_third_party//:broken"] if BZLMOD_ENABLED else [],
+        "@platforms//os:windows": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     visibility = ["//visibility:public"],


### PR DESCRIPTION
With short build paths (#1527), winflexbison's cmake build no longer exceeds MAX_PATH. 
Remove its broken marker and the BZLMOD_ENABLED guard.

Mesa itself still hits MAX_PATH on bzlmod Windows — meson's Python
runtime lives in a deeply-nested runfiles tree under the exec root, and
the bzlmod module-path segments push it past 260 characters. Mark mesa
broken on bzlmod Windows until the tool-staging work (copying runtime
closures into EXT_BUILD_DEPS) lands. The workspaces configs are short
enough to build successfully.