### PR TITLE
examples: harden third_party download mirrors

### DIFF
--- a/examples/third_party/apr_util/apr_util_repositories.bzl
+++ b/examples/third_party/apr_util/apr_util_repositories.bzl
@@ -11,7 +11,8 @@ def apr_util_repositories():
         integrity = "sha256-K3TYkycDgmhiyjBbCU7vKYPCeznVyUFEQumXaprPGYM=",
         strip_prefix = "apr-util-1.6.3",
         urls = [
-            "https://dlcdn.apache.org//apr/apr-util-1.6.3.tar.gz",
+            "https://dlcdn.apache.org/apr/apr-util-1.6.3.tar.gz",
+            "https://archive.apache.org/dist/apr/apr-util-1.6.3.tar.gz",
         ],
     )
 

--- a/examples/third_party/bison/bison_repositories.bzl
+++ b/examples/third_party/bison/bison_repositories.bzl
@@ -12,6 +12,9 @@ def bison_repositories():
         strip_prefix = "bison-3.8.2",
         urls = [
             "https://mirror.bazel.build/ftp.gnu.org/gnu/bison/bison-3.8.2.tar.xz",
+            "https://mirrors.kernel.org/gnu/bison/bison-3.8.2.tar.xz",
+            "https://mirror.csclub.uwaterloo.ca/gnu/bison/bison-3.8.2.tar.xz",
+            "https://ftp.gnu.org/gnu/bison/bison-3.8.2.tar.xz",
         ],
         integrity = "sha256-m7oCFMz38QecXVkhAEUie89hlRmEDr+oDNOEnP9aW/I=",
     )

--- a/examples/third_party/cares/cares_repositories.bzl
+++ b/examples/third_party/cares/cares_repositories.bzl
@@ -8,10 +8,10 @@ def cares_repositories():
         http_archive,
         name = "cares",
         build_file = Label("//cares:BUILD.cares.bazel"),
-        sha256 = "4358939ff800b13b92f37d5fdda003718101faedfbdee792d6b79ddc1a53d890",
+        sha256 = "912dd7cc3b3e8a79c52fd7fb9c0f4ecf0aaa73e45efda880266a2d6e26b84ef5",
         strip_prefix = "c-ares-1.34.6",
         urls = [
-            "https://mirror.bazel.build/github.com/c-ares/c-ares/archive/refs/tags/v1.34.6.tar.gz",
-            "https://github.com/c-ares/c-ares/archive/refs/tags/v1.34.6.tar.gz",
+            "https://mirror.bazel.build/github.com/c-ares/c-ares/releases/download/v1.34.6/c-ares-1.34.6.tar.gz",
+            "https://github.com/c-ares/c-ares/releases/download/v1.34.6/c-ares-1.34.6.tar.gz",
         ],
     )

--- a/examples/third_party/glib/glib_repositories.bzl
+++ b/examples/third_party/glib/glib_repositories.bzl
@@ -26,7 +26,12 @@ def glib_repositories():
         build_file = Label("//glib:BUILD.gettext.bazel"),
         strip_prefix = "gettext-0.21.1",
         sha256 = "e8c3650e1d8cee875c4f355642382c1df83058bd5a11ee8555c0cf276d646d45",
-        url = "https://ftpmirror.gnu.org/gnu/gettext/gettext-0.21.1.tar.gz",
+        urls = [
+            "https://mirrors.kernel.org/gnu/gettext/gettext-0.21.1.tar.gz",
+            "https://mirror.csclub.uwaterloo.ca/gnu/gettext/gettext-0.21.1.tar.gz",
+            "https://ftp.gnu.org/gnu/gettext/gettext-0.21.1.tar.gz",
+            "https://ftpmirror.gnu.org/gnu/gettext/gettext-0.21.1.tar.gz",
+        ],
     )
     maybe(
         http_archive,

--- a/examples/third_party/iconv/iconv_repositories.bzl
+++ b/examples/third_party/iconv/iconv_repositories.bzl
@@ -8,6 +8,8 @@ def iconv_repositories():
         http_archive,
         name = "iconv",
         urls = [
+            "https://mirrors.kernel.org/gnu/libiconv/libiconv-1.16.tar.gz",
+            "https://mirror.csclub.uwaterloo.ca/gnu/libiconv/libiconv-1.16.tar.gz",
             "https://ftp.gnu.org/gnu/libiconv/libiconv-1.16.tar.gz",
             "https://ftpmirror.gnu.org/gnu/libiconv/libiconv-1.16.tar.gz",
         ],

--- a/examples/third_party/libpng/libpng_repositories.bzl
+++ b/examples/third_party/libpng/libpng_repositories.bzl
@@ -12,5 +12,6 @@ def libpng_repositories():
         strip_prefix = "libpng-1.6.43",
         urls = [
             "https://downloads.sourceforge.net/project/libpng/libpng16/1.6.43/libpng-1.6.43.tar.xz",
+            "https://download.sourceforge.net/libpng/libpng-1.6.43.tar.xz",
         ],
     )

