### PR TITLE
framework: suppress autotools reruns when timestamps are skewed

### DIFF
--- a/examples/third_party/autotools/BUILD.autoconf.bazel
+++ b/examples/third_party/autotools/BUILD.autoconf.bazel
@@ -12,6 +12,9 @@ filegroup(
 
 configure_make(
     name = "autoconf",
+    # Suppress help2man regeneration; it's not available in the sandbox and
+    # the tarball ships pre-built man pages.
+    args = ["HELP2MAN=true"],
     build_data = [
         "@m4//:m4_exe",
     ],

--- a/examples/third_party/autotools/BUILD.m4.bazel
+++ b/examples/third_party/autotools/BUILD.m4.bazel
@@ -12,6 +12,13 @@ filegroup(
 
 configure_make(
     name = "m4",
+    # gnulib's iconv_open-*.h regeneration rules are unconditional (not
+    # guarded by maintainer-mode) and invoke gperf, which isn't available
+    # in the sandbox.  configure_in_place gives us a writable source tree,
+    # and GPERF=true makes the regeneration a no-op (the generated headers
+    # are only #include'd on AIX/HP-UX/IRIX/OSF/Solaris/z/OS).
+    args = ["GPERF=true"],
+    configure_in_place = True,
     env = select({
         "@platforms//os:macos": {"AR": ""},
         "//conditions:default": {},
@@ -20,6 +27,7 @@ configure_make(
     out_binaries = [
         "m4",
     ],
+    out_include_dir = "",
     target_compatible_with = select({
         "@platforms//os:windows": ["@platforms//:incompatible"],
         "//conditions:default": [],

--- a/examples/third_party/bison/BUILD.bison.bazel
+++ b/examples/third_party/bison/BUILD.bison.bazel
@@ -13,6 +13,8 @@ filegroup(
 # I tested and this builds for me on macOS and Linux, did not check Windows
 configure_make(
     name = "bison",
+    # gnulib's iconv_open-*.h regeneration rules invoke gperf unconditionally
+    args = ["GPERF=true"],
     build_data = [
         "@m4//:m4_exe",
     ],

--- a/examples/third_party/bison/BUILD.bison.bazel
+++ b/examples/third_party/bison/BUILD.bison.bazel
@@ -13,11 +13,18 @@ filegroup(
 # I tested and this builds for me on macOS and Linux, did not check Windows
 configure_make(
     name = "bison",
-    # gnulib's iconv_open-*.h regeneration rules invoke gperf unconditionally
-    args = ["GPERF=true"],
+    # gnulib's iconv_open-*.h regeneration rules invoke gperf unconditionally,
+    # and timestamp skew can trigger help2man and yacc/bison regeneration.
+    # configure_in_place gives us a writable copy with flattened (equal)
+    # timestamps, which prevents make from seeing stale outputs.
+    args = [
+        "GPERF=true",
+        "HELP2MAN=true",
+    ],
     build_data = [
         "@m4//:m4_exe",
     ],
+    configure_in_place = True,
     env = {
         "M4": "$$EXT_BUILD_ROOT/$(location @m4//:m4_exe)",
         "PERL": "$$EXT_BUILD_ROOT/$(PERL)",

--- a/foreign_cc/private/configure_script.bzl
+++ b/foreign_cc/private/configure_script.bzl
@@ -42,6 +42,18 @@ def create_configure_script(
         configure_path = "{}/{}".format(root_path, configure_command)
 
     script.append("##export_var## MAKE {}".format(make_path))
+
+    # When the user has not requested autotools regeneration, prevent make from
+    # re-running aclocal/autoconf/autoheader/automake if timestamps are skewed
+    # (common under RBE, where the CAS strips per-file mtimes).  Setting each
+    # tool to "true" makes any accidental rerun a silent no-op — the standard
+    # technique used by Debian, Yocto, and rpmbuild.
+    if not autoconf and not autoreconf and not autogen:
+        script.append("##export_var## AUTOCONF true")
+        script.append("##export_var## AUTOHEADER true")
+        script.append("##export_var## AUTOMAKE true")
+        script.append("##export_var## ACLOCAL true")
+
     script.append("##enable_tracing##")
 
     if autogen:

--- a/foreign_cc/private/configure_script.bzl
+++ b/foreign_cc/private/configure_script.bzl
@@ -44,15 +44,17 @@ def create_configure_script(
     script.append("##export_var## MAKE {}".format(make_path))
 
     # When the user has not requested autotools regeneration, prevent make from
-    # re-running aclocal/autoconf/autoheader/automake if timestamps are skewed
-    # (common under RBE, where the CAS strips per-file mtimes).  Setting each
-    # tool to "true" makes any accidental rerun a silent no-op — the standard
-    # technique used by Debian, Yocto, and rpmbuild.
+    # re-running aclocal/autoconf/autoheader/automake/makeinfo if timestamps
+    # are skewed (common under RBE, where the CAS strips per-file mtimes).
+    # Setting each tool to "true" makes any accidental rerun a silent no-op —
+    # the standard technique used by Debian, Yocto, and rpmbuild.
     if not autoconf and not autoreconf and not autogen:
         script.append("##export_var## AUTOCONF true")
         script.append("##export_var## AUTOHEADER true")
         script.append("##export_var## AUTOMAKE true")
         script.append("##export_var## ACLOCAL true")
+        script.append("##export_var## MAKEINFO true")
+        script.append("##export_var## HELP2MAN true")
 
     script.append("##enable_tracing##")
 


### PR DESCRIPTION
RBE's Content-Addressable Storage strips per-file mtimes, so autotools
source tarballs that ship with carefully ordered timestamps
(`configure.ac` < `aclocal.m4` < `configure` < `Makefile.in`) can end
up with equal or reversed timestamps. When make notices this, it tries
to re-run aclocal/autoconf/automake to regenerate the build system —
which fails because the real autotools aren't part of our controlled
environment and the correct version might not be in the PATH.

This is especially insidious because it's flaky: local builds preserve
timestamps via symlinks and pass fine, then the RBE build fails, then
the RBE retry passes because the local build cached the result; the
timestamps are not part of the cache-key interface.

Setting `AUTOCONF=true`, `AUTOHEADER=true`, `AUTOMAKE=true`, and
`ACLOCAL=true` makes any accidental rerun a silent no-op. This is the
standard technique used by Debian, Yocto, and rpmbuild for building from
release tarballs. The env vars are only injected when the user has not
explicitly requested autotools regeneration via `autoconf`, `autoreconf`,
or `autogen`.