### PR TITLE
foreign_cc: extract FOREIGN_CC_FRAMEWORK_COMMON_ATTRS

### DIFF
--- a/examples/integration_tests/standard_cxx_flags_test/tests.bzl
+++ b/examples/integration_tests/standard_cxx_flags_test/tests.bzl
@@ -3,7 +3,7 @@
 load("@rules_foreign_cc//foreign_cc/private:cc_toolchain_util.bzl", "get_flags_info")
 
 # buildifier: disable=bzl-visibility
-load("@rules_foreign_cc//foreign_cc/private/framework:platform.bzl", "PLATFORM_CONSTRAINTS_RULE_ATTRIBUTES")
+load("@rules_foreign_cc//foreign_cc/private:framework.bzl", "FOREIGN_CC_FRAMEWORK_COMMON_ATTRS")
 load("@with_cfg.bzl", "with_cfg")
 
 def _impl(ctx):
@@ -59,19 +59,12 @@ def assert_contains_once(arr, value):
     if cnt > 1:
         fail("Value is included multiple times: " + value)
 
-_FLAGS_TEST_ATTRS = {
-    "copts": attr.string_list(),
-    "deps": attr.label_list(),
-    "linkopts": attr.string_list(),
-    "out": attr.output(),
-    "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
-}
-
-_FLAGS_TEST_ATTRS.update(PLATFORM_CONSTRAINTS_RULE_ATTRIBUTES)
-
 _flags_test_test = rule(
     implementation = _impl,
-    attrs = _FLAGS_TEST_ATTRS,
+    attrs = {
+        "deps": attr.label_list(),
+        "out": attr.output(),
+    } | FOREIGN_CC_FRAMEWORK_COMMON_ATTRS,
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
     fragments = ["cpp", "j2objc"],
     test = True,

--- a/foreign_cc/built_tools/private/built_tools_framework.bzl
+++ b/foreign_cc/built_tools/private/built_tools_framework.bzl
@@ -1,13 +1,11 @@
 """A module defining a common framework for "built_tools" rules"""
 
-load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("//foreign_cc/private:cc_toolchain_util.bzl", "absolutize_path_in_str")
 load("//foreign_cc/private:detect_root.bzl", "detect_root")
-load("//foreign_cc/private:framework.bzl", "get_env_prelude", "wrap_outputs")
-load("//foreign_cc/private:resource_sets.bzl", "SIZE_ATTRIBUTES", "get_resource_env_vars")
+load("//foreign_cc/private:framework.bzl", "FOREIGN_CC_FRAMEWORK_COMMON_ATTRS", "get_env_prelude", "wrap_outputs")
+load("//foreign_cc/private:resource_sets.bzl", "get_resource_env_vars")
 load("//foreign_cc/private/framework:helpers.bzl", "convert_shell_script", "shebang")
-load("//foreign_cc/private/framework:platform.bzl", "PLATFORM_CONSTRAINTS_RULE_ATTRIBUTES")
 
 # Common attributes for all built_tool rules
 FOREIGN_CC_BUILT_TOOLS_ATTRS = {
@@ -17,31 +15,11 @@ FOREIGN_CC_BUILT_TOOLS_ATTRS = {
         ),
         default = False,
     ),
-    "env": attr.string_dict(
-        doc = "Environment variables to set during the build. This attribute is subject to make variable substitution.",
-        default = {},
-    ),
     "srcs": attr.label(
         doc = "The target containing the build tool's sources",
         mandatory = True,
     ),
-    "_allow_building_in_tmp": attr.label(
-        default = Label("@rules_foreign_cc//foreign_cc/settings:allow_building_in_tmp"),
-        providers = [BuildSettingInfo],
-    ),
-    "_cc_toolchain": attr.label(
-        default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
-    ),
-    "_foreign_cc_framework_platform": attr.label(
-        doc = "Information about the execution platform",
-        cfg = "exec",
-        default = Label("@rules_foreign_cc//foreign_cc/private/framework:platform_info"),
-    ),
-}
-
-# this would be cleaner as x | y, but that's not supported in bazel 5.4.0
-FOREIGN_CC_BUILT_TOOLS_ATTRS.update(PLATFORM_CONSTRAINTS_RULE_ATTRIBUTES)
-FOREIGN_CC_BUILT_TOOLS_ATTRS.update(SIZE_ATTRIBUTES)
+} | FOREIGN_CC_FRAMEWORK_COMMON_ATTRS
 
 # Common fragments for all built_tool rules
 FOREIGN_CC_BUILT_TOOLS_FRAGMENTS = [

--- a/foreign_cc/private/cc_toolchain_util.bzl
+++ b/foreign_cc/private/cc_toolchain_util.bzl
@@ -171,7 +171,7 @@ def get_env_vars(ctx):
         ctx = ctx,
         cc_toolchain = cc_toolchain,
     )
