### PR TITLE
feat(make): add module linker flag variables

### DIFF
--- a/examples/integration_tests/standard_cxx_flags_test/tests.bzl
+++ b/examples/integration_tests/standard_cxx_flags_test/tests.bzl
@@ -1,6 +1,9 @@
 # buildifier: disable=module-docstring
 # buildifier: disable=bzl-visibility
 load("@rules_foreign_cc//foreign_cc/private:cc_toolchain_util.bzl", "get_flags_info")
+
+# buildifier: disable=bzl-visibility
+load("@rules_foreign_cc//foreign_cc/private/framework:platform.bzl", "PLATFORM_CONSTRAINTS_RULE_ATTRIBUTES")
 load("@with_cfg.bzl", "with_cfg")
 
 def _impl(ctx):
@@ -56,15 +59,19 @@ def assert_contains_once(arr, value):
     if cnt > 1:
         fail("Value is included multiple times: " + value)
 
+_FLAGS_TEST_ATTRS = {
+    "copts": attr.string_list(),
+    "deps": attr.label_list(),
+    "linkopts": attr.string_list(),
+    "out": attr.output(),
+    "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
+}
+
+_FLAGS_TEST_ATTRS.update(PLATFORM_CONSTRAINTS_RULE_ATTRIBUTES)
+
 _flags_test_test = rule(
     implementation = _impl,
-    attrs = {
-        "copts": attr.string_list(),
-        "deps": attr.label_list(),
-        "linkopts": attr.string_list(),
-        "out": attr.output(),
-        "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
-    },
+    attrs = _FLAGS_TEST_ATTRS,
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
     fragments = ["cpp", "j2objc"],
     test = True,

--- a/foreign_cc/configure.bzl
+++ b/foreign_cc/configure.bzl
@@ -165,6 +165,7 @@ def _create_configure_script(configureParameters):
         make_args = args,
         executable_ldflags_vars = ctx.attr.executable_ldflags_vars,
         shared_ldflags_vars = ctx.attr.shared_ldflags_vars,
+        dynamic_module_ldflags_vars = ctx.attr.dynamic_module_ldflags_vars,
         is_msvc = is_msvc,
     )
     return define_install_prefix + configure
@@ -249,6 +250,15 @@ def _attrs():
                 "If this is set and an xcompile scenario is detected, pass the necessary autotools flags."
             ),
             default = False,
