### PR TITLE
Use `pwd -P` so EXT_BUILD_ROOT survives the build-dir cd

### DIFF
--- a/foreign_cc/private/framework/toolchains/freebsd_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/freebsd_commands.bzl
@@ -18,7 +18,7 @@ def script_extension():
     return ".sh"
 
 def pwd():
-    return "$(pwd)"
+    return "$(pwd -P)"
 
 def echo(text):
     return "echo {text}".format(text = text)

--- a/foreign_cc/private/framework/toolchains/linux_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/linux_commands.bzl
@@ -9,7 +9,7 @@ def script_extension():
     return ".sh"
 
 def pwd():
-    return "$(pwd)"
+    return "$(pwd -P)"
 
 def echo(text):
     return "echo {text}".format(text = text)

--- a/foreign_cc/private/framework/toolchains/macos_commands.bzl
+++ b/foreign_cc/private/framework/toolchains/macos_commands.bzl
@@ -9,7 +9,7 @@ def script_extension():
     return ".sh"
 
 def pwd():
-    return "$(pwd)"
+    return "$(pwd -P)"
 
 def echo(text):
     return "echo {text}".format(text = text)


### PR DESCRIPTION
## Problem

The Unix command frameworks set `EXT_BUILD_ROOT=$(pwd)` (`*_commands.bzl` `pwd()`), then `cd` into the build tmpdir before invoking the build tool with source paths like `$EXT_BUILD_ROOT/external/<repo>`.

Logical `$(pwd)` honours `$PWD`. Under **`--incompatible_strict_action_env`**, Bazel exports `PWD=/proc/self/cwd`, so `EXT_BUILD_ROOT` becomes the `/proc/self/cwd` symlink. After the `cd`, that symlink points at the build tmpdir, so `$EXT_BUILD_ROOT/external/<repo>` no longer resolves:

```
CMake Error: The source directory ".../external/<repo>" does not exist.
```

This reproduces with any `cmake()`/`configure_make()` target when the consuming module builds with `--incompatible_strict_action_env` (common for remote-cache determinism).

## Fix

Use `pwd -P`, which ignores `$PWD` and prints the physical absolute working directory — stable across the `cd`. `-ffile-prefix-map=$EXT_BUILD_ROOT=.` still keeps the absolute path out of build outputs, so reproducibility is unaffected.

Applied to `linux`/`macos`/`freebsd` command files; `windows` already uses `pwd -W`.

## Test

Before: a `cmake()` target in a module built with `--incompatible_strict_action_env` fails with the "source directory does not exist" error above. After: it builds (verified end-to-end on a downstream project that pins `--incompatible_strict_action_env`).