--- a/examples/third_party/mesa/mesa_repositories.bzl
+++ b/examples/third_party/mesa/mesa_repositories.bzl
@@ -26,7 +26,10 @@ def mesa_repositories():
         ],
         sha256 = "670d8cbe8b72902a45ea2da68a9da4dc4a5d99c5953a926177adbce1b1640b76",
         strip_prefix = "mesa-22.1.4",
-        urls = ["https://archive.mesa3d.org/older-versions/22.x/mesa-22.1.4.tar.xz"],
+        urls = [
+            "https://archive.mesa3d.org/older-versions/22.x/mesa-22.1.4.tar.xz",
+            "https://mesa.freedesktop.org/archive/older-versions/22.x/mesa-22.1.4.tar.xz",
+        ],
     )
 
     maybe(
@@ -35,7 +38,10 @@ def mesa_repositories():
         build_file = Label("//mesa:BUILD.libpciaccess.bazel"),
         sha256 = "84413553994aef0070cf420050aa5c0a51b1956b404920e21b81e96db6a61a27",
         strip_prefix = "libpciaccess-0.16",
-        url = "https://www.x.org/archive//individual/lib/libpciaccess-0.16.tar.gz",
+        urls = [
+            "https://www.x.org/archive/individual/lib/libpciaccess-0.16.tar.gz",
+            "https://mirror.csclub.uwaterloo.ca/x.org/individual/lib/libpciaccess-0.16.tar.gz",
+        ],
     )
 
     maybe(
@@ -80,7 +86,10 @@ def mesa_repositories():
         build_file = Label("//mesa:BUILD.xcb-proto.bazel"),
         sha256 = "d34c3b264e8365d16fa9db49179cfa3e9952baaf9275badda0f413966b65955f",
         strip_prefix = "xcb-proto-1.15",
-        url = "https://xcb.freedesktop.org/dist/xcb-proto-1.15.tar.xz",
+        urls = [
+            "https://xcb.freedesktop.org/dist/xcb-proto-1.15.tar.xz",
+            "https://mirror.csclub.uwaterloo.ca/x.org/individual/proto/xcb-proto-1.15.tar.xz",
+        ],
     )
 
     maybe(
@@ -89,7 +98,10 @@ def mesa_repositories():
         build_file = Label("//mesa:BUILD.libxshmfence.bazel"),
         sha256 = "7eb3d46ad91bab444f121d475b11b39273142d090f7e9ac43e6a87f4ff5f902c",
         strip_prefix = "libxshmfence-1.3",
-        url = "https://www.x.org/releases/individual/lib/libxshmfence-1.3.tar.gz",
+        urls = [
+            "https://www.x.org/releases/individual/lib/libxshmfence-1.3.tar.gz",
+            "https://mirror.csclub.uwaterloo.ca/x.org/individual/lib/libxshmfence-1.3.tar.gz",
+        ],
     )
 
     maybe(
@@ -98,7 +110,10 @@ def mesa_repositories():
         build_file = Label("//mesa:BUILD.libxau.bazel"),
         sha256 = "8be6f292334d2f87e5b919c001e149a9fdc27005d6b3e053862ac6ebbf1a0c0a",
         strip_prefix = "libXau-1.0.10",
-        url = "https://www.x.org/pub/individual/lib/libXau-1.0.10.tar.xz",
+        urls = [
+            "https://www.x.org/pub/individual/lib/libXau-1.0.10.tar.xz",
+            "https://mirror.csclub.uwaterloo.ca/x.org/individual/lib/libXau-1.0.10.tar.xz",
+        ],
     )
 
     maybe(
@@ -107,7 +122,10 @@ def mesa_repositories():
         build_file = Label("//mesa:BUILD.xorgproto.bazel"),
         sha256 = "5d13dbf2be08f95323985de53352c4f352713860457b95ccaf894a647ac06b9e",
         strip_prefix = "xorgproto-2022.2",
-        url = "https://xorg.freedesktop.org/archive/individual/proto/xorgproto-2022.2.tar.xz",
+        urls = [
+            "https://xorg.freedesktop.org/archive/individual/proto/xorgproto-2022.2.tar.xz",
+            "https://mirror.csclub.uwaterloo.ca/x.org/individual/proto/xorgproto-2022.2.tar.xz",
+        ],
     )
 
     maybe(
@@ -116,7 +134,10 @@ def mesa_repositories():
         build_file = Label("//mesa:BUILD.libxdmcp.bazel"),
         sha256 = "2dce5cc317f8f0b484ec347d87d81d552cdbebb178bd13c5d8193b6b7cd6ad00",
         strip_prefix = "libXdmcp-1.1.4",
-        url = "https://www.x.org/pub/individual/lib/libXdmcp-1.1.4.tar.xz",
+        urls = [
+            "https://www.x.org/pub/individual/lib/libXdmcp-1.1.4.tar.xz",
+            "https://mirror.csclub.uwaterloo.ca/x.org/individual/lib/libXdmcp-1.1.4.tar.xz",
+        ],
     )
 
     maybe(
@@ -125,7 +146,10 @@ def mesa_repositories():
         build_file = Label("//mesa:BUILD.libx11.bazel"),
         sha256 = "081bf42ebab023aa92cfdb20c7af8c5ae13d13e88a5e22f90f4453ef80bbdde4",
         strip_prefix = "libX11-1.8",
-        url = "https://www.x.org/archive/individual/lib/libX11-1.8.tar.xz",
+        urls = [
+            "https://www.x.org/archive/individual/lib/libX11-1.8.tar.xz",
+            "https://mirror.csclub.uwaterloo.ca/x.org/individual/lib/libX11-1.8.tar.xz",
+        ],
     )
 
     maybe(
@@ -134,7 +158,10 @@ def mesa_repositories():
         build_file = Label("//mesa:BUILD.libxrandr.bazel"),
         sha256 = "897639014a78e1497704d669c5dd5682d721931a4452c89a7ba62676064eb428",
         strip_prefix = "libXrandr-1.5.3",
-        url = "https://www.x.org/archive/individual/lib/libXrandr-1.5.3.tar.xz",
+        urls = [
+            "https://www.x.org/archive/individual/lib/libXrandr-1.5.3.tar.xz",
+            "https://mirror.csclub.uwaterloo.ca/x.org/individual/lib/libXrandr-1.5.3.tar.xz",
+        ],
     )
 
     maybe(
@@ -143,7 +170,10 @@ def mesa_repositories():
         build_file = Label("//mesa:BUILD.libxext.bazel"),
         sha256 = "db14c0c895c57ea33a8559de8cb2b93dc76c42ea4a39e294d175938a133d7bca",
         strip_prefix = "libXext-1.3.5",
-        url = "https://www.x.org/archive/individual/lib/libXext-1.3.5.tar.xz",
+        urls = [
+            "https://www.x.org/archive/individual/lib/libXext-1.3.5.tar.xz",
+            "https://mirror.csclub.uwaterloo.ca/x.org/individual/lib/libXext-1.3.5.tar.xz",
+        ],
     )
 
     maybe(
@@ -152,7 +182,10 @@ def mesa_repositories():
         build_file = Label("//mesa:BUILD.libxrender.bazel"),
         sha256 = "bc53759a3a83d1ff702fb59641b3d2f7c56e05051fa0cfa93501166fa782dc24",
         strip_prefix = "libXrender-0.9.11",
-        url = "https://www.x.org/archive//individual/lib/libXrender-0.9.11.tar.xz",
+        urls = [
+            "https://www.x.org/archive/individual/lib/libXrender-0.9.11.tar.xz",
+            "https://mirror.csclub.uwaterloo.ca/x.org/individual/lib/libXrender-0.9.11.tar.xz",
+        ],
     )
 
     maybe(
@@ -161,7 +194,10 @@ def mesa_repositories():
         build_file = Label("//mesa:BUILD.renderproto.bazel"),
         sha256 = "a0a4be3cad9381ae28279ba5582e679491fc2bec9aab8a65993108bf8dbce5fe",
         strip_prefix = "renderproto-0.11.1",
-        url = "https://www.x.org/releases/individual/proto/renderproto-0.11.1.tar.gz",
+        urls = [
+            "https://www.x.org/releases/individual/proto/renderproto-0.11.1.tar.gz",
+            "https://mirror.csclub.uwaterloo.ca/x.org/individual/proto/renderproto-0.11.1.tar.gz",
+        ],
     )
 
     maybe(
@@ -170,7 +206,10 @@ def mesa_repositories():
         build_file = Label("//mesa:BUILD.xtrans.bazel"),
         sha256 = "48ed850ce772fef1b44ca23639b0a57e38884045ed2cbb18ab137ef33ec713f9",
         strip_prefix = "xtrans-1.4.0",
-        url = "https://www.x.org/archive/individual/lib/xtrans-1.4.0.tar.gz",
+        urls = [
+            "https://www.x.org/archive/individual/lib/xtrans-1.4.0.tar.gz",
+            "https://mirror.csclub.uwaterloo.ca/x.org/individual/lib/xtrans-1.4.0.tar.gz",
+        ],
     )
 
     maybe(
@@ -179,7 +218,10 @@ def mesa_repositories():
         build_file = Label("//mesa:BUILD.libpthread-stubs.bazel"),
         sha256 = "f8f7ca635fa54bcaef372fd5fd9028f394992a743d73453088fcadc1dbf3a704",
         strip_prefix = "libpthread-stubs-0.1",
-        url = "https://www.x.org/archive//individual/lib/libpthread-stubs-0.1.tar.gz",
+        urls = [
+            "https://www.x.org/archive/individual/lib/libpthread-stubs-0.1.tar.gz",
+            "https://mirror.csclub.uwaterloo.ca/x.org/individual/lib/libpthread-stubs-0.1.tar.gz",
+        ],
     )
 
     maybe(
@@ -188,5 +230,8 @@ def mesa_repositories():
         build_file = Label("//mesa:BUILD.libxfixes.bazel"),
         sha256 = "82045da5625350838390c9440598b90d69c882c324ca92f73af9f0e992cb57c7",
         strip_prefix = "libXfixes-6.0.0",
-        url = "https://www.x.org/archive//individual/lib/libXfixes-6.0.0.tar.gz",
+        urls = [
+            "https://www.x.org/archive/individual/lib/libXfixes-6.0.0.tar.gz",
+            "https://mirror.csclub.uwaterloo.ca/x.org/individual/lib/libXfixes-6.0.0.tar.gz",
+        ],
     )