-    copts = getattr(ctx.attr, "copts", [])
+    copts = ctx.attr.copts
 
     action_names = [
         ACTION_NAMES.c_compile,
@@ -253,9 +253,9 @@ def get_flags_info(ctx, link_output_file = None):
         cc_toolchain = cc_toolchain_,
     )
 
-    copts = (ctx.fragments.cpp.copts + ctx.fragments.cpp.conlyopts + getattr(ctx.attr, "copts", [])) or []
-    cxxopts = (ctx.fragments.cpp.copts + ctx.fragments.cpp.cxxopts + getattr(ctx.attr, "copts", [])) or []
-    linkopts = (ctx.fragments.cpp.linkopts + getattr(ctx.attr, "linkopts", [])) or []
+    copts = (ctx.fragments.cpp.copts + ctx.fragments.cpp.conlyopts + ctx.attr.copts) or []
+    cxxopts = (ctx.fragments.cpp.copts + ctx.fragments.cpp.cxxopts + ctx.attr.copts) or []
+    linkopts = (ctx.fragments.cpp.linkopts + ctx.attr.linkopts) or []
     defines = _defines_from_deps(ctx)
     use_pic = cc_toolchain_.needs_pic_for_dynamic_libraries(feature_configuration = feature_configuration)
 

--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -34,6 +34,45 @@ load(
 
 CcSharedLibraryInfo = bazel_features.globals.CcSharedLibraryInfo
 
+# Attributes shared by every framework rule (regular `cc_external_rule_impl`-based
+# rules and `built_tools` rules alike).
+FOREIGN_CC_FRAMEWORK_COMMON_ATTRS = {
+    "copts": attr.string_list(
+        doc = "Optional. Add these options to the compile flags passed to the foreign build system. The flags only take affect for compiling this target, not its dependencies.",
+        mandatory = False,
+        default = [],
+    ),
+    "env": attr.string_dict(
+        doc = (
+            "Environment variables to set during the build. " +
+            "`$(execpath)` macros may be used to point at files which are listed as `data`, `deps`, or `build_data`, " +
+            "but unlike with other rules, these will be replaced with absolute paths to those files, " +
+            "because the build does not run in the exec root. " +
+            "This attribute is subject to make variable substitution. " +
+            "No other macros are supported." +
+            "Variables containing `PATH` (e.g. `PATH`, `LD_LIBRARY_PATH`, `CPATH`) entries will be prepended to the existing variable."
+        ),
+        default = {},
+    ),
+    "linkopts": attr.string_list(
+        doc = "Optional link options to be passed up to the dependencies of this library",
+        mandatory = False,
+        default = [],
+    ),
+    "_allow_building_in_tmp": attr.label(
+        default = Label("@rules_foreign_cc//foreign_cc/settings:allow_building_in_tmp"),
+        providers = [BuildSettingInfo],
+    ),
+    "_cc_toolchain": attr.label(
+        default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+    ),
+    "_foreign_cc_framework_platform": attr.label(
+        doc = "Information about the execution platform",
+        cfg = "exec",
+        default = Label("@rules_foreign_cc//foreign_cc/private/framework:platform_info"),
+    ),
+} | PLATFORM_CONSTRAINTS_RULE_ATTRIBUTES | SIZE_ATTRIBUTES
+
 # Dict with definitions of the context attributes, that customize cc_external_rule_impl function.
 # Many of the attributes have default values.
 #
@@ -73,11 +112,6 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
         cfg = "exec",
         default = [],
     ),
