### PR TITLE
test(integration): generalize harness into a scenario() macro

### DIFF
--- a/test/integration/BUILD.bazel
+++ b/test/integration/BUILD.bazel
@@ -1,69 +1,26 @@
 # test/integration/BUILD.bazel
 #
-# A sanity scenario that exercises rules_foreign_cc end-to-end in BOTH
-# WORKSPACE and bzlmod mode from a single test. The scenario dir ships both
-# a MODULE.bazel and a WORKSPACE.bazel; the inner Bazel reads whichever the
-# mode flags select (see runner.sh). The outer mode is detected here and
-# passed in, so a `bazel test` under --enable_workspace tests the WORKSPACE
-# path and one under --enable_bzlmod tests the MODULE.bazel path -- the same
-# coverage a local user gets in their own mode. It is intentionally minimal:
-# it builds a static library via cmake doing exactly what docs/src/index.md
-# tells users to do. The point is regression coverage on the basic entry
-# point that should not change as the bzlmod surface evolves.
-load("@bazel_binaries//:defs.bzl", "bazel_binaries")
-load(
-    "@rules_bazel_integration_test//bazel_integration_test:defs.bzl",
-    "bazel_integration_test",
-    "integration_test_utils",
-)
-load(":bzlmod_enabled.bzl", "BZLMOD_ENABLED")
+# Bazel-in-bazel sanity + API scenarios for rules_foreign_cc. Each scenario is
+# a self-contained workspace under test/integration/<name>/ that an inner Bazel
+# builds; see scenarios.bzl for the shared harness and runner.sh for how the
+# inner build is driven.
+#
+# `basic` is the dual-mode smoke test: it ships both a MODULE.bazel and a
+# WORKSPACE.bazel and runs in whichever mode the outer Bazel uses, building a
+# static library via cmake exactly as docs/src/index.md tells users to. The
+# remaining scenarios are bzlmod-only and exercise the hub-and-spoke `tools`
+# extension surface (modes, register_toolchain, non-root spoke fetching).
+load("//test/integration:scenarios.bzl", "scenario")
 
 package(default_visibility = ["//visibility:private"])
 
 exports_files(["runner.sh"])
 
