### PR TITLE
ci: add bazel 9.1.1 to the test matrix

### DIFF
--- a/.bazelci/config.yaml
+++ b/.bazelci/config.yaml
@@ -12,13 +12,14 @@ matrix:
   bazel_version:
     7.x: 7.7.1
     8.x: 8.6.0
-    # 9.x: 9.0.1
+    9.x: 9.1.1
 
   # hack to work around it until the fix lands:
   # https://github.com/bazelbuild/continuous-integration/pull/2526
   bazel_rc_config:
     7.x: --config=bazel-7.x
     8.x: --config=bazel-8.x
+    9.x: --config=bazel-9.x
 
   bzlmod:
     bzlmod: [--enable_bzlmod, --noenable_workspace]
@@ -38,6 +39,9 @@ matrix:
     - bazel_version: 9.x
       bzlmod: workspaces
 
+    - bazel_version: 9.x
+      bzlmod: mixed
+
     # bazel 7 has an unfortunate habit of crashing on bzlmod lock files, so
     # only support bazel 7 in workspace mode
     - bazel_version: 7.x
@@ -46,11 +50,25 @@ matrix:
     - bazel_version: 7.x
       bzlmod: mixed
 
+    # Each bazel version must only pair with its own --config=bazel-x.x block;
+    # exclude every cross-version combination.
     - bazel_version: 7.x
       bazel_rc_config: 8.x
 
+    - bazel_version: 7.x
+      bazel_rc_config: 9.x
+
     - bazel_version: 8.x
       bazel_rc_config: 7.x
+
+    - bazel_version: 8.x
+      bazel_rc_config: 9.x
+
+    - bazel_version: 9.x
+      bazel_rc_config: 7.x
+
+    - bazel_version: 9.x
+      bazel_rc_config: 8.x
 
     # Windows doesn't actually have a sandbox anyway, and there aren't a lot of
     # windows runners, so don't run the standalones

--- a/.bazelrc.common
+++ b/.bazelrc.common
@@ -52,6 +52,12 @@ common --experimental_ui_max_stdouterr_bytes=10485760
 # see https://github.com/bazelbuild/bazel/issues/12844.
 common:bazel-7.x --show_progress
 common:bazel-8.x --incompatible_disable_autoloads_in_main_repo
+# The checked-in MODULE.bazel.lock is written by the bazel version in
+# .bazelversion (8.x), and bazel 9 uses a newer lockfile format it can't read.
+# Bazel 8 and 9 can't share one committed lockfile version, so let bazel 9
+# rewrite it in-process instead of erroring. This overrides --config=ci's
+# --lockfile_mode=error (bazel-9.x is applied after :ci in test_flags).
+common:bazel-9.x --lockfile_mode=update
 # Remind people to set good test timeouts / sizes
 common --test_verbose_timeout_warnings
 


### PR DESCRIPTION
Enables the 9.x row in `.bazelci/config.yaml` (pinned to 9.1.1) and
wires up the matching `--config=bazel-9.x` rc config. Bazel 9 dropped
WORKSPACE support, so the matrix excludes both the `workspaces` and
`mixed` bzlmod modes for 9.x (mixed also enables workspaces); 9.x runs
in pure bzlmod only. The new `bazel_rc_config` excludes keep each bazel
version paired with its own rc block.

The bazel-9.x config sets `--lockfile_mode=update`. The checked-in
`MODULE.bazel.lock` is written by the bazel version in `.bazelversion`
(8.x) at lockfile format v24, and bazel 9 needs v26 -- the two formats
can't share one committed file, and each errors on the other's version.
Letting bazel 9 rewrite the lock in-process avoids the conflict. It
applies after `--config=ci` in `test_flags`, so it overrides the
`--lockfile_mode=error` that ci sets.

The dependency, test, and toolchain changes bazel 9 needs landed
separately ahead of this; this commit only flips on the matrix row.

Note: the Windows 9.x job is expected to fail on the pkg-config build
tools for now. Bazel 9's relocatable Windows launcher (`ae818c43e5`)
makes a nested launcher resolve its own entry point against an
inherited `RUNFILES_MANIFEST_FILE` rather than its own colocated
manifest, so when meson (a `py_binary` launcher) spawns pkg-config (an
`sh_binary` launcher) the pkg-config launcher looks itself up in
meson's manifest, fails `Rlocation`, and exits before the wrapper
runs. This is a bazel bug, not a rules_foreign_cc one, and is tracked
separately; the rest of the 9.x matrix is unaffected.