--- a/examples/third_party/openssl/openssl_repositories.bzl
+++ b/examples/third_party/openssl/openssl_repositories.bzl
@@ -12,7 +12,7 @@ def openssl_repositories():
         strip_prefix = "openssl-1.1.1w",
         urls = [
             "https://www.openssl.org/source/openssl-1.1.1w.tar.gz",
-            "https://github.com/openssl/openssl/archive/OpenSSL_1_1_1w.tar.gz",
+            "https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1w/openssl-1.1.1w.tar.gz",
         ],
     )
 

--- a/examples/third_party/pcre/pcre_repositories.bzl
+++ b/examples/third_party/pcre/pcre_repositories.bzl
@@ -12,5 +12,6 @@ def pcre_repositories():
         sha256 = "04e214c0c40a97b8a5c2b4ae88a3aa8a93e6f2e45c6b3534ddac351f26548577",
         urls = [
             "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.37/pcre2-10.37.tar.gz",
+            "https://downloads.sourceforge.net/project/pcre/pcre2/10.37/pcre2-10.37.tar.gz",
         ],
     )

--- a/examples/third_party/zlib/zlib_repositories.bzl
+++ b/examples/third_party/zlib/zlib_repositories.bzl
@@ -16,6 +16,8 @@ def zlib_repositories():
             Label("//zlib:zlib.patch"),
         ],
         urls = [
+            "https://mirror.bazel.build/github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz",
             "https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz",
+            "https://zlib.net/fossils/zlib-1.3.1.tar.gz",
         ],
     )


