### PR TITLE
boost_build: derive b2's -j from resource_size

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -178,6 +178,17 @@ were not tracked here.
 
 ### Bug fixes
 
+**boost_build**
+
+- `resource_size` now reaches b2. b2 reads none of the parallelism environment
+  variables the other rules use and defaults `-j` to every detected CPU thread,
+  so a sized `boost_build` target reserved N cpus from the Bazel scheduler and
+  then forked as many compilers as the machine had cores. The job count is now
+  derived from the same `resource_size` that produces the `resource_set` and
+  passed as `-jN`. An explicit `-j` in `user_options` still wins, and targets
+  without a `resource_size` are unchanged
+  ([#1577](https://github.com/bazel-contrib/rules_foreign_cc/pull/1577)).
+
 **cmake**
 
 - Default `CMAKE_MSVC_DEBUG_INFORMATION_FORMAT` to `Embedded` (`/Z7`) and

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -20,6 +20,16 @@ bzl_library(
 )
 
 stardoc(
+    name = "boost_build_docs",
+    out = "src/boost_build.md",
+    input = "@rules_foreign_cc//foreign_cc:boost_build.bzl",
+    deps = [
+        ":rules_cc_deps",
+        "@rules_foreign_cc//foreign_cc:boost_build",
+    ],
+)
+
+stardoc(
     name = "cmake_docs",
     out = "src/cmake.md",
     input = "@rules_foreign_cc//foreign_cc:cmake.bzl",
@@ -90,6 +100,7 @@ stardoc(
 )
 
 DOCS_TARGETS = [
+    ":boost_build_docs",
     ":cmake_docs",
     ":ninja_docs",
     ":make_docs",

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -11,3 +11,4 @@
         - [meson](meson.md)
         - [msbuild](msbuild.md)
         - [ninja](ninja.md)
+        - [boost_build](boost_build.md)

--- a/foreign_cc/BUILD.bazel
+++ b/foreign_cc/BUILD.bazel
@@ -42,8 +42,14 @@ bzl_library(
     srcs = ["boost_build.bzl"],
     visibility = ["//visibility:public"],
     deps = [
+        "//foreign_cc/private:cc_toolchain_util",
         "//foreign_cc/private:detect_root",
         "//foreign_cc/private:framework",
+        "//foreign_cc/private:resource_sets",
+        "//foreign_cc/private/framework:helpers",
+        "@rules_cc//cc:bzl_srcs",
+        "@rules_cc//cc/common",
+        "@rules_cc//cc/toolchains:toolchain_rules",
     ],
 )
 

--- a/foreign_cc/boost_build.bzl
+++ b/foreign_cc/boost_build.bzl
@@ -12,6 +12,7 @@ load(
     "create_attrs",
     "expand_locations_and_make_variables",
 )
+load("//foreign_cc/private:resource_sets.bzl", "get_resource_parallelism")
 load("//foreign_cc/private/framework:helpers.bzl", "escape_dquote_bash")
 
 def _boost_build_impl(ctx):
@@ -49,6 +50,27 @@ def _user_supplied_toolset(user_options):
         if opt.startswith("toolset=") or opt == "--user-config" or opt.startswith("--user-config="):
             return True
     return False
+
+def _user_supplied_jobs(user_options):
+    # b2 spells this `-jN` or `-j N`; it has no long form.
+    for opt in user_options:
+        if opt.startswith("-j"):
+            return True
+    return False
+
+def _b2_install_command(b2_extra_args, user_options, jobs):
+    # b2 defaults `-j` to every detected CPU thread, which ignores whatever
+    # Bazel reserved for this action. Derive it from the same `resource_size`
+    # that produced the resource_set so the two cannot disagree. The flag goes
+    # ahead of `user_options` so an explicit user `-j` still wins, matching the
+    # convention in the ninja wrapper and cmake's build args.
+    jobs_args = []
+    if jobs and not _user_supplied_jobs(user_options):
+        jobs_args = ["-j{}".format(jobs)]
+
+    return " ".join(
+        ["./b2", "install"] + jobs_args + b2_extra_args + user_options + ["--prefix=."],
+    )
 
 def _jam_quote(text):
     # b2's jam parser accepts double-quoted strings with backslash escaping.
@@ -117,7 +139,11 @@ def _create_configure_script(configureParameters):
             if opt
         ])
 
-    script.append("./b2 install {} {} --prefix=.".format(" ".join(b2_extra_args), " ".join(user_options)))
+    script.append(_b2_install_command(
+        b2_extra_args = b2_extra_args,
+        user_options = user_options,
+        jobs = get_resource_parallelism(ctx.attr),
+    ))
     script.append("##disable_tracing##")
     return script
 
@@ -147,4 +173,8 @@ boost_build = rule(
         "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
+)
+
+export_for_test = struct(
+    b2_install_command = _b2_install_command,
 )

--- a/foreign_cc/private/resource_sets.bzl
+++ b/foreign_cc/private/resource_sets.bzl
@@ -112,8 +112,10 @@ SIZE_ATTRIBUTES = {
 Set the approximate size of this build, which controls two things:
 
 1. The Bazel scheduler reservation, so large builds don't all run at once.
-2. The parallelism passed to the underlying build system via environment
-   variables (CMAKE_BUILD_PARALLEL_LEVEL, GNUMAKEFLAGS, NINJA_JOBS, etc.).
+2. The parallelism passed to the underlying build system, either via
+   environment variables (CMAKE_BUILD_PARALLEL_LEVEL, GNUMAKEFLAGS,
+   NINJA_JOBS, etc.) or, for build systems that read no such variable, on
+   the command line (b2's `-j`).
 
 Build tool parallelism is set to the scheduler reservation plus a small
 overcommit (default +2, matching ninja's ncpus+2 convention). This hides
@@ -217,12 +219,49 @@ def get_resource_set(attr):
         allow_cpu_overcommit = not _is_fixed(cfg, "cpu"),
     )
 
+def parallelism_for(resources, overcommit):
+    """Returns the job count for a resource set. Pure; see get_resource_parallelism.
+
+    Args:
+        resources: the struct returned by get_resource_set
+        overcommit: the value of the parallelism_overcommit setting
+    Returns:
+        int: the job count, or 0 for "leave the build system's default alone"
+    """
+    if resources.cpu <= 0:
+        return 0
+
+    return resources.cpu + (overcommit if resources.allow_cpu_overcommit else 0)
+
+def get_resource_parallelism(attr):
+    """ get the job count the underlying build system should run with
+
+    This is the scheduler reservation plus the overcommit, i.e. the single
+    number that every parallelism knob -- env var or command line flag --
+    must be derived from, so that what we tell the build system cannot drift
+    from what we told Bazel.
+
+    Args:
+        attr: the ctx.attr associated with the target
+    Returns:
+        int: the job count, or 0 when the size is `default` and we should
+        leave the build system's own default alone.
+    """
+
+    return parallelism_for(
+        get_resource_set(attr),
+        attr._parallelism_overcommit[BuildSettingInfo].value,
+    )
+
 def get_resource_env_vars(attr):
     """ get the values of env vars controlling parallelism
 
     Because any of these tools (cmake, meson, ninja, make, etc) can call into
     other tools, we set all of the flags in the hopes that complicated call
     structures will still see the values.
+
+    Note that b2 (see //foreign_cc:boost_build.bzl) reads none of these, so it
+    takes `get_resource_parallelism` and puts a `-j` on the command line instead.
 
     Args:
         attr: the ctx.attr associated with the target
@@ -234,11 +273,11 @@ def get_resource_env_vars(attr):
     """
 
     resources = get_resource_set(attr)
+    jobs = parallelism_for(resources, attr._parallelism_overcommit[BuildSettingInfo].value)
 
     env = None
-    if resources.cpu > 0:
-        overcommit = attr._parallelism_overcommit[BuildSettingInfo].value if resources.allow_cpu_overcommit else 0
-        parallelism = str(resources.cpu + overcommit)
+    if jobs > 0:
+        parallelism = str(jobs)
         env = {
             "CMAKE_BUILD_PARALLEL_LEVEL": parallelism,
 

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -2,12 +2,14 @@ load("@bazel_lib//lib:diff_test.bzl", "diff_test")
 load("@rules_shell//shell:sh_library.bzl", "sh_library")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tools/lint:linters.bzl", "shellcheck_test")
+load(":boost_text_tests.bzl", "boost_script_test_suite")
 load(":cmake_text_tests.bzl", "cmake_script_test_suite")
 load(":convert_shell_script_test.bzl", "shell_script_conversion_suite")
 load(":make_env_vars_test.bzl", "make_env_vars_test_suite")
 load(":meson_text_tests.bzl", "meson_script_test_suite")
 load(":msbuild_text_tests.bzl", "msbuild_script_test_suite")
 load(":planner_test.bzl", "planner_test_suite")
+load(":resource_sets_test.bzl", "resource_sets_test_suite")
 load(":shell_script_helper_test_rule.bzl", "shell_script_helper_test_rule")
 load(":symlink_contents_to_dir_test_rule.bzl", "symlink_contents_to_dir_test_rule")
 load(":utils_test.bzl", "utils_test_suite")
@@ -62,6 +64,8 @@ shellcheck_test(
     }),
 )
 
+boost_script_test_suite()
+
 cmake_script_test_suite()
 
 meson_script_test_suite()
@@ -71,6 +75,8 @@ msbuild_script_test_suite()
 shell_script_conversion_suite()
 
 make_env_vars_test_suite()
+
+resource_sets_test_suite()
 
 utils_test_suite()
 

--- a/test/boost_text_tests.bzl
+++ b/test/boost_text_tests.bzl
@@ -1,0 +1,88 @@
+"""Unit tests for Boost.Build (b2) script creation."""
+
+load("@bazel_skylib//lib:partial.bzl", "partial")
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//foreign_cc:boost_build.bzl", "export_for_test")
+
+_TOOLCHAIN_ARGS = ["toolset=clang", "--user-config=user-config.jam"]
+
+# Without a `resource_size` there is no reservation to respect, so b2 keeps its
+# own default and we add nothing.
+def _no_jobs_leaves_command_untouched_test(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(
+        env,
+        "./b2 install toolset=clang --with-timer --prefix=.",
+        export_for_test.b2_install_command(
+            b2_extra_args = ["toolset=clang"],
+            user_options = ["--with-timer"],
+            jobs = 0,
+        ),
+    )
+
+    return unittest.end(env)
+
+def _jobs_are_passed_to_b2_test(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(
+        env,
+        "./b2 install -j3 toolset=clang --user-config=user-config.jam --with-timer --prefix=.",
+        export_for_test.b2_install_command(
+            b2_extra_args = _TOOLCHAIN_ARGS,
+            user_options = ["--with-timer"],
+            jobs = 3,
+        ),
+    )
+
+    return unittest.end(env)
+
+# `resource_size = "serial"` resolves to one cpu with no overcommit, which has
+# to reach b2 as -j1 rather than as "no flag at all".
+def _serial_size_forces_one_job_test(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(
+        env,
+        "./b2 install -j1 --prefix=.",
+        export_for_test.b2_install_command(
+            b2_extra_args = [],
+            user_options = [],
+            jobs = 1,
+        ),
+    )
+
+    return unittest.end(env)
+
+# The injected flag goes ahead of user_options so a hand-written -j still wins;
+# skip injecting entirely so the command line doesn't carry two of them.
+def _user_supplied_jobs_win_test(ctx):
+    env = unittest.begin(ctx)
+
+    for user_jobs in [["-j1"], ["-j", "1"]]:
+        asserts.equals(
+            env,
+            "./b2 install " + " ".join(user_jobs) + " --prefix=.",
+            export_for_test.b2_install_command(
+                b2_extra_args = [],
+                user_options = user_jobs,
+                jobs = 8,
+            ),
+        )
+
+    return unittest.end(env)
+
+no_jobs_leaves_command_untouched_test = unittest.make(_no_jobs_leaves_command_untouched_test)
+jobs_are_passed_to_b2_test = unittest.make(_jobs_are_passed_to_b2_test)
+serial_size_forces_one_job_test = unittest.make(_serial_size_forces_one_job_test)
+user_supplied_jobs_win_test = unittest.make(_user_supplied_jobs_win_test)
+
+def boost_script_test_suite():
+    unittest.suite(
+        "boost_script_test_suite",
+        partial.make(no_jobs_leaves_command_untouched_test, size = "small"),
+        partial.make(jobs_are_passed_to_b2_test, size = "small"),
+        partial.make(serial_size_forces_one_job_test, size = "small"),
+        partial.make(user_supplied_jobs_win_test, size = "small"),
+    )

--- a/test/resource_sets_test.bzl
+++ b/test/resource_sets_test.bzl
@@ -1,0 +1,50 @@
+"""Unit tests for the resource_size -> parallelism arithmetic."""
+
+load("@bazel_skylib//lib:partial.bzl", "partial")
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+
+# buildifier: disable=bzl-visibility
+load("//foreign_cc/private:resource_sets.bzl", "parallelism_for")
+
+def _resources(cpu, allow_cpu_overcommit = True):
+    return struct(cpu = cpu, allow_cpu_overcommit = allow_cpu_overcommit)
+
+# `resource_size = "default"` means no reservation, which has to stay
+# distinguishable from "reserve one cpu" so callers leave the build system's
+# own default alone rather than pinning it to -j1.
+def _default_size_has_no_parallelism_test(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(env, 0, parallelism_for(_resources(cpu = 0), 2))
+
+    return unittest.end(env)
+
+def _overcommit_is_added_to_the_reservation_test(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(env, 3, parallelism_for(_resources(cpu = 1), 2))
+    asserts.equals(env, 10, parallelism_for(_resources(cpu = 8), 2))
+    asserts.equals(env, 8, parallelism_for(_resources(cpu = 8), 0))
+
+    return unittest.end(env)
+
+# Fixed-cpu sizes ("serial") exist for packages that break under parallelism,
+# so the overcommit must not sneak back in.
+def _fixed_cpu_sizes_ignore_overcommit_test(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(env, 1, parallelism_for(_resources(cpu = 1, allow_cpu_overcommit = False), 2))
+
+    return unittest.end(env)
+
+default_size_has_no_parallelism_test = unittest.make(_default_size_has_no_parallelism_test)
+overcommit_is_added_to_the_reservation_test = unittest.make(_overcommit_is_added_to_the_reservation_test)
+fixed_cpu_sizes_ignore_overcommit_test = unittest.make(_fixed_cpu_sizes_ignore_overcommit_test)
+
+def resource_sets_test_suite():
+    unittest.suite(
+        "resource_sets_test_suite",
+        partial.make(default_size_has_no_parallelism_test, size = "small"),
+        partial.make(overcommit_is_added_to_the_reservation_test, size = "small"),
+        partial.make(fixed_cpu_sizes_ignore_overcommit_test, size = "small"),
+    )


### PR DESCRIPTION
b2 reads none of the parallelism environment variables the framework sets (CMAKE_BUILD_PARALLEL_LEVEL, GNUMAKEFLAGS, MESON_NUM_PROCESSES, NINJA_JOBS), and modern b2 defaults -j to every detected CPU thread. So a boost_build target with a resource_size reserved N cpus from the Bazel scheduler and then forked as many compilers as the machine had cores -- the reservation bought nothing, and Bazel kept scheduling other actions alongside it.

Derive the job count from the same resource_size that produces the resource_set, and put it on the b2 command line ahead of user_options so an explicit user -j still wins. Targets without a resource_size are unchanged.

The arithmetic moves into parallelism_for/get_resource_parallelism so the env vars and the command line flag come from one place and cannot drift.

boost_build.bzl had no stardoc target, so its attributes were not rendered anywhere; add one.