### PR TITLE
cmake: add armv7 and x86_32 support with OS-aware processor values

### DIFF
--- a/foreign_cc/private/cmake_script.bzl
+++ b/foreign_cc/private/cmake_script.bzl
@@ -18,53 +18,80 @@ def _escape_dquote_bash_crosstool(text):
     # We use a starlark raw string to prevent the need to escape backslashes for starlark as well.
     return text.replace('"', r'\\\\\\\"')
 
-_TARGET_OS_PARAMS = {
-    "android": {
-        "ANDROID": "YES",
-        "CMAKE_SYSTEM_NAME": "Linux",
-    },
-    "emscripten": {
-        "CMAKE_SYSTEM_NAME": "Emscripten",
-    },
-    "ios": {
-        "CMAKE_SYSTEM_NAME": "iOS",
-    },
-    "linux": {
-        "CMAKE_SYSTEM_NAME": "Linux",
-    },
-    "macos": {
-        "CMAKE_SYSTEM_NAME": "Darwin",
-    },
-    "tvos": {
-        "CMAKE_SYSTEM_NAME": "tvOS",
-    },
-    "watchos": {
-        "CMAKE_SYSTEM_NAME": "watchOS",
-    },
+_CMAKE_SYSTEM_NAME = {
+    "android": "Linux",
+    "emscripten": "Emscripten",
+    "ios": "iOS",
+    "linux": "Linux",
+    "macos": "Darwin",
+    "tvos": "tvOS",
+    "watchos": "watchOS",
 }
 
-_TARGET_ARCH_PARAMS = {
-    "aarch64": {
-        "CMAKE_SYSTEM_PROCESSOR": "aarch64",
-    },
-    "ppc64le": {
-        "CMAKE_SYSTEM_PROCESSOR": "ppc64le",
-    },
-    "s390x": {
-        "CMAKE_SYSTEM_PROCESSOR": "s390x",
-    },
+# CMAKE_SYSTEM_PROCESSOR values for architectures whose value does not depend on
+# the target OS. Architectures that need an OS-dependent value (e.g. armv7) are
+# intentionally absent and handled as exceptions in `_cmake_target_params`.
+_CMAKE_SYSTEM_PROCESSOR = {
+    "aarch64": "aarch64",
+    "ppc64le": "ppc64le",
+    "s390x": "s390x",
     # Emscripten configures CMAKE_SYSTEM_PROCESSOR as follows for compatibility with libraries such as OpenCV
     # https://github.com/emscripten-core/emscripten/blob/79ee3d1/cmake/Modules/Platform/Emscripten.cmake#L23-L30
-    "wasm32": {
-        "CMAKE_SYSTEM_PROCESSOR": "x86",
-    },
-    "wasm64": {
-        "CMAKE_SYSTEM_PROCESSOR": "x86_64",
-    },
-    "x86_64": {
-        "CMAKE_SYSTEM_PROCESSOR": "x86_64",
-    },
+    "wasm32": "x86",
+    "wasm64": "x86_64",
+    # CMAKE_SYSTEM_PROCESSOR should match `uname -m`
+    # (https://cmake.org/cmake/help/latest/variable/CMAKE_HOST_SYSTEM_PROCESSOR.html),
+    # which is `i686` on 32-bit x86: the kernel starts the machine string as
+    # `i386` and rewrites the family digit to the (capped) CPU family
+    # (https://github.com/torvalds/linux/blob/v6.14/arch/x86/kernel/cpu/common.c#L2379-L2380).
+    "x86_32": "i686",
+    "x86_64": "x86_64",
 }
+
+def _cmake_target_params(current_label, target_os, target_arch):
+    """Return the CMake cross-compile params for a target (os, arch) pair.
+
+    Most architectures map to a single processor name regardless of OS (see
+    `_CMAKE_SYSTEM_PROCESSOR`); the exceptions are handled inline. Fails with a
+    specific diagnostic if the OS or arch is unsupported.
+
+    Args:
+        current_label: The label of the target currently being built
+        target_os: The normalized target OS name
+        target_arch: The normalized target arch name
+
+    Returns:
+        dict: CMake cache/toolchain values for the target platform
+    """
+    if target_os not in _CMAKE_SYSTEM_NAME:
+        fail("target_os", target_os, "is not supported, please update foreign_cc/private/cmake_script.bzl; triggered by", current_label)
+
+    params = {}
+    if target_os == "android":
+        params["ANDROID"] = "YES"
+    params["CMAKE_SYSTEM_NAME"] = _CMAKE_SYSTEM_NAME[target_os]
+
+    if target_arch == "armv7":
+        # CMAKE_SYSTEM_PROCESSOR should match `uname -m`
+        # (https://cmake.org/cmake/help/latest/variable/CMAKE_HOST_SYSTEM_PROCESSOR.html),
+        # which is `armv7l` on Linux: the kernel builds the machine string from
+        # the arch name `armv7`
+        # (https://github.com/torvalds/linux/blob/v6.14/arch/arm/mm/proc-v7.S#L644)
+        # plus the endianness char `l`
+        # (https://github.com/torvalds/linux/blob/v6.14/arch/arm/kernel/setup.c#L723-L724).
+        # On Android it is instead `armv7-a`, the NDK's canonical proc value for
+        # the armeabi-v7a ABI, which CMake's NDK support rejects any deviation from
+        # (https://android.googlesource.com/platform/ndk/+/refs/tags/ndk-r28c/meta/abis.json).
+        if target_os == "android":
+            params["CMAKE_SYSTEM_PROCESSOR"] = "armv7-a"
+        else:
+            params["CMAKE_SYSTEM_PROCESSOR"] = "armv7l"
+    elif target_arch in _CMAKE_SYSTEM_PROCESSOR:
+        params["CMAKE_SYSTEM_PROCESSOR"] = _CMAKE_SYSTEM_PROCESSOR[target_arch]
+    else:
+        fail("target_arch", target_arch, "is not supported, please update foreign_cc/private/cmake_script.bzl; triggered by", current_label)
+
+    return params
 
 def create_cmake_script(
         workspace_name,
@@ -136,15 +163,7 @@ def create_cmake_script(
     elif target_os != host_os or target_arch != host_arch:
         # if we don't have a value here, it will end up attempting a native
         # compile, even if that's not right, so emit a warning
-        if target_os in _TARGET_OS_PARAMS:
-            toolchain_dict.update(_TARGET_OS_PARAMS[target_os])
-        else:
-            fail("target_os", target_os, "is not in _TARGET_OS_PARAMS, please update foreign_cc/private/cmake_script.bzl; triggered by", current_label)
-
-        if target_arch in _TARGET_ARCH_PARAMS:
-            toolchain_dict.update(_TARGET_ARCH_PARAMS[target_arch])
-        else:
-            fail("target_arch", target_arch, "is not in _TARGET_ARCH_PARAMS, please update foreign_cc/private/cmake_script.bzl; triggered by", current_label)
+        toolchain_dict.update(_cmake_target_params(current_label, target_os, target_arch))
 
     keys_with_empty_values_in_user_cache = [key for key in user_cache if user_cache.get(key) == ""]
 
@@ -528,6 +547,7 @@ export_for_test = struct(
     move_dict_values = _move_dict_values,
     reverse_descriptor_dict = _reverse_descriptor_dict,
     merge_toolchain_and_user_values = _merge_toolchain_and_user_values,
+    cmake_target_params = _cmake_target_params,
     CMAKE_ENV_VARS_FOR_CROSSTOOL = _CMAKE_ENV_VARS_FOR_CROSSTOOL,
     CMAKE_CACHE_ENTRIES_CROSSTOOL = _CMAKE_CACHE_ENTRIES_CROSSTOOL,
 )

--- a/foreign_cc/private/framework/platform.bzl
+++ b/foreign_cc/private/framework/platform.bzl
@@ -2,10 +2,12 @@
 
 SUPPORTED_CPU = [
     "aarch64",
+    "armv7",
     "ppc64le",
     "s390x",
     "wasm32",
     "wasm64",
+    "x86_32",
     "x86_64",
 ]
 
@@ -188,10 +190,14 @@ def triplet_name(os, arch):
         # consistently, I don't think this will break alpine.
         if arch == "aarch64":
             return "aarch64-unknown-linux-gnu"
+        elif arch == "armv7":
+            return "armv7l-unknown-linux-gnueabihf"
         elif arch == "ppc64le":
             return "powerpc64le-unknown-linux-gnu"
         elif arch == "s390x":
             return "s390x-ibm-linux-gnu"
+        elif arch == "x86_32":
+            return "i686-pc-linux-gnu"
         elif arch == "x86_64":
             return "x86_64-pc-linux-gnu"
 

--- a/test/cmake_text_tests.bzl
+++ b/test/cmake_text_tests.bzl
@@ -698,6 +698,25 @@ cmake -DCMAKE_AR="/cxx_linker_static" -DCMAKE_CXX_LINK_EXECUTABLE="became" -DCMA
 
     return unittest.end(env)
 
+def _cmake_target_params_test(ctx):
+    env = unittest.begin(ctx)
+
+    # format: (target_os, target_arch): expected CMAKE_SYSTEM_PROCESSOR
+    cases = {
+        ("android", "armv7"): "armv7-a",
+        ("android", "x86_32"): "i686",
+        ("linux", "aarch64"): "aarch64",
+        ("linux", "armv7"): "armv7l",
+        ("linux", "x86_32"): "i686",
+        ("linux", "x86_64"): "x86_64",
+    }
+
+    for (target_os, target_arch), expected_processor in cases.items():
+        params = export_for_test.cmake_target_params(ctx.label, target_os, target_arch)
+        asserts.equals(env, expected_processor, params["CMAKE_SYSTEM_PROCESSOR"])
+
+    return unittest.end(env)
+
 def _create_cmake_script_windows_no_toolchain_file_test(ctx):
     env = unittest.begin(ctx)
 
@@ -937,6 +956,7 @@ create_cmake_script_no_toolchain_file_test = unittest.make(_create_cmake_script_
 create_cmake_script_toolchain_file_test = unittest.make(_create_cmake_script_toolchain_file_test)
 create_cmake_script_android_test = unittest.make(_create_cmake_script_android_test)
 create_cmake_script_linux_test = unittest.make(_create_cmake_script_linux_test)
+cmake_target_params_test = unittest.make(_cmake_target_params_test)
 create_cmake_script_windows_no_toolchain_file_test = unittest.make(_create_cmake_script_windows_no_toolchain_file_test)
 create_cmake_script_windows_toolchain_file_test = unittest.make(_create_cmake_script_windows_toolchain_file_test)
 merge_flag_values_no_toolchain_file_test = unittest.make(_merge_flag_values_no_toolchain_file_test)
@@ -958,6 +978,7 @@ def cmake_script_test_suite():
         partial.make(create_cmake_script_toolchain_file_test, size = "small"),
         partial.make(create_cmake_script_android_test, size = "small"),
         partial.make(create_cmake_script_linux_test, size = "small"),
+        partial.make(cmake_target_params_test, size = "small"),
         partial.make(create_cmake_script_windows_no_toolchain_file_test, size = "small"),
         partial.make(create_cmake_script_windows_toolchain_file_test, size = "small"),
         partial.make(merge_flag_values_no_toolchain_file_test, size = "small"),


### PR DESCRIPTION
Based on #1541 by @jagobagascon; should fix #1540 (android cmake builds for armeabi-v7a/x86 failing with "target_arch is unknown").

`x86_32` is `i686` everywhere. `armv7` depends on the target OS: Linux reports `armv7l` (`uname -m` / config.guess), but CMake's NDK support only accepts `armv7-a` and `FATAL_ERROR`s on anything else (see [`Android-Determine.cmake`](https://gitlab.kitware.com/cmake/cmake/-/blob/v3.31.12/Modules/Platform/Android-Determine.cmake#L358)), which mirrors the NDK's canonical [`meta/abis.json`](https://android.googlesource.com/platform/ndk/+/refs/tags/ndk-r28c/meta/abis.json) (`armeabi-v7a` -> `armv7-a`, `x86` -> `i686`). So the static `_TARGET_OS_PARAMS` / `_TARGET_ARCH_PARAMS` dicts are replaced with a single `_cmake_target_params(os, arch)` function (mirroring `triplet_name`), with armv7 handled inline as the exception.

`triplet_name` gets the config.guess linux triplets `armv7l-unknown-linux-gnueabihf` and `i686-pc-linux-gnu` for the autotools path. (We have no known users of android/autotools, so triplet_name doesn't support it currently).