### PR DESCRIPTION
The examples' third_party fetches are a recurring source of CI flakiness
when a single upstream host is slow or down. This adds verified
byte-identical fallback mirrors to every dep that previously relied on a
single source (or on a single GNU-run host, which are themselves often
unreliable).

Every added URL was checked to serve content matching the recorded
sha256/integrity — http_archive enforces one hash across all URLs, so a
divergent mirror would break the build rather than save it. Notably:

- gettext/iconv/bison: add independent kernel.org and csclub mirrors
  (the prior URLs were all GNU hosts).
- the mesa x.org cluster (libpciaccess, libX*, *proto, etc.): add csclub
  x.org fallbacks, and fix several `/archive//individual` double-slashes.
- zlib/libpng/pcre/apr_util: add sourceforge/archive.apache.org/zlib.net
  fallbacks; drop the `dlcdn.apache.org//apr` double-slash.

Two deps had broken or missing primaries rather than just missing
fallbacks:

- cares: its `mirror.bazel.build` URL 404s (never cached), leaving it
  single-source on a github `/archive/` auto-tarball, whose hash is not
  stable. Switch to the immutable uploaded release asset
  (`c-ares-1.34.6.tar.gz`), which changes the recorded sha256.
- openssl: the github `/archive/` fallback served different bytes than
  the recorded hash (so it would fail checksum, not recover). Replace it
  with the byte-identical uploaded release asset.

ninja 1.13.0 and winflexbison still use github `/archive/` tarballs; no
stable source alternative exists for them, so they're left as-is.