### PR TITLE
foreign_cc: extract bazelrc-shim plumbing into settings_script.bzl

### DIFF
--- a/foreign_cc/private/resource_sets.bzl
+++ b/foreign_cc/private/resource_sets.bzl
@@ -1,9 +1,7 @@
 """Resource set definitions for build actions"""
 
-load("@bazel_lib//lib:expand_template.bzl", "expand_template")
 load("@bazel_lib//lib:resource_sets.bzl", "resource_set_for")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo", "int_flag", "string_flag")
-load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 
 _PARALLELISM_OVERCOMMIT_DEFAULT = 2
 _PARALLELISM_OVERCOMMIT_SETTING = "parallelism_overcommit"
@@ -37,9 +35,6 @@ _SIZES = {
     },
 }
 
-def _bazelrc_line(name, value):
-    return "common --@rules_foreign_cc//foreign_cc/settings:{}={}".format(name, value)
-
 def _is_fixed(cfg, resource):
     return cfg.get("fixed_{}".format(resource), False)
 
@@ -56,18 +51,16 @@ def _setting(size, resource, mode):
     else:
         fail("unknown mode", mode)
 
-def create_settings():
-    """create the settings that configure these functions."""
-    settings = {
-        _PARALLELISM_OVERCOMMIT_SETTING: {
-            "sort_key": (0, 0, 0, ""),
-            "value": _PARALLELISM_OVERCOMMIT_DEFAULT,
-        },
-        "size_default": {
-            "sort_key": (0, 0, 1, ""),
-            "value": _DEFAULT_SIZE,
-        },
-    }
+def create_resource_set_settings():
+    """Declares the resource_set build settings and returns their default values.
+
+    Returns:
+        list of (sort_key, name, value) tuples to feed into the bazelrc-printing script.
+    """
+    settings = [
+        ((0, 0, 0, ""), _PARALLELISM_OVERCOMMIT_SETTING, _PARALLELISM_OVERCOMMIT_DEFAULT),
+        ((0, 0, 1, ""), "size_default", _DEFAULT_SIZE),
+    ]
     int_flag(
         name = _PARALLELISM_OVERCOMMIT_SETTING,
         build_setting_default = _PARALLELISM_OVERCOMMIT_DEFAULT,
@@ -98,36 +91,17 @@ def create_settings():
 
             # Keep the generated bazelrc grouped by descending size, with
             # fixed-resource variants after non-fixed ones when values tie.
-            settings[name] = {
-                "sort_key": (
-                    1,
-                    -cfg["cpu"],
-                    -cfg["mem"],
-                    1 if cfg.get("fixed_cpu", False) or cfg.get("fixed_mem", False) else 0,
-                    size,
-                    0 if resource == "cpu" else 1,
-                ),
-                "value": default,
-            }
+            sort_key = (
+                1,
+                -cfg["cpu"],
+                -cfg["mem"],
+                1 if cfg.get("fixed_cpu", False) or cfg.get("fixed_mem", False) else 0,
+                size,
+                0 if resource == "cpu" else 1,
+            )
+            settings.append((sort_key, name, default))
 
-    expand_template(
-        name = "settings_script",
-        out = "settings.sh",
-        template = Label(":settings.sh.in"),
-        substitutions = {
-            "{{SETTINGS_BAZELRC_LINES}}": "\n".join([
-                _bazelrc_line(name, settings[name]["value"])
-                for name in sorted(settings.keys(), key = lambda name: settings[name]["sort_key"])
-            ]),
-        },
-    )
-
-    # Create an executable shim for the script
-    sh_binary(
-        name = "settings",
-        srcs = [":settings_script"],
-        visibility = ["//visibility:public"],
-    )
+    return settings
 
 SIZE_ATTRIBUTES = {
     "resource_size": attr.string(

--- a/foreign_cc/private/settings_script.bzl
+++ b/foreign_cc/private/settings_script.bzl
@@ -1,0 +1,40 @@
+"""Helpers for generating the `bazel run //foreign_cc/settings` shim."""
+
+load("@bazel_lib//lib:expand_template.bzl", "expand_template")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+
+def _render(value):
+    # bazelrc accepts lowercase booleans; Starlark's str() yields "True"/"False".
+    if type(value) == "bool":
+        return "true" if value else "false"
+    return str(value)
+
+def _bazelrc_line(name, value):
+    return "common --@rules_foreign_cc//foreign_cc/settings:{}={}".format(name, _render(value))
+
+def settings_script(name, settings):
+    """Emit a sh_binary that prints `settings` as bazelrc lines.
+
+    Args:
+        name: target name for the resulting sh_binary.
+        settings: list of (sort_key, name, value) tuples. `sort_key` may be any
+            comparable value (typically a tuple); entries are sorted by it
+            before rendering.
+    """
+    lines = [
+        _bazelrc_line(setting_name, value)
+        for _, setting_name, value in sorted(settings, key = lambda entry: entry[0])
+    ]
+    expand_template(
+        name = name + "_script",
+        out = name + ".sh",
+        template = Label("//foreign_cc/private:settings.sh.in"),
+        substitutions = {
+            "{{SETTINGS_BAZELRC_LINES}}": "\n".join(lines),
+        },
+    )
+    sh_binary(
+        name = name,
+        srcs = [name + "_script"],
+        visibility = ["//visibility:public"],
+    )

--- a/foreign_cc/settings/BUILD.bazel
+++ b/foreign_cc/settings/BUILD.bazel
@@ -1,10 +1,25 @@
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
-load("//foreign_cc/private:resource_sets.bzl", _create_settings = "create_settings")
-
-_create_settings()
+load(
+    "//foreign_cc/private:resource_sets.bzl",
+    _create_resource_set_settings = "create_resource_set_settings",
+)
+load("//foreign_cc/private:settings_script.bzl", _settings_script = "settings_script")
 
 bool_flag(
     name = "allow_building_in_tmp",
     build_setting_default = False,
     visibility = ["//visibility:public"],
+)
+
+# `bazel run //foreign_cc/settings` prints every public build setting in
+# bazelrc form so users can copy them verbatim into their own bazelrc.
+_settings_script(
+    name = "settings",
+    settings = _create_resource_set_settings() + [
+        (
+            (2, 0),
+            "allow_building_in_tmp",
+            False,
+        ),
+    ],
 )


### PR DESCRIPTION
`bazel run //foreign_cc/settings` prints every public build setting in
bazelrc form, but the helper that wires it up was buried inside
`resource_sets.bzl` and conflated two responsibilities: declaring the
`resource_set` flags and rendering the bazelrc shim.

Pull the rendering into a new `settings_script.bzl` helper that takes a
list of `(sort_key, name, value)` tuples, and reshape `create_settings`
in `resource_sets.bzl` into `create_resource_set_settings` returning that
list. `//foreign_cc/settings` now glues them together explicitly, which
also lets non-resource-set flags (like `allow_building_in_tmp`) appear in
the bazelrc output without a second template/shim pair.

No functional change to the resource_set defaults; this is preparation
for adding a second standalone bool_flag in a follow-up.