### PR TITLE
foreign_cc: honor toolchain copts/linkopts in boost_build and ninja_build

### DIFF
--- a/foreign_cc/boost_build.bzl
+++ b/foreign_cc/boost_build.bzl
@@ -1,6 +1,8 @@
 """ Rule for building Boost from sources. """
 
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("@rules_cc//cc:defs.bzl", "CcInfo")
+load("//foreign_cc/private:cc_toolchain_util.bzl", "absolutize_path_in_str", "get_flags_info", "get_tools_info")
 load("//foreign_cc/private:detect_root.bzl", "detect_root")
 load(
     "//foreign_cc/private:framework.bzl",
@@ -10,6 +12,7 @@ load(
     "create_attrs",
     "expand_locations_and_make_variables",
 )
+load("//foreign_cc/private/framework:helpers.bzl", "escape_dquote_bash")
 
 def _boost_build_impl(ctx):
     attrs = create_attrs(
@@ -20,21 +23,103 @@ def _boost_build_impl(ctx):
     )
     return cc_external_rule_impl(ctx, attrs)
 
+def _absolutize(workspace_name, text, force = False):
+    return absolutize_path_in_str(workspace_name, "$$EXT_BUILD_ROOT$$/", text, force)
+
+def _join_flags_list(workspace_name, flags):
+    return " ".join([escape_dquote_bash(_absolutize(workspace_name, flag)) for flag in flags])
+
+# Map Bazel cc_toolchain.compiler values to b2 toolset names. Returns None
+# for compilers we don't recognize, in which case we fall back to today's
+# free-feature cmdline route (which has the apple-placeholder caveat).
+def _b2_toolset(compiler):
+    # `clang-cl` is clang in MSVC mode; b2's clang toolset can't drive it.
+    if compiler == "clang-cl":
+        return None
+    if compiler.startswith("clang"):
+        return "clang"
+    if compiler.startswith("gcc") or compiler.startswith("mingw-gcc"):
+        return "gcc"
+    if compiler == "msvc-cl":
+        return "msvc"
+    return None
+
+def _user_supplied_toolset(user_options):
+    for opt in user_options:
+        if opt.startswith("toolset=") or opt == "--user-config" or opt.startswith("--user-config="):
+            return True
+    return False
+
+def _jam_quote(text):
+    # b2's jam parser accepts double-quoted strings with backslash escaping.
+    # Escape backslashes first, then quotes.
+    return text.replace("\\", "\\\\").replace("\"", "\\\"")
+
+def _jam_property_line(prop, flag):
+    return "    <{}>\"{}\"".format(prop, _jam_quote(flag))
+
+def _b2_free_feature(workspace_name, name, flags):
+    if not flags:
+        return ""
+    return "{}=\"{}\"".format(name, _join_flags_list(workspace_name, flags))
+
 def _create_configure_script(configureParameters):
     ctx = configureParameters.ctx
     root = detect_root(ctx.attr.lib_source)
     data = ctx.attr.data + ctx.attr.build_data
     user_options = expand_locations_and_make_variables(ctx, ctx.attr.user_options, "user_options", data)
 
-    return [
+    flags = get_flags_info(ctx)
+    cc_toolchain = find_cpp_toolchain(ctx)
+    tools = get_tools_info(ctx)
+
+    toolset = _b2_toolset(cc_toolchain.compiler)
+    pin_compiler = toolset and not _user_supplied_toolset(user_options)
+
+    script = [
         "cd $INSTALLDIR",
         "##copy_dir_contents_to_dir## $$EXT_BUILD_ROOT$$/{}/. .".format(root),
         "chmod -R +w .",
         "##enable_tracing##",
         "./bootstrap.sh {}".format(" ".join(ctx.attr.bootstrap_options)),
-        "./b2 install {} --prefix=.".format(" ".join(user_options)),
-        "##disable_tracing##",
     ]
+
+    b2_extra_args = []
+    if pin_compiler:
+        # Pin b2 to the Bazel cc_toolchain compiler via a generated
+        # `user-config.jam`. Without this b2 discovers `clang++`/`g++` from
+        # PATH and bypasses any toolchain wrappers — on apple this means
+        # placeholders like __BAZEL_XCODE_SDKROOT__ leak through to clang
+        # because apple_support's `wrapped_clang` shim never runs.
+        absolute_cxx = _absolutize(ctx.workspace_name, tools.cxx, True)
+        jam_lines = ["using {} : : \"{}\" :".format(toolset, absolute_cxx)]
+        for flag in flags.cxx:
+            jam_lines.append(_jam_property_line("cxxflags", flag))
+        for flag in flags.cxx_linker_executable:
+            jam_lines.append(_jam_property_line("linkflags", flag))
+        jam_lines.append("    ;")
+
+        # Note: unquoted heredoc so $$EXT_BUILD_ROOT$$ in the compiler path
+        # expands. Toolchain flags don't contain literal `$`, so unquoted is
+        # safe; if that ever changes we'd need to split the heredoc.
+        script.append("cat > user-config.jam <<EOF")
+        script.extend(jam_lines)
+        script.append("EOF")
+        b2_extra_args.append("--user-config=user-config.jam")
+        b2_extra_args.append("toolset={}".format(toolset))
+    else:
+        b2_extra_args.extend([
+            opt
+            for opt in [
+                _b2_free_feature(ctx.workspace_name, "cxxflags", flags.cxx),
+                _b2_free_feature(ctx.workspace_name, "linkflags", flags.cxx_linker_executable),
+            ]
+            if opt
+        ])
+
+    script.append("./b2 install {} {} --prefix=.".format(" ".join(b2_extra_args), " ".join(user_options)))
+    script.append("##disable_tracing##")
+    return script
 
 def _attrs():
     attrs = dict(CC_EXTERNAL_RULE_ATTRIBUTES)

--- a/foreign_cc/built_tools/ninja_build.bzl
+++ b/foreign_cc/built_tools/ninja_build.bzl
@@ -7,7 +7,10 @@ load(
     "FOREIGN_CC_BUILT_TOOLS_HOST_FRAGMENTS",
     "absolutize",
     "built_tool_rule_impl",
+    "split_system_include_flags",
 )
+load("//foreign_cc/private:cc_toolchain_util.bzl", "get_flags_info", "get_tools_info")
+load("//foreign_cc/private/framework:helpers.bzl", "escape_dquote_bash")
 load("//foreign_cc/private/framework:platform.bzl", "os_name")
 
 def _ninja_tool_impl(ctx):
@@ -20,8 +23,39 @@ def _ninja_tool_impl(ctx):
 
     absolute_py_interpreter_path = absolutize(ctx.workspace_name, py_toolchain.py3_runtime.interpreter.path, True)
 
+    # ninja's configure.py honors CXX / CXXFLAGS / LDFLAGS from the env
+    # during --bootstrap; forward the Bazel toolchain compiler and flags so
+    # toolchain copts/linkopts reach the bootstrap compile rather than
+    # whatever `c++` happens to be on PATH.
+    flags = get_flags_info(ctx)
+    tools = get_tools_info(ctx)
+
+    cxxflags = flags.cxx
+    ldflags = flags.cxx_linker_executable
+
+    # configure.py invokes $CXX once with both compile- and link-style
+    # arguments; --sysroot / -isystem must reach both that invocation and
+    # any sub-link. Append them directly to CXX so they're always present.
+    system_cxx, plain_cxx = split_system_include_flags(cxxflags)
+    system_ld, plain_ld = split_system_include_flags(ldflags)
+
+    absolute_cxx = absolutize(ctx.workspace_name, tools.cxx, True)
+    if system_cxx:
+        absolute_cxx += " " + _join_flags_list(ctx.workspace_name, system_cxx)
+    if system_ld:
+        absolute_cxx += " " + _join_flags_list(ctx.workspace_name, system_ld)
+
+    bootstrap_env = ["CXX=\"{}\"".format(absolute_cxx)]
+    if plain_cxx:
+        bootstrap_env.append("CXXFLAGS=\"{}\"".format(_join_flags_list(ctx.workspace_name, plain_cxx)))
+    if plain_ld:
+        bootstrap_env.append("LDFLAGS=\"{}\"".format(_join_flags_list(ctx.workspace_name, plain_ld)))
+
     script = [
-        "\"{}\" ./configure.py --bootstrap".format(absolute_py_interpreter_path),
+        "{} \"{}\" ./configure.py --bootstrap".format(
+            " ".join(bootstrap_env),
+            absolute_py_interpreter_path,
+        ),
         "mkdir \"$$INSTALLDIR$$/bin\"",
         "cp -p ./ninja{} \"$$INSTALLDIR$$/bin/\"".format(
             ".exe" if "win" in os_name(ctx) else "",
@@ -35,6 +69,9 @@ def _ninja_tool_impl(ctx):
         "BootstrapNinjaBuild",
         additional_tools,
     )
+
+def _join_flags_list(workspace_name, flags):
+    return " ".join([escape_dquote_bash(absolutize(workspace_name, flag)) for flag in flags])
 
 ninja_tool = rule(
     doc = "Rule for building Ninja. Invokes configure script.",


### PR DESCRIPTION
`boost_build` and `ninja_build` advertise `copts` / `linkopts` (via the
shared attr dict) but never call `get_flags_info` — toolchain flags
go nowhere. Wire them through:

- `boost_build` forwards toolchain flags as b2 free features
  (`cxxflags="…" linkflags="…"`); they accumulate cleanly with any
  user-supplied `user_options`. Note: b2 doesn't read `$CC` / `$CXX`
  from the env, so the toolchain compiler is still picked by
  `bootstrap.sh` — pinning it would require generating a
  `user-config.jam`, which is left as future work.
- `ninja_build` forwards `CXX` / `CXXFLAGS` / `LDFLAGS` to
  `configure.py --bootstrap`, which honors them from the env.
  `--sysroot` / `-isystem` are appended to `CXX` directly because
  `configure.py` invokes `$CXX` once with both compile- and link-style
  arguments.