-# True in the bzlmod and mixed lanes, false in the workspaces lane. We pass it
-# to runner.sh so the inner build runs in the matching pure mode.
-_OUTER_BZLMOD = "1" if BZLMOD_ENABLED else "0"
-
-# These are bazel-in-bazel tests: runner.sh spawns a nested Bazel that
-# builds the scenario. That inner Bazel breaks the outer test's normal
-# isolation in three specific ways:
-#   exclusive      - the inner Bazel starts its own server and is heavy on
-#                    CPU/RAM; only a couple can run at once before
-#                    reliability and runtime suffer. Bazel has no knob to
-#                    cap concurrency, so we serialize entirely.
-#   no-sandbox     - runner.sh runs the inner `bazel build` with no
-#                    --output_user_root, so it defaults its output base to
-#                    $HOME/.cache/bazel. The sandbox confines writes to the
-#                    action's outputs, so those home-dir writes would fail.
-#   no-remote-exec - a nested Bazel server needs a persistent local
-#                    workspace; the CI RBE setup can't run it remotely.
-# rules_python's integration tests use the same three tags for the same
-# reasons (tests/integration/integration_test.bzl).
-_COMMON_TAGS = [
-    "exclusive",
-    "no-sandbox",
-    "no-remote-exec",
-]
-
-# A cold inner build downloads Bazel, then bootstraps GNU Make and pkg-config
-# from source before it can build the cmake target. On slower CI agents (macOS)
-# that overruns the 300s "moderate" budget, so give it the 900s "long" budget.
-bazel_integration_test(
-    name = "basic_test",
-    timeout = "long",
-    bazel_binaries = bazel_binaries,
-    bazel_version = bazel_binaries.versions.current,
-    env = {
-        "EXPECT_BUILD": "//:hello_cmake",
-        "OUTER_BZLMOD": _OUTER_BZLMOD,
-        "SCENARIO": "basic",
-    },
-    tags = _COMMON_TAGS,
-    test_runner = ":runner.sh",
-    workspace_files = integration_test_utils.glob_workspace_files("basic") + [
-        "//:distribution",
-    ],
-    workspace_path = "basic",
+# Dual-mode smoke test -- the only scenario that also runs under WORKSPACE, and
+# the only one that enforces a committed inner lock.
+scenario(
+    name = "basic",
+    dual_mode = True,
+    enforce_lock = True,
+    env = {"EXPECT_BUILD": "//:hello_cmake"},
 )

--- a/test/integration/runner.sh
+++ b/test/integration/runner.sh
@@ -1,22 +1,30 @@
 #!/bin/bash
-# Shared runner for integration scenarios. Invoked by
-# rules_bazel_integration_test for each scenario target.
+# Shared runner for bazel-in-bazel integration scenarios. Invoked by
+# rules_bazel_integration_test for each scenario target (see scenarios.bzl).
 #
 # Required env (set by bazel_integration_test):
 #   BIT_WORKSPACE_DIR - path to the scenario's workspace directory
-#   BIT_BAZEL_BINARY - path to the bazel binary to run
+#   BIT_BAZEL_BINARY  - path to the bazel binary to run
 # Required env (set by the scenario's `env = {...}`):
 #   SCENARIO - scenario name (informational)
-#   EXPECT_BUILD - target to build (must succeed)
+# Mode env (set by the scenario() macro):
+#   DUAL_MODE    - "1" if the scenario ships both MODULE.bazel and
+#                  WORKSPACE.bazel and should run in the outer Bazel's mode.
 #   OUTER_BZLMOD - "1" if the outer (this) Bazel had bzlmod enabled, else "0".
-#                  Computed in BUILD.bazel via `"@@" in str(Label(...))`. We
-#                  run the inner build in the matching pure mode so a local
-#                  `bazel test --enable_workspace` exercises the WORKSPACE path
-#                  and a bzlmod build exercises the MODULE.bazel path. The
-#                  scenario dir ships both files; the flags pick which one the
-#                  inner Bazel reads. We force a pure mode (never mixed) so a
+#                  Only meaningful when DUAL_MODE=1. Computed in BUILD.bazel
+#                  via `"@@" in str(Label(...))`. We run the inner build in the
+#                  matching pure mode so a local `bazel test --enable_workspace`
+#                  exercises the WORKSPACE path and a bzlmod build exercises the
+#                  MODULE.bazel path. We force a pure mode (never mixed) so a
 #                  stray WORKSPACE can't silently satisfy something the
 #                  MODULE.bazel path is supposed to provide.
+#   ENFORCE_LOCK - "1" to pass --lockfile_mode=error on the bzlmod inner build,
+#                  enforcing a committed MODULE.bazel.lock (same as parent CI).
+# Assertion env (at least one expected; set by the scenario's `env = {...}`):
+#   EXPECT_BUILD          - target to build (must succeed)
+#   EXPECT_BUILD_FAIL     - target whose build must fail (non-zero exit)
+#   EXPECT_CQUERY         - cquery expression to run; output is captured
+#   EXPECT_STDOUT_PATTERN - regex that EXPECT_CQUERY's output must match
 set -euo pipefail
 
 # On the RBE lane, bazelci.py injects
@@ -32,17 +40,45 @@ set -euo pipefail
 # non-RBE Ubuntu lanes build identically).
 unset BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN
 
-if [[ "${OUTER_BZLMOD}" == "1" ]]; then
-  # --lockfile_mode=error enforces the committed MODULE.bazel.lock: if rfcc's
-  # resolution drifts, the build fails instead of silently rewriting it (same
-  # as the parent repo's CI). Regenerate with, from this scenario dir:
-  #   USE_BAZEL_VERSION=8.6.0 bazel mod deps --enable_bzlmod --noenable_workspace
-  MODE_FLAGS=(--enable_bzlmod --noenable_workspace --lockfile_mode=error)
-else
+# Pick the inner Bazel's mode. A bzlmod-only scenario always runs pure bzlmod;
+# a dual-mode scenario mirrors the outer Bazel's mode.
+if [[ "${DUAL_MODE:-0}" == "1" && "${OUTER_BZLMOD:-1}" == "0" ]]; then
   MODE_FLAGS=(--noenable_bzlmod --enable_workspace)
+else
+  MODE_FLAGS=(--enable_bzlmod --noenable_workspace)
+  if [[ "${ENFORCE_LOCK:-0}" == "1" ]]; then
+    # --lockfile_mode=error enforces the committed MODULE.bazel.lock: if rfcc's
+    # resolution drifts, the build fails instead of silently rewriting it (same
+    # as the parent repo's CI). Regenerate with, from this scenario dir:
+    #   USE_BAZEL_VERSION=8.6.0 bazel mod deps --enable_bzlmod --noenable_workspace
+    MODE_FLAGS+=(--lockfile_mode=error)
+  fi
 fi
 
 cd "${BIT_WORKSPACE_DIR}"
-echo ">> ${SCENARIO} (OUTER_BZLMOD=${OUTER_BZLMOD}): bazel build ${MODE_FLAGS[*]} ${EXPECT_BUILD}"
-"${BIT_BAZEL_BINARY}" build "${MODE_FLAGS[@]}" "${EXPECT_BUILD}"
+BAZEL="${BIT_BAZEL_BINARY}"
+
+if [[ -n "${EXPECT_BUILD:-}" ]]; then
+  echo ">> ${SCENARIO}: bazel build ${MODE_FLAGS[*]} ${EXPECT_BUILD}"
+  "${BAZEL}" build "${MODE_FLAGS[@]}" "${EXPECT_BUILD}"
+fi
+
+if [[ -n "${EXPECT_BUILD_FAIL:-}" ]]; then
+  echo ">> ${SCENARIO}: bazel build ${MODE_FLAGS[*]} ${EXPECT_BUILD_FAIL} (expecting failure)"
+  if "${BAZEL}" build "${MODE_FLAGS[@]}" "${EXPECT_BUILD_FAIL}"; then
+    echo "FAIL: build was expected to fail but succeeded"
+    exit 1
+  fi
+fi
+
+if [[ -n "${EXPECT_CQUERY:-}" ]]; then
+  echo ">> ${SCENARIO}: bazel cquery ${MODE_FLAGS[*]} ${EXPECT_CQUERY}"
+  output="$("${BAZEL}" cquery "${MODE_FLAGS[@]}" "${EXPECT_CQUERY}" 2>&1)"
+  echo "${output}"
+  if [[ -n "${EXPECT_STDOUT_PATTERN:-}" ]] && ! grep -qE "${EXPECT_STDOUT_PATTERN}" <<<"${output}"; then
+    echo "FAIL: expected pattern '${EXPECT_STDOUT_PATTERN}' not found in output"
+    exit 1
+  fi
+fi
+
 echo ">> ${SCENARIO}: PASS"

--- a/test/integration/scenarios.bzl
+++ b/test/integration/scenarios.bzl
@@ -1,0 +1,100 @@
+# test/integration/scenarios.bzl
+"""Macro for declaring a bazel-in-bazel integration-test scenario.
+
+Each scenario is a self-contained workspace directory under test/integration/.
+The directory is `--deleted_packages`-ed at the outer level (see
+.bazelrc.deleted_packages) so the outer Bazel does not load it as a
+sub-package and `glob_workspace_files()` sees its files as plain inputs.
+
+`workspace_files` always includes `//:distribution` so the rfcc source tree
+is staged into the runfiles tree, letting each scenario's
+`local_path_override(module_name = "rules_foreign_cc", path = "../../..")`
+resolve.
+
+Two scenario shapes share this one harness:
+  * dual_mode = True   - the scenario ships both a MODULE.bazel and a
+                         WORKSPACE.bazel; the inner build runs in whichever
+                         pure mode the outer Bazel uses (detected via
+                         bzlmod_enabled.bzl). Used by the `basic` smoke test
+                         so the workspaces and bzlmod CI lanes each exercise
+                         their own path.
+  * dual_mode = False  - bzlmod-only scenario (ships MODULE.bazel + an empty
+                         WORKSPACE). Used by the hub-and-spoke API scenarios,
+                         which only have meaning under bzlmod.
+"""
+
+load("@bazel_binaries//:defs.bzl", "bazel_binaries")
+load(
+    "@rules_bazel_integration_test//bazel_integration_test:defs.bzl",
+    "bazel_integration_test",
+    "integration_test_utils",
+)
+load(":bzlmod_enabled.bzl", "BZLMOD_ENABLED")
+
+# These are bazel-in-bazel tests: runner.sh spawns a nested Bazel that builds
+# the scenario. That inner Bazel breaks the outer test's normal isolation in
+# three specific ways:
+#   exclusive      - the inner Bazel starts its own server and is heavy on
+#                    CPU/RAM; only a couple can run at once before reliability
+#                    and runtime suffer. Bazel has no knob to cap concurrency,
+#                    so we serialize entirely.
+#   no-sandbox     - runner.sh runs the inner `bazel build` with no
+#                    --output_user_root, so it defaults its output base to
+#                    $HOME/.cache/bazel. The sandbox confines writes to the
+#                    action's outputs, so those home-dir writes would fail.
+#   no-remote-exec - a nested Bazel server needs a persistent local workspace;
+#                    the CI RBE setup can't run it remotely.
+# rules_python's integration tests use the same three tags for the same
+# reasons (tests/integration/integration_test.bzl).
+_COMMON_TAGS = [
+    "exclusive",
+    "no-sandbox",
+    "no-remote-exec",
+]
+
+def scenario(
+        name,
+        env = None,
+        dual_mode = False,
+        enforce_lock = False,
+        timeout = "long",
+        **kwargs):
+    """Declare a bazel-in-bazel integration-test scenario.
+
+    Args:
+      name: scenario directory name under test/integration/.
+      env: dict of assertion env vars passed to runner.sh. Recognized keys:
+           EXPECT_BUILD (target that must build), EXPECT_BUILD_FAIL (target
+           whose build must fail), EXPECT_CQUERY (cquery expression to run),
+           EXPECT_STDOUT_PATTERN (regex EXPECT_CQUERY's output must match).
+      dual_mode: if True, the inner build runs in the outer Bazel's mode
+           (WORKSPACE or bzlmod); if False it always runs under pure bzlmod.
+      enforce_lock: if True, the bzlmod inner build passes
+           --lockfile_mode=error so a committed MODULE.bazel.lock is enforced.
+      timeout: test timeout; defaults to "long" because a cold inner build
+           downloads Bazel and bootstraps make/pkg-config from source.
+      **kwargs: forwarded to bazel_integration_test.
+    """
+    env = dict(env or {})
+    env.setdefault("SCENARIO", name)
+    if dual_mode:
+        env["DUAL_MODE"] = "1"
+
+        # True in the bzlmod and mixed lanes, false in the workspaces lane.
+        env["OUTER_BZLMOD"] = "1" if BZLMOD_ENABLED else "0"
+    if enforce_lock:
+        env["ENFORCE_LOCK"] = "1"
+    bazel_integration_test(
+        name = name + "_test",
+        timeout = timeout,
+        bazel_binaries = bazel_binaries,
+        bazel_version = bazel_binaries.versions.current,
+        test_runner = "//test/integration:runner.sh",
+        workspace_path = name,
+        workspace_files = integration_test_utils.glob_workspace_files(name) + [
+            "//:distribution",
+        ],
+        env = env,
+        tags = (kwargs.pop("tags", None) or []) + _COMMON_TAGS,
+        **kwargs
+    )


### PR DESCRIPTION
Extract the bazel-in-bazel wiring that #1557 inlined for the `basic` smoke
test into a reusable `scenario(name, env=..., dual_mode=..., enforce_lock=...)`
macro in `test/integration/scenarios.bzl`, and generalize `runner.sh` to
interpret `EXPECT_BUILD` / `EXPECT_BUILD_FAIL` / `EXPECT_CQUERY` /
`EXPECT_STDOUT_PATTERN`. `basic` becomes the lone `dual_mode` + `enforce_lock`
scenario.

This is groundwork: it has no behavioral change to the existing test (the
`basic` scenario still builds `//:hello_cmake` in whichever mode the outer
Bazel uses), but it turns the harness into something subsequent commits can
hang additional bzlmod-only hub-and-spoke API scenarios off of, each as its
own self-contained workspace directory.