### PR TITLE
Only ignore macOS AR if it is libtool

### DIFF
--- a/foreign_cc/built_tools/pkgconfig_build.bzl
+++ b/foreign_cc/built_tools/pkgconfig_build.bzl
@@ -56,7 +56,6 @@ def _pkgconfig_tool_impl(ctx):
     absolute_ar = absolutize(ctx.workspace_name, ar_path, True)
 
     if os_name(ctx) == "macos":
-        absolute_ar = ""
         non_system_include_ldflags += ["-undefined", "error"]
 
     arflags = [e for e in frozen_arflags]

--- a/foreign_cc/built_tools/pkgconfig_build.bzl
+++ b/foreign_cc/built_tools/pkgconfig_build.bzl
@@ -56,6 +56,10 @@ def _pkgconfig_tool_impl(ctx):
     absolute_ar = absolutize(ctx.workspace_name, ar_path, True)
 
     if os_name(ctx) == "macos":
+        # When using libtool nested build systems that expect 'ar' will pass
+        # invalid arguments
+        if "libtool" in absolute_ar:
+            absolute_ar = ""
         non_system_include_ldflags += ["-undefined", "error"]
 
     arflags = [e for e in frozen_arflags]


### PR DESCRIPTION
This way if you've configured `ar` in your toolchain, you get a hermetic version
where if you wipe this out you get the system default