-    "copts": attr.string_list(
-        doc = "Optional. Add these options to the compile flags passed to the foreign build system. The flags only take affect for compiling this target, not its dependencies.",
-        mandatory = False,
-        default = [],
-    ),
     "data": attr.label_list(
         doc = "Files needed by this rule at runtime. May list file or rule targets. Generally allows any target.",
         mandatory = False,
@@ -112,17 +146,6 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
         default = [],
         # providers = [CcSharedLibraryInfo],
     ),
-    "env": attr.string_dict(
-        doc = (
-            "Environment variables to set during the build. " +
-            "`$(execpath)` macros may be used to point at files which are listed as `data`, `deps`, or `build_data`, " +
-            "but unlike with other rules, these will be replaced with absolute paths to those files, " +
-            "because the build does not run in the exec root. " +
-            "This attribute is subject to make variable substitution. " +
-            "No other macros are supported." +
-            "Variables containing `PATH` (e.g. `PATH`, `LD_LIBRARY_PATH`, `CPATH`) entries will be prepended to the existing variable."
-        ),
-    ),
     "experimental_validate_outputs_in_action": attr.bool(
         doc = "Validate expected installed outputs inside the main foreign build action before it exits.",
         mandatory = False,
@@ -152,11 +175,6 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
         ),
         mandatory = True,
         allow_files = True,
-    ),
-    "linkopts": attr.string_list(
-        doc = "Optional link options to be passed up to the dependencies of this library",
-        mandatory = False,
-        default = [],
     ),
     "out_bin_dir": attr.string(
         doc = "Optional name of the output subdirectory with the binary files, defaults to 'bin'. ",
@@ -248,24 +266,7 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
         cfg = "exec",
         default = [],
     ),
-    "_allow_building_in_tmp": attr.label(
-        default = Label("@rules_foreign_cc//foreign_cc/settings:allow_building_in_tmp"),
-        providers = [BuildSettingInfo],
-    ),
-    # we need to declare this attribute to access cc_toolchain
-    "_cc_toolchain": attr.label(
-        default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
-    ),
-    "_foreign_cc_framework_platform": attr.label(
-        doc = "Information about the execution platform",
-        cfg = "exec",
-        default = Label("@rules_foreign_cc//foreign_cc/private/framework:platform_info"),
-    ),
-}
-
-# this would be cleaner as x | y, but that's not supported in bazel 5.4.0
-CC_EXTERNAL_RULE_ATTRIBUTES.update(PLATFORM_CONSTRAINTS_RULE_ATTRIBUTES)
-CC_EXTERNAL_RULE_ATTRIBUTES.update(SIZE_ATTRIBUTES)
+} | FOREIGN_CC_FRAMEWORK_COMMON_ATTRS
 
 # A list of common fragments required by rules using this framework
 CC_EXTERNAL_RULE_FRAGMENTS = [


### PR DESCRIPTION
`CC_EXTERNAL_RULE_ATTRIBUTES` and `FOREIGN_CC_BUILT_TOOLS_ATTRS`
duplicated several attributes (env, _allow_building_in_tmp,
_cc_toolchain, _foreign_cc_framework_platform, plus the platform and
size attribute dicts). Lift them — along with `copts` and `linkopts`,
which `built_tools` rules will need next — into a shared
`FOREIGN_CC_FRAMEWORK_COMMON_ATTRS` and merge it into both rule
families.

Now that we no longer support bazel 5, drop the `dict.update` hack and
use `|`. With `copts`/`linkopts` guaranteed on every framework rule,
also drop the `getattr(ctx.attr, "copts", [])` defensiveness in
`cc_toolchain_util`. The standard_cxx_flags test pulls in the shared
dict instead of redeclaring the toolchain attrs.

No behavior change.