### PR TITLE
toolchains: use rules_cc's msvc-cl config_setting

### DIFF
--- a/examples/third_party/apr/BUILD.apr.bazel
+++ b/examples/third_party/apr/BUILD.apr.bazel
@@ -10,18 +10,10 @@ filegroup(
     ),
 )
 
-config_setting(
-    name = "msvc_compiler",
-    flag_values = {
-        "@bazel_tools//tools/cpp:compiler": "msvc-cl",
-    },
-    visibility = ["//visibility:public"],
-)
-
 alias(
     name = "apr",
     actual = select({
-        ":msvc_compiler": "apr_msvc",
+        "@rules_cc//cc/compiler:msvc-cl": "apr_msvc",
         "//conditions:default": "apr_default",
     }),
     visibility = ["//visibility:public"],

--- a/examples/third_party/apr_util/BUILD.expat.bazel
+++ b/examples/third_party/apr_util/BUILD.expat.bazel
@@ -13,7 +13,7 @@ LIB_NAME = "expat"
 alias(
     name = "expat",
     actual = select({
-        "@apr//:msvc_compiler": "expat_msvc",
+        "@rules_cc//cc/compiler:msvc-cl": "expat_msvc",
         "//conditions:default": "expat_default",
     }),
     visibility = ["//visibility:public"],

--- a/examples/third_party/curl/BUILD.bazel
+++ b/examples/third_party/curl/BUILD.bazel
@@ -13,17 +13,17 @@ cc_test(
     size = "small",
     srcs = ["curl_test.cc"],
     defines = select({
-        "@openssl//:msvc_compiler": ["CURL_STATICLIB"],
+        "@rules_cc//cc/compiler:msvc-cl": ["CURL_STATICLIB"],
         "//conditions:default": [],
     }),
     linkopts = select({
-        "@openssl//:msvc_compiler": [
+        "@platforms//os:linux": ["-ldl"],
+        "@rules_cc//cc/compiler:msvc-cl": [
             "crypt32.lib",
             "ws2_32.lib",
             "advapi32.lib",
             "user32.lib",
         ],
-        "@platforms//os:linux": ["-ldl"],
         "//conditions:default": [],
     }),
     deps = [

--- a/examples/third_party/glib/BUILD.glib.bazel
+++ b/examples/third_party/glib/BUILD.glib.bazel
@@ -2,13 +2,6 @@ load("@rules_foreign_cc//foreign_cc:defs.bzl", "meson")
 
 package(default_visibility = ["//visibility:public"])
 
-config_setting(
-    name = "msvc_compiler",
-    flag_values = {
-        "@bazel_tools//tools/cpp:compiler": "msvc-cl",
-    },
-)
-
 filegroup(
     name = "all_srcs",
     srcs = glob(["**"]),
@@ -23,7 +16,7 @@ DEPS = [
 meson(
     name = "glib",
     copts = select({
-        ":msvc_compiler": [
+        "@rules_cc//cc/compiler:msvc-cl": [
             # This string is used as enum in gio/glib-compile-resources.c:718
             "-UCOMPILER_MSVC",
         ],
@@ -32,14 +25,14 @@ meson(
     env = {
         "PATH": "$$(dirname $$EXT_BUILD_ROOT/$(PYTHON3)):$$PATH",
     } | select({
-        ":msvc_compiler": {
-            "INCLUDE": "$$EXT_BUILD_DEPS/include",
-            "LIB": "$$EXT_BUILD_DEPS/lib",
-            "PATH": "$$EXT_BUILD_DEPS/lib:$$(dirname $$EXT_BUILD_ROOT/$(PYTHON3)):$$PATH",
-        },
         "@platforms//os:macos": {
             "CPATH": "$$EXT_BUILD_DEPS/gettext/include",
             "LIBRARY_PATH": "$$EXT_BUILD_DEPS/gettext/lib",
+        },
+        "@rules_cc//cc/compiler:msvc-cl": {
+            "INCLUDE": "$$EXT_BUILD_DEPS/include",
+            "LIB": "$$EXT_BUILD_DEPS/lib",
+            "PATH": "$$EXT_BUILD_DEPS/lib:$$(dirname $$EXT_BUILD_ROOT/$(PYTHON3)):$$PATH",
         },
         "//conditions:default": {},
     }),

--- a/examples/third_party/mesa/BUILD.mesa.bazel
+++ b/examples/third_party/mesa/BUILD.mesa.bazel
@@ -7,13 +7,6 @@ filegroup(
     srcs = glob(["**"]),
 )
 
-config_setting(
-    name = "msvc_compiler",
-    flag_values = {
-        "@bazel_tools//tools/cpp:compiler": "msvc-cl",
-    },
-)
-
 meson_with_requirements(
     name = "mesa",
     build_args = select({
@@ -41,15 +34,15 @@ meson_with_requirements(
     }),
     lib_source = ":all_srcs",
     linkopts = select({
-        "@openssl//:msvc_compiler": [
-            "ws2_32.lib",
-        ],
         "@platforms//os:linux": [
             # Newer ld.lld rejects version script entries for symbols that are
             # not present in the final link; see
             # https://gitlab.freedesktop.org/mesa/mesa/-/issues/8338 for
             # breadcrumbs
             "-Wl,--undefined-version",
+        ],
+        "@rules_cc//cc/compiler:msvc-cl": [
+            "ws2_32.lib",
         ],
         "//conditions:default": [],
     }),
@@ -65,7 +58,7 @@ meson_with_requirements(
         "//conditions:default": {},
     }),
     out_interface_libs = select({
-        ":msvc_compiler": [
+        "@rules_cc//cc/compiler:msvc-cl": [
             "libgallium_wgl.lib",
             "opengl32.lib",
         ],
@@ -76,10 +69,6 @@ meson_with_requirements(
         "//conditions:default": "lib",
     }),
     out_shared_libs = select({
-        ":msvc_compiler": [
-            "libgallium_wgl.dll",
-            "opengl32.dll",
-        ],
         "@platforms//os:linux": [
             "libEGL.so",
             "libgbm.so",
@@ -98,6 +87,10 @@ meson_with_requirements(
             "libGLESv2.2.dylib",
             "libGL.1.dylib",
             "libGLESv2.dylib",
+        ],
+        "@rules_cc//cc/compiler:msvc-cl": [
+            "libgallium_wgl.dll",
+            "opengl32.dll",
         ],
     }),
     requirements = [

--- a/examples/third_party/openssl/BUILD.bazel
+++ b/examples/third_party/openssl/BUILD.bazel
@@ -14,7 +14,7 @@ cc_test(
     size = "small",
     srcs = ["openssl_test.cc"],
     linkopts = select({
-        "@openssl//:msvc_compiler": [
+        "@rules_cc//cc/compiler:msvc-cl": [
             "advapi32.lib",
             "user32.lib",
         ],

--- a/examples/third_party/openssl/BUILD.openssl.bazel
+++ b/examples/third_party/openssl/BUILD.openssl.bazel
@@ -30,18 +30,10 @@ MAKE_TARGETS = [
     "install_sw",
 ]
 
-config_setting(
-    name = "msvc_compiler",
-    flag_values = {
-        "@bazel_tools//tools/cpp:compiler": "msvc-cl",
-    },
-    visibility = ["//visibility:public"],
-)
-
 alias(
     name = "openssl",
     actual = select({
-        ":msvc_compiler": "openssl_msvc",
+        "@rules_cc//cc/compiler:msvc-cl": "openssl_msvc",
         "//conditions:default": "openssl_default",
     }),
     visibility = ["//visibility:public"],

--- a/foreign_cc/built_tools/cmake_build.bzl
+++ b/foreign_cc/built_tools/cmake_build.bzl
@@ -15,7 +15,7 @@ def cmake_tool(name, srcs, **kwargs):
     native.alias(
         name = "{}.build".format(name),
         actual = select({
-            ":msvc_compiler": "{}_msvc".format(name),
+            "@rules_cc//cc/compiler:msvc-cl": "{}_msvc".format(name),
             "//conditions:default": "{}_default".format(name),
         }),
     )

--- a/foreign_cc/built_tools/pkgconfig_build.bzl
+++ b/foreign_cc/built_tools/pkgconfig_build.bzl
@@ -129,17 +129,10 @@ def pkgconfig_tool(name, srcs, **kwargs):
     """
     tags = ["manual"] + kwargs.pop("tags", [])
 
-    native.config_setting(
-        name = "msvc_compiler",
-        flag_values = {
-            "@bazel_tools//tools/cpp:compiler": "msvc-cl",
-        },
-    )
-
     native.alias(
         name = name,
         actual = select({
-            ":msvc_compiler": "{}_msvc".format(name),
+            "@rules_cc//cc/compiler:msvc-cl": "{}_msvc".format(name),
             "//conditions:default": "{}_default".format(name),
         }),
     )


### PR DESCRIPTION
Several places defined their own local `msvc_compiler` config_setting
(keyed off `@bazel_tools//tools/cpp:compiler`) -- the cmake/pkgconfig
built-tool macros plus the apr/glib/mesa/openssl examples -- and some
examples reached across repos for it (`@apr//:msvc_compiler`,
`@openssl//:msvc_compiler`). rules_cc already ships this setting at
`@rules_cc//cc/compiler:msvc-cl`, so point every `select()` there and
delete the local copies.

No behavioral change (same underlying flag); rules_foreign_cc already
depends on rules_cc, and the label resolves inside the http_archive-
injected example BUILD files.