### PR TITLE
foreign_cc: wire set_file_prefix_map into built_tools and add a global default

### DIFF
--- a/foreign_cc/private/cc_toolchain_util.bzl
+++ b/foreign_cc/private/cc_toolchain_util.bzl
@@ -2,6 +2,7 @@
 """
 
 load("@bazel_skylib//lib:collections.bzl", "collections")
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("@rules_cc//cc:defs.bzl", "CcInfo", "cc_common")
@@ -236,6 +237,17 @@ def get_tools_info(ctx):
         ) else "",
     )
 
+def _set_file_prefix_map_enabled(ctx, cc_toolchain):
+    # `-ffile-prefix-map` is a gcc/clang flag; MSVC has no equivalent that
+    # rewrites embedded paths the same way, so skip it there.
+    if cc_toolchain.compiler == "msvc-cl":
+        return False
+    if ctx.attr.set_file_prefix_map:
+        return True
+    if ctx.attr._set_file_prefix_map_default[BuildSettingInfo].value:
+        return True
+    return False
+
 def get_flags_info(ctx, link_output_file = None):
     """Takes information about flags from cc_toolchain, returns CxxFlagsInfo
 
@@ -327,7 +339,7 @@ def get_flags_info(ctx, link_output_file = None):
         ),
     )
 
-    if "set_file_prefix_map" in dir(ctx.attr) and ctx.attr.set_file_prefix_map:
+    if _set_file_prefix_map_enabled(ctx, cc_toolchain_):
         copts.append("-ffile-prefix-map=$EXT_BUILD_ROOT=.")
         cxxopts.append("-ffile-prefix-map=$EXT_BUILD_ROOT=.")
 

--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -59,6 +59,15 @@ FOREIGN_CC_FRAMEWORK_COMMON_ATTRS = {
         mandatory = False,
         default = [],
     ),
+    "set_file_prefix_map": attr.bool(
+        doc = (
+            "If True, pass `-ffile-prefix-map=$EXT_BUILD_ROOT=.` to strip the sandbox " +
+            "path from compiled outputs. If False (the default), inherit from " +
+            "`//foreign_cc/settings:set_file_prefix_map_default`. Has no effect on MSVC."
+        ),
+        mandatory = False,
+        default = False,
+    ),
     "_allow_building_in_tmp": attr.label(
         default = Label("@rules_foreign_cc//foreign_cc/settings:allow_building_in_tmp"),
         providers = [BuildSettingInfo],
@@ -70,6 +79,10 @@ FOREIGN_CC_FRAMEWORK_COMMON_ATTRS = {
         doc = "Information about the execution platform",
         cfg = "exec",
         default = Label("@rules_foreign_cc//foreign_cc/private/framework:platform_info"),
+    ),
+    "_set_file_prefix_map_default": attr.label(
+        default = Label("@rules_foreign_cc//foreign_cc/settings:set_file_prefix_map_default"),
+        providers = [BuildSettingInfo],
     ),
 } | PLATFORM_CONSTRAINTS_RULE_ATTRIBUTES | SIZE_ATTRIBUTES
 
@@ -232,14 +245,6 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
     "postfix_script": attr.string(
         doc = "Optional part of the shell script to be added after the make commands",
         mandatory = False,
-    ),
-    "set_file_prefix_map": attr.bool(
-        doc = (
-            "Use -ffile-prefix-map with the intention to remove the sandbox path from " +
-            "debug symbols"
-        ),
-        mandatory = False,
-        default = False,
     ),
     "static_suffix": attr.string(
         doc = (

--- a/foreign_cc/settings/BUILD.bazel
+++ b/foreign_cc/settings/BUILD.bazel
@@ -11,6 +11,12 @@ bool_flag(
     visibility = ["//visibility:public"],
 )
 
+bool_flag(
+    name = "set_file_prefix_map_default",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
 # `bazel run //foreign_cc/settings` prints every public build setting in
 # bazelrc form so users can copy them verbatim into their own bazelrc.
 _settings_script(
@@ -19,6 +25,11 @@ _settings_script(
         (
             (2, 0),
             "allow_building_in_tmp",
+            False,
+        ),
+        (
+            (2, 1),
+            "set_file_prefix_map_default",
             False,
         ),
     ],


### PR DESCRIPTION
`-ffile-prefix-map=$EXT_BUILD_ROOT=.` exists as an opt-in `set_file_prefix_map`
attribute on the `cc_external_rule_impl`-based rules (added in #1288), but it
was never plumbed into the `built_tools` rules (`make_tool`, `pkgconfig_tool`,
`ninja_tool`, …). That matters because built-tool binaries are consumed by
digest downstream — sandbox paths leaking in via the hermetic CC toolchain's
`--sysroot=` / `-isystem` flags (which `make_build.bzl` and
`pkgconfig_build.bzl` absolutize into `CC` / `LD`) cause `make_tool`'s digest
to vary per-machine.

This moves the `set_file_prefix_map` attr into `FOREIGN_CC_FRAMEWORK_COMMON_ATTRS`
(the shared dict introduced in #1553) so both rule families pick it up, and
adds a `//foreign_cc/settings:set_file_prefix_map_default` `bool_flag` so the
flag can be turned on globally without touching call sites. The per-rule attr
still wins when set to True. Skipped on `msvc-cl` (no equivalent).

Necessary but not sufficient for full reproducibility — other sources may
remain (`__DATE__`, timestamps, etc.) — but it removes the dominant
per-machine variation.

Continues #1543.