### PR TITLE
Make the extensions compatible with Bazel 9.x

### DIFF
--- a/toolchains/built_toolchains.bzl
+++ b/toolchains/built_toolchains.bzl
@@ -262,7 +262,7 @@ def _pkgconfig_toolchain(version, register_toolchains):
     maybe(
         http_archive,
         name = "glib_dev",
-        build_file_content = '''
+        build_file_content = '''load("@rules_cc//cc:defs.bzl", "cc_import")
 cc_import(
     name = "glib_dev",
     hdrs = glob(["include/**"]),
@@ -280,7 +280,7 @@ cc_import(
     maybe(
         http_archive,
         name = "glib_src",
-        build_file_content = '''
+        build_file_content = '''load("@rules_cc//cc:defs.bzl", "cc_import")
 cc_import(
     name = "msvc_hdr",
     hdrs = ["msvc_recommended_pragmas.h"],
@@ -320,7 +320,7 @@ exports_files(
     maybe(
         http_archive,
         name = "gettext_runtime",
-        build_file_content = '''
+        build_file_content = '''load("@rules_cc//cc:defs.bzl", "cc_import")
 cc_import(
     name = "gettext_runtime",
     shared_library = "bin/libintl-8.dll",


### PR DESCRIPTION
I have found that on MSVC we are hitting import errors when using Bazel 9.x. Example:
https://buildkite.com/bazel/bcr-presubmit/builds/35775/canvas?jid=019eaeb8-b267-462c-bf7b-77c4cbfc6230&tab=output

This PR is an attempt to fix this issue.