### PR TITLE
DO NOT MERGE: cache-bust validation for #1549

### DIFF
--- a/foreign_cc/private/framework/toolchains/freebsd_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/freebsd_commands.bzl
@@ -97,7 +97,12 @@ fi
 def copy_dir_contents_to_dir(source, target):
     # Beause FreeBSD `cp` doesn't have `--no-target-directory`, we have to
     # do something more complex for this environment.
+    #
+    # cache-bust salt: changes the action key vs origin/main without changing
+    # observable behavior or runtime cost. Used to isolate one-time cache-pop
+    # cost from steady-state action cost when measuring PR #1549's effect.
     return """\
+: rfcc-cache-bust-1549
 if [[ -d "{source}" ]]; then
   cp -L -R "{source}"/. "{target}"
 else

--- a/foreign_cc/private/framework/toolchains/linux_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/linux_commands.bzl
@@ -86,7 +86,10 @@ fi
     )
 
 def copy_dir_contents_to_dir(source, target):
-    return """cp -L -r --no-target-directory "{source}" "{target}" && find "{target}" -type f -exec touch -r "{source}" "{{}}" \\;""".format(
+    # cache-bust salt: changes the action key vs origin/main without changing
+    # observable behavior or runtime cost. Used to isolate one-time cache-pop
+    # cost from steady-state action cost when measuring PR #1549's effect.
+    return """: rfcc-cache-bust-1549; cp -L -r --no-target-directory "{source}" "{target}" && find "{target}" -type f -exec touch -r "{source}" "{{}}" \\;""".format(
         source = source,
         target = target,
     )

--- a/foreign_cc/private/framework/toolchains/macos_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/macos_commands.bzl
@@ -88,7 +88,12 @@ fi
 def copy_dir_contents_to_dir(source, target):
     # Beause macos `cp` doesn't have `--no-target-directory`, we have to
     # do something more complext for this environment.
+    #
+    # cache-bust salt: changes the action key vs origin/main without changing
+    # observable behavior or runtime cost. Used to isolate one-time cache-pop
+    # cost from steady-state action cost when measuring PR #1549's effect.
     return """\
+: rfcc-cache-bust-1549
 if [[ -d "{source}" ]]; then
   cp -L -R "{source}"/. "{target}"
 else

--- a/foreign_cc/private/framework/toolchains/windows_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/windows_commands.bzl
@@ -108,7 +108,10 @@ fi
     )
 
 def copy_dir_contents_to_dir(source, target):
-    return """cp -L -r --no-target-directory "{source}" "{target}" && $REAL_FIND "{target}" -type f -exec touch -r "{source}" "{{}}" \\;""".format(
+    # cache-bust salt: changes the action key vs origin/main without changing
+    # observable behavior or runtime cost. Used to isolate one-time cache-pop
+    # cost from steady-state action cost when measuring PR #1549's effect.
+    return """: rfcc-cache-bust-1549; cp -L -r --no-target-directory "{source}" "{target}" && $REAL_FIND "{target}" -type f -exec touch -r "{source}" "{{}}" \\;""".format(
         source = source,
         target = target,
     )


### PR DESCRIPTION
**This PR is for CI measurement only and must not be merged.**

Adds a no-op `: rfcc-cache-bust-1549` prefix to `copy_dir_contents_to_dir` on all four shell toolchains. This changes the foreign_cc action key vs `origin/main`, but `:` is the bash null builtin and the rest of the command (the per-file `find … \;`) is identical to `origin/main`. So this branch should pop exactly the same cache entries as #1549 did, but execute the recovered actions at `origin/main` speed (not at #1549's `+`-batched speed).

## What this measures

| Branch | Action key | Per-file forks | Goal |
|---|---|---|---|
| `origin/main` (pre-#1549) | A | many (`\;`) | baseline |
| #1549 | B | one (`+`) | the change |
| this branch | C | many (`\;`) | cache-pop control |

If this branch's wall time on darwin Intel/arm64 matches #1549's pipeline 8057, then 8057's slowdown was 100% one-time cache invalidation and `+` is at least as fast as `\;`.

If this branch is meaningfully slower than 8057, then the `+` batching in #1549 is providing real per-action speedup over `\;` (and we can quantify it).

Either way, the steady-state speedup of #1549 vs pre-#1549 will be measurable on the next post-merge daily build by comparing `actionsExecuted` and per-target wall times in `test_bep.json` (which is what #1548 unlocked).

After CI runs, this PR will be closed without merging.