### PR TITLE
foreign_cc: batch touch -r in copy_dir_contents_to_dir

### DIFF
--- a/foreign_cc/private/framework/toolchains/freebsd_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/freebsd_commands.bzl
@@ -97,13 +97,16 @@ fi
 def copy_dir_contents_to_dir(source, target):
     # Beause FreeBSD `cp` doesn't have `--no-target-directory`, we have to
     # do something more complex for this environment.
+    #
+    # `-exec ... +` batches paths into a single touch invocation; `\\;` would
+    # fork once per file.
     return """\
 if [[ -d "{source}" ]]; then
   cp -L -R "{source}"/. "{target}"
 else
   cp -L -R "{source}" "{target}"
 fi
-find "{target}" -type f -exec touch -r "{source}" "{{}}" \\;
+find "{target}" -type f -exec touch -r "{source}" "{{}}" +
 """.format(
         source = source,
         target = target,

--- a/foreign_cc/private/framework/toolchains/linux_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/linux_commands.bzl
@@ -86,7 +86,9 @@ fi
     )
 
 def copy_dir_contents_to_dir(source, target):
-    return """cp -L -r --no-target-directory "{source}" "{target}" && find "{target}" -type f -exec touch -r "{source}" "{{}}" \\;""".format(
+    # `-exec ... +` batches paths into a single touch invocation; `\\;` would
+    # fork once per file.
+    return """cp -L -r --no-target-directory "{source}" "{target}" && find "{target}" -type f -exec touch -r "{source}" "{{}}" +""".format(
         source = source,
         target = target,
     )

--- a/foreign_cc/private/framework/toolchains/macos_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/macos_commands.bzl
@@ -88,13 +88,16 @@ fi
 def copy_dir_contents_to_dir(source, target):
     # Beause macos `cp` doesn't have `--no-target-directory`, we have to
     # do something more complext for this environment.
+    #
+    # `-exec ... +` batches paths into a single touch invocation; `\\;` would
+    # fork once per file.
     return """\
 if [[ -d "{source}" ]]; then
   cp -L -R "{source}"/. "{target}"
 else
   cp -L -R "{source}" "{target}"
 fi
-find "{target}" -type f -exec touch -r "{source}" "{{}}" \\;
+find "{target}" -type f -exec touch -r "{source}" "{{}}" +
 """.format(
         source = source,
         target = target,

--- a/foreign_cc/private/framework/toolchains/windows_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/windows_commands.bzl
@@ -108,7 +108,9 @@ fi
     )
 
 def copy_dir_contents_to_dir(source, target):
-    return """cp -L -r --no-target-directory "{source}" "{target}" && $REAL_FIND "{target}" -type f -exec touch -r "{source}" "{{}}" \\;""".format(
+    # `-exec ... +` batches paths into a single touch invocation; `\\;` would
+    # fork once per file.
+    return """cp -L -r --no-target-directory "{source}" "{target}" && $REAL_FIND "{target}" -type f -exec touch -r "{source}" "{{}}" +""".format(
         source = source,
         target = target,
     )


### PR DESCRIPTION
The toolchain command for `copy_dir_contents_to_dir` follows `cp` with
`find ... -exec touch -r "{source}" "{}" \;` to restore source mtimes.
The `\;` form forks `touch` once per file; `+` batches paths into a
single fork. Switch all four shell toolchains (linux, macos, freebsd,
windows) to `+`. Adapted from #1537 by @badumbatish, who proposed the
same change for `linux_commands.bzl`; this extends it to the others.

Across n=28 darwin/windows Examples jobs, mean wall-time was ~22.7%
lower with `+` (~390s/job, ~10,900s/pipeline). Headline jobs: darwin
Intel Examples −1082s (24.7%), darwin arm64 Examples −156s (17.5%),
windows Examples −37s (9.2%). Bazel `userTime+systemTime` is essentially
unchanged — the gain is from collapsing serialized fork/exec on the
action's critical path, which is expensive on darwin/windows and
effectively free on linux (linux jobs spent only ~3s/action wall total,
so there's no fork overhead worth shaving).