### PR TITLE
toolchains: load cc_import in the glib/gettext spoke BUILD files

### DIFF
--- a/toolchains/private/source_spokes.bzl
+++ b/toolchains/private/source_spokes.bzl
@@ -321,7 +321,7 @@ def pkgconfig_source_spokes(version, register_toolchains = False):
     maybe(
         http_archive,
         name = "glib_dev",
-        build_file_content = '''
+        build_file_content = '''load("@rules_cc//cc:defs.bzl", "cc_import")
 cc_import(
     name = "glib_dev",
     hdrs = glob(["include/**"]),
@@ -339,7 +339,7 @@ cc_import(
     maybe(
         http_archive,
         name = "glib_src",
-        build_file_content = '''
+        build_file_content = '''load("@rules_cc//cc:defs.bzl", "cc_import")
 cc_import(
     name = "msvc_hdr",
     hdrs = ["msvc_recommended_pragmas.h"],
@@ -379,7 +379,7 @@ exports_files(
     maybe(
         http_archive,
         name = "gettext_runtime",
-        build_file_content = '''
+        build_file_content = '''load("@rules_cc//cc:defs.bzl", "cc_import")
 cc_import(
     name = "gettext_runtime",
     shared_library = "bin/libintl-8.dll",


### PR DESCRIPTION
Bazel 9 disables autoloads by default, so the bare `cc_import` calls in
the generated `build_file_content` for the `glib_dev`, `glib_src`, and
`gettext_runtime` Windows archives are no longer resolvable as builtins
and fail to load. Add an explicit `cc_import` load from
`@rules_cc//cc:defs.bzl` to each. The `glib_runtime` block only uses
`exports_files` (still a builtin), so it needs no load.