+        ),
+        "dynamic_module_ldflags_vars": attr.string_list(
+            doc = (
+                "Make variables receiving linker flags for loadable dynamic modules. " +
+                "This is primarily useful on Darwin, where module builds cannot use " +
+                "conflicting `-dynamiclib`/`-shared` and `-bundle` linker flags together."
+            ),
+            mandatory = False,
+            default = [],
         ),
         "executable_ldflags_vars": attr.string_list(
             doc = (

--- a/foreign_cc/make.bzl
+++ b/foreign_cc/make.bzl
@@ -86,6 +86,7 @@ def _create_make_script(configureParameters):
         make_install_prefix = ctx.attr.install_prefix,
         executable_ldflags_vars = ctx.attr.executable_ldflags_vars,
         shared_ldflags_vars = ctx.attr.shared_ldflags_vars,
+        dynamic_module_ldflags_vars = ctx.attr.dynamic_module_ldflags_vars,
         is_msvc = is_msvc,
     )
 
@@ -94,6 +95,15 @@ def _attrs():
     attrs.update({
         "args": attr.string_list(
             doc = "A list of arguments to pass to the call to `make`",
+        ),
+        "dynamic_module_ldflags_vars": attr.string_list(
+            doc = (
+                "Make variables receiving linker flags for loadable dynamic modules. " +
+                "This is primarily useful on Darwin, where module builds cannot use " +
+                "conflicting `-dynamiclib`/`-shared` and `-bundle` linker flags together."
+            ),
+            mandatory = False,
+            default = [],
         ),
         "executable_ldflags_vars": attr.string_list(
             doc = (

--- a/foreign_cc/private/cc_toolchain_util.bzl
+++ b/foreign_cc/private/cc_toolchain_util.bzl
@@ -5,6 +5,7 @@ load("@bazel_skylib//lib:collections.bzl", "collections")
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("@rules_cc//cc:defs.bzl", "CcInfo", "cc_common")
+load("//foreign_cc/private/framework:platform.bzl", "target_os_name")
 
 LibrariesToLinkInfo = provider(
     doc = "Libraries to be wrapped into CcLinkingInfo",
@@ -33,6 +34,7 @@ CxxFlagsInfo = provider(
         cc = "C compiler flags",
         cxx = "C++ compiler flags",
         cxx_linker_shared = "C++ linker flags when linking shared library",
+        cxx_linker_dynamic_module = "C++ linker flags when linking dynamic modules",
         cxx_linker_static = "C++ linker flags when linking static library",
         cxx_linker_executable = "C++ linker flags when linking executable",
         assemble = "Assemble flags",
@@ -119,6 +121,11 @@ def _files_map(files_list, suffix = ""):
 
 def _defines_from_deps(ctx):
     return depset(transitive = [dep[CcInfo].compilation_context.defines for dep in getattr(ctx.attr, "deps", [])])
+
+def _dynamic_module_link_flags(shared_flags, is_darwin):
+    if is_darwin:
+        return [flag for flag in shared_flags if flag not in ["-shared", "-dynamiclib"]]
+    return shared_flags
 
 def targets_windows(ctx, cc_toolchain):
     """Returns true if build is targeting Windows
@@ -285,6 +292,7 @@ def get_flags_info(ctx, link_output_file = None):
                 must_keep_debug = False,
             ),
         ),
+        cxx_linker_dynamic_module = [],
         cxx_linker_static = cc_common.get_memory_inefficient_command_line(
             feature_configuration = feature_configuration,
             action_name = ACTION_NAMES.cpp_link_static_library,
@@ -323,10 +331,12 @@ def get_flags_info(ctx, link_output_file = None):
         copts.append("-ffile-prefix-map=$EXT_BUILD_ROOT=.")
         cxxopts.append("-ffile-prefix-map=$EXT_BUILD_ROOT=.")
 
+    shared_link_flags = _convert_flags(cc_toolchain_.compiler, _add_if_needed(flags.cxx_linker_shared, linkopts))
     return CxxFlagsInfo(
         cc = _convert_flags(cc_toolchain_.compiler, _add_if_needed(flags.cc, copts)),
         cxx = _convert_flags(cc_toolchain_.compiler, _add_if_needed(flags.cxx, cxxopts)),
-        cxx_linker_shared = _convert_flags(cc_toolchain_.compiler, _add_if_needed(flags.cxx_linker_shared, linkopts)),
+        cxx_linker_shared = shared_link_flags,
+        cxx_linker_dynamic_module = _dynamic_module_link_flags(shared_link_flags, target_os_name(ctx) == "macos"),
         cxx_linker_static = _convert_flags(cc_toolchain_.compiler, flags.cxx_linker_static),
         cxx_linker_executable = _convert_flags(cc_toolchain_.compiler, _add_if_needed(flags.cxx_linker_executable, linkopts)),
         assemble = _convert_flags(cc_toolchain_.compiler, _add_if_needed(flags.assemble, copts)),
@@ -404,3 +414,7 @@ def _prefix(text, from_str, prefix):
 def _file_name_no_ext(basename):
     (before, _separator, _after) = basename.rpartition(".")
     return before
+
+export_for_test = struct(
+    dynamic_module_link_flags = _dynamic_module_link_flags,
+)

--- a/foreign_cc/private/cmake_script.bzl
+++ b/foreign_cc/private/cmake_script.bzl
@@ -119,7 +119,7 @@ def create_cmake_script(
 
     merged_prefix_path = _merge_prefix_path(user_cache, include_dirs, ext_build_dirs)
 
-    toolchain_dict = _fill_crossfile_from_toolchain(workspace_name, tools, flags, target_os)
+    toolchain_dict = _fill_crossfile_from_toolchain(workspace_name, tools, flags)
     params = None
 
     # Avoid CMake passing the wrong linker flags when cross compiling
@@ -389,7 +389,7 @@ def _move_dict_values(target, source, descriptor_map):
             else:
                 target[existing.value] = target[existing.value] + " " + value
 
-def _fill_crossfile_from_toolchain(workspace_name, tools, flags, target_os):
+def _fill_crossfile_from_toolchain(workspace_name, tools, flags):
     dict = {}
 
     _sysroot = _find_in_cc_or_cxx(flags, "sysroot")
@@ -444,16 +444,8 @@ def _fill_crossfile_from_toolchain(workspace_name, tools, flags, target_os):
     if flags.cxx_linker_shared:
         dict["CMAKE_SHARED_LINKER_FLAGS_INIT"] = _join_flags_list(workspace_name, flags.cxx_linker_shared)
 
-        # cxx_linker_shared will contain '-shared' or '-dynamiclib' on macos. This flag conflicts with "-bundle"
-        # that is set by CMAKE based on platform. e.g.
-        # https://gitlab.kitware.com/cmake/cmake/-/blob/master/Modules/Platform/Apple-Intel.cmake#L11
-        # Therefore, for modules aka bundles we want to remove these flags.
-        module_linker_flags = []
-        if target_os == "macos":
-            module_linker_flags = [flag for flag in flags.cxx_linker_shared if flag not in ["-shared", "-dynamiclib"]]
-        else:
-            module_linker_flags = flags.cxx_linker_shared
-        dict["CMAKE_MODULE_LINKER_FLAGS_INIT"] = _join_flags_list(workspace_name, module_linker_flags)
+    if flags.cxx_linker_dynamic_module:
+        dict["CMAKE_MODULE_LINKER_FLAGS_INIT"] = _join_flags_list(workspace_name, flags.cxx_linker_dynamic_module)
     if flags.cxx_linker_executable:
         dict["CMAKE_EXE_LINKER_FLAGS_INIT"] = _join_flags_list(workspace_name, flags.cxx_linker_executable)
 

--- a/foreign_cc/private/configure_script.bzl
+++ b/foreign_cc/private/configure_script.bzl
@@ -31,6 +31,7 @@ def create_configure_script(
         make_args,
         executable_ldflags_vars,
         shared_ldflags_vars,
+        dynamic_module_ldflags_vars,
         is_msvc):
     ext_build_dirs = inputs.ext_build_dirs
 
@@ -102,7 +103,7 @@ def create_configure_script(
         user_options = " ".join(user_options),
     ))
 
-    ldflags_make_vars = get_ldflags_make_vars(executable_ldflags_vars, shared_ldflags_vars, workspace_name, flags, env_vars, deps, inputs, is_msvc)
+    ldflags_make_vars = get_ldflags_make_vars(executable_ldflags_vars, shared_ldflags_vars, dynamic_module_ldflags_vars, workspace_name, flags, env_vars, deps, inputs, is_msvc)
 
     make_commands = []
     for target in make_targets:

--- a/foreign_cc/private/make_env_vars.bzl
+++ b/foreign_cc/private/make_env_vars.bzl
@@ -45,13 +45,14 @@ def get_make_env_vars(
 def get_ldflags_make_vars(
         executable_ldflags_vars,
         shared_ldflags_vars,
+        dynamic_module_ldflags_vars,
         workspace_name,
         flags,
         user_vars,
         deps,
         inputs,
         is_msvc):
-    vars = _get_ldflags_vars(executable_ldflags_vars, shared_ldflags_vars, flags, user_vars)
+    vars = _get_ldflags_vars(executable_ldflags_vars, shared_ldflags_vars, dynamic_module_ldflags_vars, flags, user_vars)
 
     deps_flags = _define_deps_flags(deps, inputs, is_msvc)
     for key in vars.keys():
@@ -168,13 +169,15 @@ def _get_make_variables(workspace_name, tools, flags, user_env_vars, make_comman
 def _get_ldflags_vars(
         executable_ldflags_vars,
         shared_ldflags_vars,
+        dynamic_module_ldflags_vars,
         flags,
         user_env_vars):
     executable_ldflags = {var: "cxx_linker_executable" for var in executable_ldflags_vars}
     shared_ldflags = {var: "cxx_linker_shared" for var in shared_ldflags_vars}
+    dynamic_module_ldflags = {var: "cxx_linker_dynamic_module" for var in dynamic_module_ldflags_vars}
 
     linker_make_flags = {}
-    for ldflags in [executable_ldflags, shared_ldflags]:
+    for ldflags in [executable_ldflags, shared_ldflags, dynamic_module_ldflags]:
         linker_make_flags.update(ldflags)
 
     return _merge_env_vars(flags, linker_make_flags, user_env_vars)

--- a/foreign_cc/private/make_script.bzl
+++ b/foreign_cc/private/make_script.bzl
@@ -18,6 +18,7 @@ def create_make_script(
         make_install_prefix,
         executable_ldflags_vars,
         shared_ldflags_vars,
+        dynamic_module_ldflags_vars,
         is_msvc):
     ext_build_dirs = inputs.ext_build_dirs
 
@@ -27,7 +28,7 @@ def create_make_script(
 
     script.append("##enable_tracing##")
 
-    ldflags_make_vars = get_ldflags_make_vars(executable_ldflags_vars, shared_ldflags_vars, workspace_name, flags, env_vars, deps, inputs, is_msvc)
+    ldflags_make_vars = get_ldflags_make_vars(executable_ldflags_vars, shared_ldflags_vars, dynamic_module_ldflags_vars, workspace_name, flags, env_vars, deps, inputs, is_msvc)
 
     make_commands = []
     for target in make_targets:

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -4,6 +4,7 @@ load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tools/lint:linters.bzl", "shellcheck_test")
 load(":cmake_text_tests.bzl", "cmake_script_test_suite")
 load(":convert_shell_script_test.bzl", "shell_script_conversion_suite")
+load(":make_env_vars_test.bzl", "make_env_vars_test_suite")
 load(":msbuild_text_tests.bzl", "msbuild_script_test_suite")
 load(":shell_script_helper_test_rule.bzl", "shell_script_helper_test_rule")
 load(":symlink_contents_to_dir_test_rule.bzl", "symlink_contents_to_dir_test_rule")
@@ -58,6 +59,8 @@ cmake_script_test_suite()
 msbuild_script_test_suite()
 
 shell_script_conversion_suite()
+
+make_env_vars_test_suite()
 
 utils_test_suite()
 

--- a/test/cmake_text_tests.bzl
+++ b/test/cmake_text_tests.bzl
@@ -88,17 +88,18 @@ def _fill_crossfile_from_toolchain_test(ctx):
         "unknown": (["shared1", "shared2"], ["shared1", "shared2"]),
     }
 
-    for target_os, inputs in cases.items():
+    for inputs in cases.values():
         flags = CxxFlagsInfo(
             cc = ["-cc-flag", "-gcc_toolchain", "cc-toolchain"],
             cxx = ["--quoted=\"abc def\"", "--sysroot=/abc/sysroot", "--gcc_toolchain", "cxx-toolchain"],
             cxx_linker_shared = inputs[0],
+            cxx_linker_dynamic_module = inputs[1],
             cxx_linker_static = ["static"],
             cxx_linker_executable = ["executable"],
             assemble = ["assemble"],
         )
 
-        res = export_for_test.fill_crossfile_from_toolchain("ws", tools, flags, target_os)
+        res = export_for_test.fill_crossfile_from_toolchain("ws", tools, flags)
 
         expected = {
             "CMAKE_AR": "/cxx_linker_static",
@@ -242,6 +243,7 @@ def _merge_flag_values_no_toolchain_file_test(ctx):
         cc = [],
         cxx = ['foo="bar"'],
         cxx_linker_shared = [],
+        cxx_linker_dynamic_module = [],
         cxx_linker_static = [],
         cxx_linker_executable = [],
         assemble = [],
@@ -298,6 +300,7 @@ def _create_min_cmake_script_no_toolchain_file_test(ctx):
         cc = ["-U_FORTIFY_SOURCE", "-fstack-protector", "-Wall"],
         cxx = ["-U_FORTIFY_SOURCE", "-fstack-protector", "-Wall"],
         cxx_linker_shared = ["-shared", "-fuse-ld=gold"],
+        cxx_linker_dynamic_module = ["-shared", "-fuse-ld=gold"],
         cxx_linker_static = ["static"],
         cxx_linker_executable = ["-fuse-ld=gold", "-Wl", "-no-as-needed"],
         assemble = ["-U_FORTIFY_SOURCE", "-fstack-protector", "-Wall"],
@@ -355,6 +358,7 @@ def _create_min_cmake_script_wipe_toolchain_test(ctx):
         cc = ["-U_FORTIFY_SOURCE", "-fstack-protector", "-Wall"],
         cxx = ["-U_FORTIFY_SOURCE", "-fstack-protector", "-Wall"],
         cxx_linker_shared = ["-shared", "-fuse-ld=gold"],
+        cxx_linker_dynamic_module = ["-shared", "-fuse-ld=gold"],
         cxx_linker_static = ["static"],
         cxx_linker_executable = ["-fuse-ld=gold", "-Wl", "-no-as-needed"],
         assemble = ["-U_FORTIFY_SOURCE", "-fstack-protector", "-Wall"],
@@ -418,6 +422,7 @@ def _create_min_cmake_script_toolchain_file_test(ctx):
         cc = ["-U_FORTIFY_SOURCE", "-fstack-protector", "-Wall"],
         cxx = ["-U_FORTIFY_SOURCE", "-fstack-protector", "-Wall"],
         cxx_linker_shared = ["-shared", "-fuse-ld=gold"],
+        cxx_linker_dynamic_module = ["-shared", "-fuse-ld=gold"],
         cxx_linker_static = ["static"],
         cxx_linker_executable = ["-fuse-ld=gold", "-Wl", "-no-as-needed"],
         assemble = ["-U_FORTIFY_SOURCE", "-fstack-protector", "-Wall"],
@@ -495,6 +500,7 @@ def _create_cmake_script_no_toolchain_file_test(ctx):
             "cxx-toolchain",
         ],
         cxx_linker_shared = ["shared1", "shared2"],
+        cxx_linker_dynamic_module = ["shared1", "shared2"],
         cxx_linker_static = ["static"],
         cxx_linker_executable = ["executable"],
         assemble = ["assemble"],
@@ -566,6 +572,7 @@ def _create_cmake_script_android_test(ctx):
             "cxx-toolchain",
         ],
         cxx_linker_shared = ["shared1", "shared2"],
+        cxx_linker_dynamic_module = ["shared1", "shared2"],
         cxx_linker_static = ["static"],
         cxx_linker_executable = ["executable"],
         assemble = ["assemble"],
@@ -637,6 +644,7 @@ def _create_cmake_script_linux_test(ctx):
             "cxx-toolchain",
         ],
         cxx_linker_shared = ["shared1", "shared2"],
+        cxx_linker_dynamic_module = ["shared1", "shared2"],
         cxx_linker_static = ["static"],
         cxx_linker_executable = ["executable"],
         assemble = ["assemble"],
@@ -703,6 +711,7 @@ def _create_cmake_script_windows_no_toolchain_file_test(ctx):
         cc = ["/Z7"],
         cxx = ["/Z7"],
         cxx_linker_shared = [],
+        cxx_linker_dynamic_module = [],
         cxx_linker_static = [],
         cxx_linker_executable = [],
         assemble = [],
@@ -754,6 +763,7 @@ def _create_cmake_script_windows_toolchain_file_test(ctx):
         cc = ["/Z7"],
         cxx = ["/Z7"],
         cxx_linker_shared = [],
+        cxx_linker_dynamic_module = [],
         cxx_linker_static = [],
         cxx_linker_executable = [],
         assemble = [],
@@ -835,6 +845,7 @@ def _create_cmake_script_toolchain_file_test(ctx):
             "cxx-toolchain",
         ],
         cxx_linker_shared = ["shared1", "shared2"],
+        cxx_linker_dynamic_module = ["shared1", "shared2"],
         cxx_linker_static = ["static"],
         cxx_linker_executable = ["executable"],
         assemble = ["assemble"],

--- a/test/make_env_vars_test.bzl
+++ b/test/make_env_vars_test.bzl
@@ -1,0 +1,105 @@
+"""Unit tests for Make environment variable helpers."""
+
+load("@bazel_skylib//lib:partial.bzl", "partial")
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+
+# buildifier: disable=bzl-visibility
+load("//foreign_cc/private:cc_toolchain_util.bzl", "export_for_test")
+
+# buildifier: disable=bzl-visibility
+load("//foreign_cc/private:make_env_vars.bzl", "get_ldflags_make_vars")
+
+def _empty_inputs():
+    return struct(
+        libs = [],
+        include_dirs = [],
+        headers = [],
+    )
+
+def _ldflags_vars_include_dynamic_modules_test(ctx):
+    env = unittest.begin(ctx)
+
+    flags = struct(
+        cxx_linker_executable = ["EXE"],
+        cxx_linker_shared = ["SHARED"],
+        cxx_linker_dynamic_module = ["MODULE"],
+    )
+
+    result = get_ldflags_make_vars(
+        [],
+        [],
+        ["MODULE_LDFLAGS"],
+        "workspace",
+        flags,
+        {},
+        [],
+        _empty_inputs(),
+        False,
+    )
+
+    asserts.equals(env, "MODULE_LDFLAGS=\"MODULE\"", result)
+
+    return unittest.end(env)
+
+def _ldflags_vars_keep_link_categories_independent_test(ctx):
+    env = unittest.begin(ctx)
+
+    flags = struct(
+        cxx_linker_executable = ["EXE"],
+        cxx_linker_shared = ["SHARED"],
+        cxx_linker_dynamic_module = ["MODULE"],
+    )
+
+    result = get_ldflags_make_vars(
+        ["LDFLAGS"],
+        ["SHARED_LDFLAGS"],
+        ["MODULE_LDFLAGS"],
+        "workspace",
+        flags,
+        {},
+        [],
+        _empty_inputs(),
+        False,
+    )
+
+    asserts.equals(env, "LDFLAGS=\"EXE\" SHARED_LDFLAGS=\"SHARED\" MODULE_LDFLAGS=\"MODULE\"", result)
+
+    return unittest.end(env)
+
+def _dynamic_module_link_flags_strip_darwin_library_flags_test(ctx):
+    env = unittest.begin(ctx)
+
+    result = export_for_test.dynamic_module_link_flags(
+        ["-shared", "-dynamiclib", "-Wl,-rpath,@loader_path/lib"],
+        True,
+    )
+
+    asserts.equals(env, ["-Wl,-rpath,@loader_path/lib"], result)
+
+    return unittest.end(env)
+
+def _dynamic_module_link_flags_preserve_non_darwin_flags_test(ctx):
+    env = unittest.begin(ctx)
+
+    result = export_for_test.dynamic_module_link_flags(
+        ["-shared", "-Wl,-rpath,$ORIGIN/lib"],
+        False,
+    )
+
+    asserts.equals(env, ["-shared", "-Wl,-rpath,$ORIGIN/lib"], result)
+
+    return unittest.end(env)
+
+ldflags_vars_include_dynamic_modules_test = unittest.make(_ldflags_vars_include_dynamic_modules_test)
+ldflags_vars_keep_link_categories_independent_test = unittest.make(_ldflags_vars_keep_link_categories_independent_test)
+dynamic_module_link_flags_strip_darwin_library_flags_test = unittest.make(_dynamic_module_link_flags_strip_darwin_library_flags_test)
+dynamic_module_link_flags_preserve_non_darwin_flags_test = unittest.make(_dynamic_module_link_flags_preserve_non_darwin_flags_test)
+
+def make_env_vars_test_suite():
+    unittest.suite(
+        "make_env_vars_test_suite",
+        partial.make(ldflags_vars_include_dynamic_modules_test, size = "small"),
+        partial.make(ldflags_vars_keep_link_categories_independent_test, size = "small"),
+        partial.make(dynamic_module_link_flags_strip_darwin_library_flags_test, size = "small"),
+        partial.make(dynamic_module_link_flags_preserve_non_darwin_flags_test, size = "small"),
+    )


### PR DESCRIPTION
Add dynamic_module_ldflags_vars to make and configure_make.

These variables are mainly for Darwin builds that need linker flags for loadable modules, such as plugins. They are separate from shared library linker flags because Darwin module links use -bundle, which conflicts with -shared and -dynamiclib.

CMake already handled module linker flags separately; this change makes that behavior consistent with make and configure_make. Also add focused Starlark tests for the new make variables and Darwin flag filtering.

Needs https://github.com/bazel-contrib/rules_foreign_cc/pull/1443 to be merged first due to conflicts.