### PR TITLE
detect_root_test: derive the expected repo root instead of a golden

### DIFF
--- a/examples/integration_tests/detect_root_test/BUILD.bazel
+++ b/examples/integration_tests/detect_root_test/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_lib//lib:diff_test.bzl", "diff_test")
-load(":detect_root_test_rule.bzl", "BZLMOD_ENABLED", "detect_root_test_rule")
+load(":detect_root_test_rule.bzl", "detect_root_test_rule", "workspace_root_rule")
 
 filegroup(
     name = "fg",
@@ -33,10 +33,19 @@ detect_root_test_rule(
     out = "out_repo.txt",
 )
 
+# bazel's own canonical external root for the same repo. Used as the expected
+# value for repo_test so the assertion tracks bazel's repo-name mangling
+# (which has changed shape across 7.x/8.x/9.x) instead of a checked-in golden.
+workspace_root_rule(
+    name = "expected_repo_root",
+    srcs = "@rules_foreign_cc_detect_root_test_repo//:srcs",
+    out = "expected_out_repo.txt",
+)
+
 diff_test(
     name = "repo_test",
     file1 = ":srcs_in_repo",
-    file2 = "expected/out_repo_bzlmod.txt" if BZLMOD_ENABLED else "expected/out_repo_workspaces.txt",
+    file2 = ":expected_repo_root",
 )
 
 diff_test(

--- a/examples/integration_tests/detect_root_test/detect_root_test_rule.bzl
+++ b/examples/integration_tests/detect_root_test/detect_root_test_rule.bzl
@@ -3,8 +3,6 @@
 # buildifier: disable=bzl-visibility
 load("@rules_foreign_cc//foreign_cc/private:detect_root.bzl", "detect_root")
 
-BZLMOD_ENABLED = "@@" in str(Label("//:unused"))
-
 def _impl(ctx):
     detected_root = detect_root(ctx.attr.srcs)
     out = ctx.actions.declare_file(ctx.attr.out)
@@ -16,6 +14,26 @@ def _impl(ctx):
 
 detect_root_test_rule = rule(
     implementation = _impl,
+    attrs = {
+        "out": attr.string(mandatory = True),
+        "srcs": attr.label(mandatory = True),
+    },
+)
+
+def _workspace_root_impl(ctx):
+    # Emit bazel's own canonical external root for the repo that `srcs` lives
+    # in. The repo's BUILD file sits at that root, so detect_root must report
+    # the same path -- giving repo_test an oracle that tracks bazel's repo-name
+    # mangling across versions instead of a golden file we re-bless each bump.
+    out = ctx.actions.declare_file(ctx.attr.out)
+    ctx.actions.write(
+        output = out,
+        content = ctx.attr.srcs.label.workspace_root + "\n",
+    )
+    return [DefaultInfo(files = depset([out]))]
+
+workspace_root_rule = rule(
+    implementation = _workspace_root_impl,
     attrs = {
         "out": attr.string(mandatory = True),
         "srcs": attr.label(mandatory = True),

--- a/examples/integration_tests/detect_root_test/expected/out_repo_bzlmod.txt
+++ b/examples/integration_tests/detect_root_test/expected/out_repo_bzlmod.txt
@@ -1,1 +1,0 @@
-external/+_repo_rules+rules_foreign_cc_detect_root_test_repo

--- a/examples/integration_tests/detect_root_test/expected/out_repo_workspaces.txt
+++ b/examples/integration_tests/detect_root_test/expected/out_repo_workspaces.txt
@@ -1,1 +1,0 @@
-external/rules_foreign_cc_detect_root_test_repo


### PR DESCRIPTION
The `repo_test` case compared `detect_root`'s output to
`expected/out_repo_{bzlmod,workspaces}.txt`, which encode bazel's
canonical external repo path -- and that path's mangling has shifted
across 7.x/8.x/9.x, so the goldens needed re-blessing on every bump.

Add a `workspace_root_rule` that emits `srcs.label.workspace_root`
(bazel's own canonical root for the same repo) and use it as the
expected value, so the assertion tracks whatever mangling the running
bazel uses. This drops both golden files and the `BZLMOD_ENABLED`
load-time switch that chose between them.
