### PR TITLE
ci: collapse build+test into a single bazel test phase

### DIFF
--- a/.bazelci/config.yaml
+++ b/.bazelci/config.yaml
@@ -71,8 +71,6 @@ matrix:
 .default_task: &default_task
   platform: ${{ platform }}
   bazel: ${{ bazel_version }}
-  build_targets:
-    - //...
   test_targets:
     - //...
 
@@ -82,11 +80,17 @@ tasks:
     name: '{primary}/{bazel_version}/{bzlmod}/{spawn_strategy}'
     working_directory: ${{ primary }}
 
-    build_flags: &primary_flags
+    # Run a single `bazel test //...` phase rather than separate build+test
+    # phases. bazelci's default `--build_tests_only` is overridden so all
+    # non-test targets still get built, and dropping the build phase means
+    # every action shows up in test_bep.json (which IS uploaded as a CI
+    # artifact, unlike build_bep.json).
+    test_flags:
       - --config=ci
       - ${{ bazel_rc_config }}
       - ${{ bzlmod }}
       - ${{ spawn_strategy }}
+      - --nobuild_tests_only
       # Segregate the remote cache by buildkite platform so that, for
       # example, an RBE worker can't pull a configure_make artifact baked by
       # a non-RBE node (where the build environment differs) just because
@@ -94,8 +98,6 @@ tasks:
       # in every spawn's action key, so each platform gets its own silo for
       # both remote-cache-only lookups and RBE executor lookups.
       - --action_env=RFCC_CACHE_SILO=${{ platform }}
-
-    test_flags: *primary_flags
 
   docs:
     name: Docs


### PR DESCRIPTION
bazelci runs `bazel build //...` and then `bazel test //...` as two
separate phases. The build phase generates a `build_bep.json` (since
[bazelbuild/continuous-integration#2614](https://github.com/bazelbuild/continuous-integration/pull/2614)) but never uploads it as an
artifact, so we lose visibility into where build-action time is spent.
The test phase generates `test_bep.json` *and* uploads it.

Drop the build phase entirely and just run `bazel test //... --nobuild_tests_only`. This:

- Eliminates the duplicate analysis phase.
- Captures every non-test build action in `test_bep.json`, which is already uploaded — no new artifact plumbing needed.
- Still builds non-test targets (like `cmake_defines` or the `meson_with_requirements` example), because `--nobuild_tests_only` reverses bazelci's hardcoded `--build_tests_only` default.

The Docs task is left alone since it's already build-only.

Once this lands, follow-ups (e.g. the batched `touch -r` fix for the per-platform `copy_dir_contents_to_dir` shells) become measurable in the BEP stats from the macOS Intel jobs.