### PR TITLE
framework: route build actions to size-scoped exec groups

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -89,7 +89,7 @@ were not tracked here.
   `exec_group_compatible_with`, or
   `--@rules_foreign_cc//foreign_cc/settings:size_exec_groups=False` to opt out.
   See the new "Remote execution" docs page
-  ([#TBD](https://github.com/bazel-contrib/rules_foreign_cc/pull/TBD)).
+  ([#1578](https://github.com/bazel-contrib/rules_foreign_cc/pull/1578)).
 - **New `msbuild` rule** for building MSBuild (`.vcxproj`/`.sln`) projects with
   `MSBuild.exe` from MSVC. Only the pre-installed toolchain is supported
   ([#1443](https://github.com/bazel-contrib/rules_foreign_cc/pull/1443)).

--- a/NEWS.md
+++ b/NEWS.md
@@ -75,6 +75,21 @@ were not tracked here.
 
 ### New features
 
+- **`resource_size` now reaches remote executors.** `resource_set` is read by
+  Bazel's local scheduler only, so a sized target told a remote executor
+  nothing about how big its action was. Each build action now runs in an exec
+  group named after its size (`size_tiny` ... `size_enormous`), which lets an
+  RBE platform declare the cpu/memory request once for every sized target:
+  `exec_properties = {"size_large.EstimatedCPU": "8", ...}`. Property names are
+  executor-specific, so `foreign_cc_size_exec_properties` generates the dict
+  from the same size table the rules use. Targets without a `resource_size` keep
+  running in the default exec group. Setting both `exec_compatible_with` and a
+  `resource_size` on one target now fails with an explanation, since a declared
+  exec group does not inherit that constraint; use
+  `exec_group_compatible_with`, or
+  `--@rules_foreign_cc//foreign_cc/settings:size_exec_groups=False` to opt out.
+  See the new "Remote execution" docs page
+  ([#TBD](https://github.com/bazel-contrib/rules_foreign_cc/pull/TBD)).
 - **New `msbuild` rule** for building MSBuild (`.vcxproj`/`.sln`) projects with
   `MSBuild.exe` from MSVC. Only the pre-installed toolchain is supported
   ([#1443](https://github.com/bazel-contrib/rules_foreign_cc/pull/1443)).

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -4,6 +4,7 @@
     - [bzlmod hub-and-spoke](bzlmod_hub.md)
         - [Examples](bzlmod_examples.md)
         - [Migrating from WORKSPACE](bzlmod_migration.md)
+    - [Remote execution](remote_execution.md)
     - [Rules](rules.md)
         - [cmake](cmake.md)
         - [configure_make](configure_make.md)

--- a/docs/src/remote_execution.md
+++ b/docs/src/remote_execution.md
@@ -1,0 +1,128 @@
+# Remote execution
+
+A `rules_foreign_cc` target runs a whole nested build — make, ninja, b2 — inside a single Bazel
+action. Telling the scheduler how big that action is matters more here than for an ordinary
+compile, and it has to be told twice, because local and remote execution read entirely different
+things.
+
+## What `resource_size` already does
+
+Setting [`resource_size`](rules.md) on a target does two things today:
+
+1. Attaches a `resource_set` to the action, which Bazel's **local** scheduler uses to reserve cpu
+   and memory instead of assuming roughly one core.
+2. Puts the same job count in the action's environment (`CMAKE_BUILD_PARALLEL_LEVEL`,
+   `GNUMAKEFLAGS`, `MESON_NUM_PROCESSES`, `NINJA_JOBS`) or on the build tool's command line
+   (b2's `-j`), so the nested build uses the parallelism Bazel budgeted rather than the machine's
+   full core count.
+
+Point 2 works on a remote executor already — the environment travels with the action. Point 1 does
+not: `resource_set` is a local-scheduler concept. A remote executor sizes an action from the
+[RE platform properties](https://github.com/bazelbuild/remote-apis) attached to it.
+
+## What the exec groups add
+
+Starlark has no way to attach platform properties to an individual action — `ctx.actions.run_shell`
+has no `exec_properties` parameter, and an action's `execution_requirements` are not forwarded to
+the remote platform. The one mechanism a ruleset can use is
+[execution groups](https://bazel.build/extending/exec-groups): `exec_properties` on a `platform()`
+or on a target can be scoped to a named group.
+
+So every `rules_foreign_cc` build action runs in the exec group named after its `resource_size`:
+
+| `resource_size` | exec group     |
+| --------------- | -------------- |
+| `tiny`          | `size_tiny`    |
+| `small`         | `size_small`   |
+| `medium`        | `size_medium`  |
+| `large`         | `size_large`   |
+| `enormous`      | `size_enormous`|
+| `serial`        | `size_serial`  |
+| `default`       | *(the default exec group — no routing)* |
+
+You declare the sizing once, on your platform, and every sized target picks it up:
+
+```python
+platform(
+    name = "rbe_linux",
+    exec_properties = {
+        "container-image": "docker://...",
+        "size_large.EstimatedCPU": "8",
+        "size_large.EstimatedMemory": "1024M",
+        "size_enormous.EstimatedCPU": "16",
+        "size_enormous.EstimatedMemory": "2048M",
+    },
+)
+```
+
+Property names are executor-specific. BuildBuddy uses `EstimatedCPU` / `EstimatedMemory`;
+Buildfarm uses `min-cores` / `max-cores` / `min-mem`; other executors differ again. Check your
+executor's documentation for the names and value formats it accepts.
+
+## Generating the properties
+
+Rather than hand-writing one entry per size, `foreign_cc_size_exec_properties` generates the whole
+dict from the same size table the rules use:
+
+```python
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "foreign_cc_size_exec_properties")
+
+platform(
+    name = "rbe_linux",
+    exec_properties = foreign_cc_size_exec_properties(
+        cpu_property = "EstimatedCPU",
+        memory_property = "EstimatedMemory",
+        memory_format = "{}M",
+    ) | {"container-image": "docker://..."},
+)
+```
+
+Either property may be omitted if your executor only schedules on one dimension.
+
+The helper runs at load time, so it cannot read the `size_<size>_<cpu|mem>` build settings. If you
+have overridden any of those, pass matching values through the `sizes` argument so the platform
+and the scheduler agree:
+
+```python
+foreign_cc_size_exec_properties(
+    cpu_property = "EstimatedCPU",
+    sizes = {
+        "large": struct(cpu = 3, mem = 1024),
+        # ...
+    },
+)
+```
+
+## Interaction with `exec_compatible_with`
+
+A declared exec group does not inherit a target's `exec_compatible_with`, so routing the build
+action into one would silently drop that constraint. Rather than diverge, the rules fail at
+analysis time if a target sets both `exec_compatible_with` and a non-default `resource_size`. Use
+Bazel's per-group form instead:
+
+```python
+cmake(
+    name = "foo",
+    exec_group_compatible_with = {"size_large": ["@platforms//os:linux"]},
+    resource_size = "large",
+    # ...
+)
+```
+
+Or turn the routing off entirely, which restores the previous behavior of running every build
+action in the default exec group:
+
+```
+common --@rules_foreign_cc//foreign_cc/settings:size_exec_groups=False
+```
+
+## Sizing the local scheduler too
+
+The per-size cpu and memory values are build settings, so you can tune them for your machines
+without touching any target. Run
+
+```
+bazel run @rules_foreign_cc//foreign_cc/settings
+```
+
+to print every setting in `bazelrc` form, then copy the ones you want into your own `bazelrc`.

--- a/foreign_cc/BUILD.bazel
+++ b/foreign_cc/BUILD.bazel
@@ -91,12 +91,20 @@ bzl_library(
         ":boost_build",
         ":cmake",
         ":configure",
+        ":exec_properties",
         ":make",
         ":meson",
         ":msbuild",
         ":ninja",
         ":utils",
     ],
+)
+
+bzl_library(
+    name = "exec_properties",
+    srcs = ["exec_properties.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["//foreign_cc/private:resource_sets"],
 )
 
 bzl_library(

--- a/foreign_cc/boost_build.bzl
+++ b/foreign_cc/boost_build.bzl
@@ -12,6 +12,7 @@ load(
     "create_attrs",
     "expand_locations_and_make_variables",
 )
+load("//foreign_cc/private:resource_sets.bzl", "size_exec_groups")
 load("//foreign_cc/private/framework:helpers.bzl", "escape_dquote_bash")
 
 def _boost_build_impl(ctx):
@@ -136,6 +137,11 @@ def _attrs():
     })
     return attrs
 
+_BOOST_BUILD_TOOLCHAINS = [
+    "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
+    "@bazel_tools//tools/cpp:toolchain_type",
+]
+
 boost_build = rule(
     doc = "Rule for building Boost. Invokes bootstrap.sh and then b2 install.",
     attrs = _attrs(),
@@ -143,8 +149,6 @@ boost_build = rule(
     output_to_genfiles = True,
     provides = [CcInfo],
     implementation = _boost_build_impl,
-    toolchains = [
-        "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
-        "@bazel_tools//tools/cpp:toolchain_type",
-    ],
+    exec_groups = size_exec_groups(_BOOST_BUILD_TOOLCHAINS),
+    toolchains = _BOOST_BUILD_TOOLCHAINS,
 )

--- a/foreign_cc/built_tools/make_build.bzl
+++ b/foreign_cc/built_tools/make_build.bzl
@@ -17,6 +17,7 @@ load(
     "get_tools_info",
 )
 load("//foreign_cc/private:detect_xcompile.bzl", "detect_xcompile")
+load("//foreign_cc/private:resource_sets.bzl", "size_exec_groups")
 load(
     "//foreign_cc/private/framework:helpers.bzl",
     "escape_dquote_bash",
@@ -133,6 +134,11 @@ def _make_tool_impl(ctx):
         "BootstrapGNUMake",
     )
 
+_MAKE_TOOL_TOOLCHAINS = [
+    "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
+    "@bazel_tools//tools/cpp:toolchain_type",
+]
+
 make_tool = rule(
     doc = "Rule for building Make. Invokes configure script and make install.",
     attrs = FOREIGN_CC_BUILT_TOOLS_ATTRS,
@@ -140,10 +146,8 @@ make_tool = rule(
     fragments = FOREIGN_CC_BUILT_TOOLS_FRAGMENTS,
     output_to_genfiles = True,
     implementation = _make_tool_impl,
-    toolchains = [
-        "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
-        "@bazel_tools//tools/cpp:toolchain_type",
-    ],
+    exec_groups = size_exec_groups(_MAKE_TOOL_TOOLCHAINS),
+    toolchains = _MAKE_TOOL_TOOLCHAINS,
 )
 
 def _join_flags_list(workspace_name, flags):

--- a/foreign_cc/built_tools/ninja_build.bzl
+++ b/foreign_cc/built_tools/ninja_build.bzl
@@ -10,6 +10,7 @@ load(
     "split_system_include_flags",
 )
 load("//foreign_cc/private:cc_toolchain_util.bzl", "get_flags_info", "get_tools_info")
+load("//foreign_cc/private:resource_sets.bzl", "size_exec_groups")
 load("//foreign_cc/private/framework:helpers.bzl", "escape_dquote_bash")
 load("//foreign_cc/private/framework:platform.bzl", "os_name")
 
@@ -73,6 +74,12 @@ def _ninja_tool_impl(ctx):
 def _join_flags_list(workspace_name, flags):
     return " ".join([escape_dquote_bash(absolutize(workspace_name, flag)) for flag in flags])
 
+_NINJA_TOOL_TOOLCHAINS = [
+    "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
+    "@bazel_tools//tools/cpp:toolchain_type",
+    "@rules_python//python:toolchain_type",
+]
+
 ninja_tool = rule(
     doc = "Rule for building Ninja. Invokes configure script.",
     attrs = FOREIGN_CC_BUILT_TOOLS_ATTRS,
@@ -80,9 +87,6 @@ ninja_tool = rule(
     fragments = FOREIGN_CC_BUILT_TOOLS_FRAGMENTS,
     output_to_genfiles = True,
     implementation = _ninja_tool_impl,
-    toolchains = [
-        "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
-        "@bazel_tools//tools/cpp:toolchain_type",
-        "@rules_python//python:toolchain_type",
-    ],
+    exec_groups = size_exec_groups(_NINJA_TOOL_TOOLCHAINS),
+    toolchains = _NINJA_TOOL_TOOLCHAINS,
 )

--- a/foreign_cc/built_tools/pkgconfig_build.bzl
+++ b/foreign_cc/built_tools/pkgconfig_build.bzl
@@ -17,6 +17,7 @@ load(
     "get_tools_info",
 )
 load("//foreign_cc/private:detect_xcompile.bzl", "detect_xcompile")
+load("//foreign_cc/private:resource_sets.bzl", "size_exec_groups")
 load(
     "//foreign_cc/private/framework:helpers.bzl",
     "escape_dquote_bash",
@@ -104,6 +105,12 @@ def _pkgconfig_tool_impl(ctx):
         additional_tools,
     )
 
+_PKGCONFIG_TOOL_TOOLCHAINS = [
+    "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
+    "@rules_foreign_cc//toolchains:make_toolchain",
+    "@bazel_tools//tools/cpp:toolchain_type",
+]
+
 pkgconfig_tool_unix = rule(
     doc = "Rule for building pkgconfig on Unix operating systems",
     attrs = FOREIGN_CC_BUILT_TOOLS_ATTRS,
@@ -111,11 +118,8 @@ pkgconfig_tool_unix = rule(
     fragments = FOREIGN_CC_BUILT_TOOLS_FRAGMENTS,
     output_to_genfiles = True,
     implementation = _pkgconfig_tool_impl,
-    toolchains = [
-        "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
-        "@rules_foreign_cc//toolchains:make_toolchain",
-        "@bazel_tools//tools/cpp:toolchain_type",
-    ],
+    exec_groups = size_exec_groups(_PKGCONFIG_TOOL_TOOLCHAINS),
+    toolchains = _PKGCONFIG_TOOL_TOOLCHAINS,
 )
 
 def pkgconfig_tool(name, srcs, **kwargs):

--- a/foreign_cc/built_tools/private/built_tools_framework.bzl
+++ b/foreign_cc/built_tools/private/built_tools_framework.bzl
@@ -4,7 +4,12 @@ load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("//foreign_cc/private:cc_toolchain_util.bzl", "absolutize_path_in_str")
 load("//foreign_cc/private:detect_root.bzl", "detect_root")
 load("//foreign_cc/private:framework.bzl", "FOREIGN_CC_FRAMEWORK_COMMON_ATTRS", "get_env_prelude", "wrap_outputs")
-load("//foreign_cc/private:resource_sets.bzl", "get_resource_env_vars")
+load(
+    "//foreign_cc/private:resource_sets.bzl",
+    "get_resource_env_vars",
+    "get_resource_exec_group",
+    "get_resource_set",
+)
 load("//foreign_cc/private/framework:helpers.bzl", "convert_shell_script", "shebang")
 
 # Common attributes for all built_tool rules
@@ -124,11 +129,13 @@ def built_tool_rule_impl(ctx, script_lines, out_dir, mnemonic, additional_tools 
         tools = depset(transitive = [tools, additional_tools])
 
     resource_set, env = get_resource_env_vars(ctx.attr)
+    exec_group = get_resource_exec_group(ctx.label, ctx.attr, get_resource_set(ctx.attr))
 
     # The use of `run_shell` here is intended to ensure bash is correctly setup on windows
     # environments. This should not be replaced with `run` until a cross platform implementation
     # is found that guarantees bash exists or appropriately errors out.
     ctx.actions.run_shell(
+        exec_group = exec_group,
         mnemonic = mnemonic,
         inputs = ctx.attr.srcs.files,
         outputs = [out_dir, wrapped_outputs.log_file],

--- a/foreign_cc/cmake.bzl
+++ b/foreign_cc/cmake.bzl
@@ -145,6 +145,7 @@ load(
     "create_attrs",
     "expand_locations_and_make_variables",
 )
+load("//foreign_cc/private:resource_sets.bzl", "size_exec_groups")
 load("//foreign_cc/private:transitions.bzl", "foreign_cc_rule_variant")
 load(
     "//foreign_cc/private/framework:platform.bzl",
@@ -422,21 +423,24 @@ def _attrs():
     })
     return attrs
 
+_CMAKE_TOOLCHAINS = [
+    "@rules_foreign_cc//toolchains:cmake_toolchain",
+    "@rules_foreign_cc//toolchains:ninja_toolchain",
+    "@rules_foreign_cc//toolchains:make_toolchain",
+    "@rules_foreign_cc//toolchains:m4_toolchain",
+    "@rules_foreign_cc//toolchains:pkgconfig_toolchain",
+    "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
+    "@bazel_tools//tools/cpp:toolchain_type",
+]
+
 cmake = rule(
     doc = "Rule for building external library with CMake.",
     attrs = _attrs(),
     fragments = CC_EXTERNAL_RULE_FRAGMENTS,
     output_to_genfiles = True,
     implementation = _cmake_impl,
-    toolchains = [
-        "@rules_foreign_cc//toolchains:cmake_toolchain",
-        "@rules_foreign_cc//toolchains:ninja_toolchain",
-        "@rules_foreign_cc//toolchains:make_toolchain",
-        "@rules_foreign_cc//toolchains:m4_toolchain",
-        "@rules_foreign_cc//toolchains:pkgconfig_toolchain",
-        "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
-        "@bazel_tools//tools/cpp:toolchain_type",
-    ],
+    exec_groups = size_exec_groups(_CMAKE_TOOLCHAINS),
+    toolchains = _CMAKE_TOOLCHAINS,
     provides = [CcInfo],
 )
 

--- a/foreign_cc/configure.bzl
+++ b/foreign_cc/configure.bzl
@@ -21,6 +21,7 @@ load(
     "expand_locations_and_make_variables",
 )
 load("//foreign_cc/private:regen_stubs.bzl", "REGEN_STUBS")
+load("//foreign_cc/private:resource_sets.bzl", "size_exec_groups")
 load("//foreign_cc/private:transitions.bzl", "foreign_cc_rule_variant")
 load(
     "//toolchains/native_tools:tool_access.bzl",
@@ -317,6 +318,16 @@ def _attrs():
 
     return attrs
 
+_CONFIGURE_MAKE_TOOLCHAINS = [
+    "@rules_foreign_cc//toolchains:autoconf_toolchain",
+    "@rules_foreign_cc//toolchains:automake_toolchain",
+    "@rules_foreign_cc//toolchains:make_toolchain",
+    "@rules_foreign_cc//toolchains:m4_toolchain",
+    "@rules_foreign_cc//toolchains:pkgconfig_toolchain",
+    "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
+    "@bazel_tools//tools/cpp:toolchain_type",
+]
+
 configure_make = rule(
     doc = (
         "Rule for building external libraries with configure-make pattern. " +
@@ -344,15 +355,8 @@ configure_make = rule(
     output_to_genfiles = True,
     provides = [CcInfo],
     implementation = _configure_make,
-    toolchains = [
-        "@rules_foreign_cc//toolchains:autoconf_toolchain",
-        "@rules_foreign_cc//toolchains:automake_toolchain",
-        "@rules_foreign_cc//toolchains:make_toolchain",
-        "@rules_foreign_cc//toolchains:m4_toolchain",
-        "@rules_foreign_cc//toolchains:pkgconfig_toolchain",
-        "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
-        "@bazel_tools//tools/cpp:toolchain_type",
-    ],
+    exec_groups = size_exec_groups(_CONFIGURE_MAKE_TOOLCHAINS),
+    toolchains = _CONFIGURE_MAKE_TOOLCHAINS,
 )
 
 def configure_make_variant(name, toolchain, **kwargs):

--- a/foreign_cc/defs.bzl
+++ b/foreign_cc/defs.bzl
@@ -7,6 +7,10 @@ load(
     _configure_make = "configure_make",
     _configure_make_variant = "configure_make_variant",
 )
+load(
+    ":exec_properties.bzl",
+    _foreign_cc_size_exec_properties = "foreign_cc_size_exec_properties",
+)
 load(":make.bzl", _make = "make", _make_variant = "make_variant")
 load(":meson.bzl", _meson = "meson", _meson_with_requirements = "meson_with_requirements")
 load(":msbuild.bzl", _msbuild = "msbuild")
@@ -18,6 +22,7 @@ cmake = _cmake
 cmake_variant = _cmake_variant
 configure_make = _configure_make
 configure_make_variant = _configure_make_variant
+foreign_cc_size_exec_properties = _foreign_cc_size_exec_properties
 make_variant = _make_variant
 make = _make
 meson = _meson

--- a/foreign_cc/exec_properties.bzl
+++ b/foreign_cc/exec_properties.bzl
@@ -1,0 +1,67 @@
+"""Helpers for sizing rules_foreign_cc build actions on a remote executor.
+
+Bazel's `resource_set` is read by the local execution scheduler only. A remote
+executor sizes an action from the RE platform properties attached to it, and
+nothing in the Starlark action API can set those. What a ruleset *can* do is
+put each action in a named exec group, because `exec_properties` -- on a
+`platform()` or on a target -- can be scoped to one:
+
+    exec_properties = {"<exec group>.<key>": "<value>"}
+
+rules_foreign_cc runs each build action in the exec group named after its
+`resource_size`, so a remote user declares the mapping once on their platform
+and every sized target picks it up.
+
+The property *keys* are executor-specific (BuildBuddy spells them
+`EstimatedCPU`/`EstimatedMemory`, Buildfarm `min-cores`/`min-mem`, and others
+differ again), so this helper takes them as arguments rather than guessing.
+"""
+
+load(
+    "//foreign_cc/private:resource_sets.bzl",
+    _SIZES = "SIZES",
+    _size_exec_group_name = "size_exec_group_name",
+)
+
+def foreign_cc_size_exec_properties(
+        cpu_property = None,
+        memory_property = None,
+        memory_format = "{}",
+        sizes = None):
+    """Builds the `exec_properties` describing every `resource_size` to a remote executor.
+
+    Example, for a BuildBuddy-style executor:
+
+        platform(
+            name = "rbe_linux",
+            exec_properties = foreign_cc_size_exec_properties(
+                cpu_property = "EstimatedCPU",
+                memory_property = "EstimatedMemory",
+                memory_format = "{}M",
+            ) | {"container-image": "docker://..."},
+        )
+
+    Args:
+      cpu_property: property name for the cpu request, or None to omit it.
+      memory_property: property name for the memory request, or None to omit it.
+      memory_format: format string applied to the memory value, which is in MB.
+        Use e.g. `"{}M"` or `"{}MB"` for executors that require a unit suffix.
+      sizes: optional `{size: struct(cpu, mem)}` overriding the built-in table.
+        Pass this if you have overridden the `size_<size>_<cpu|mem>` build
+        settings; this helper runs at load time and cannot read them.
+
+    Returns:
+      dict[str, str] suitable for a `platform()`'s or a target's `exec_properties`.
+    """
+    if not cpu_property and not memory_property:
+        fail("foreign_cc_size_exec_properties: set cpu_property, memory_property, or both")
+
+    properties = {}
+    for size, cfg in (sizes or _SIZES).items():
+        prefix = _size_exec_group_name(size) + "."
+        if cpu_property:
+            properties[prefix + cpu_property] = str(cfg.cpu)
+        if memory_property:
+            properties[prefix + memory_property] = memory_format.format(cfg.mem)
+
+    return properties

--- a/foreign_cc/make.bzl
+++ b/foreign_cc/make.bzl
@@ -20,6 +20,7 @@ load(
     "expand_locations_and_make_variables",
 )
 load("//foreign_cc/private:make_script.bzl", "create_make_script")
+load("//foreign_cc/private:resource_sets.bzl", "size_exec_groups")
 load("//foreign_cc/private:transitions.bzl", "foreign_cc_rule_variant")
 load("//toolchains/native_tools:tool_access.bzl", "get_make_data")
 
@@ -144,6 +145,12 @@ def _attrs():
     })
     return attrs
 
+_MAKE_TOOLCHAINS = [
+    "@rules_foreign_cc//toolchains:make_toolchain",
+    "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
+    "@bazel_tools//tools/cpp:toolchain_type",
+]
+
 make = rule(
     doc = (
         "Rule for building external libraries with GNU Make. " +
@@ -167,11 +174,8 @@ make = rule(
     output_to_genfiles = True,
     provides = [CcInfo],
     implementation = _make,
-    toolchains = [
-        "@rules_foreign_cc//toolchains:make_toolchain",
-        "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
-        "@bazel_tools//tools/cpp:toolchain_type",
-    ],
+    exec_groups = size_exec_groups(_MAKE_TOOLCHAINS),
+    toolchains = _MAKE_TOOLCHAINS,
 )
 
 def make_variant(name, toolchain, **kwargs):

--- a/foreign_cc/meson.bzl
+++ b/foreign_cc/meson.bzl
@@ -22,6 +22,7 @@ load(
     "expand_locations_and_make_variables",
 )
 load("//foreign_cc/private:make_script.bzl", "pkgconfig_script")
+load("//foreign_cc/private:resource_sets.bzl", "size_exec_groups")
 load("//foreign_cc/private:transitions.bzl", "foreign_cc_rule_variant")
 load("//toolchains/native_tools:native_tools_toolchain.bzl", "native_tool_toolchain")
 load("//toolchains/native_tools:tool_access.bzl", "get_cmake_data", "get_make_data", "get_meson_data", "get_ninja_data", "get_pkgconfig_data")
@@ -267,6 +268,16 @@ def _attrs():
     })
     return attrs
 
+_MESON_TOOLCHAINS = [
+    "@rules_foreign_cc//toolchains:meson_toolchain",
+    "@rules_foreign_cc//toolchains:cmake_toolchain",
+    "@rules_foreign_cc//toolchains:ninja_toolchain",
+    "@rules_foreign_cc//toolchains:pkgconfig_toolchain",
+    "@rules_foreign_cc//toolchains:make_toolchain",
+    "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
+    "@bazel_tools//tools/cpp:toolchain_type",
+]
+
 meson = rule(
     doc = (
         "Rule for building external libraries with [Meson](https://mesonbuild.com/)."
@@ -276,15 +287,8 @@ meson = rule(
     output_to_genfiles = True,
     provides = [CcInfo],
     implementation = _meson_impl,
-    toolchains = [
-        "@rules_foreign_cc//toolchains:meson_toolchain",
-        "@rules_foreign_cc//toolchains:cmake_toolchain",
-        "@rules_foreign_cc//toolchains:ninja_toolchain",
-        "@rules_foreign_cc//toolchains:pkgconfig_toolchain",
-        "@rules_foreign_cc//toolchains:make_toolchain",
-        "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
-        "@bazel_tools//tools/cpp:toolchain_type",
-    ],
+    exec_groups = size_exec_groups(_MESON_TOOLCHAINS),
+    toolchains = _MESON_TOOLCHAINS,
 )
 
 def meson_with_requirements(name, requirements, **kwargs):

--- a/foreign_cc/msbuild.bzl
+++ b/foreign_cc/msbuild.bzl
@@ -99,6 +99,7 @@ load(
     "get_foreign_cc_dep",
 )
 load("//foreign_cc/private:msbuild_script.bzl", "create_msbuild_script")
+load("//foreign_cc/private:resource_sets.bzl", "size_exec_groups")
 load("//toolchains/native_tools:tool_access.bzl", "get_msbuild_data")
 
 def _msbuild(ctx):
@@ -211,6 +212,12 @@ def _attrs():
     })
     return attrs
 
+_MSBUILD_TOOLCHAINS = [
+    "@rules_foreign_cc//toolchains:msbuild_toolchain",
+    "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
+    "@bazel_tools//tools/cpp:toolchain_type",
+]
+
 msbuild = rule(
     doc = "Rule for building external library with MSBuild.",
     attrs = _attrs(),
@@ -218,11 +225,8 @@ msbuild = rule(
     output_to_genfiles = True,
     provides = [CcInfo],
     implementation = _msbuild,
-    toolchains = [
-        "@rules_foreign_cc//toolchains:msbuild_toolchain",
-        "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
-        "@bazel_tools//tools/cpp:toolchain_type",
-    ],
+    exec_groups = size_exec_groups(_MSBUILD_TOOLCHAINS),
+    toolchains = _MSBUILD_TOOLCHAINS,
 )
 
 def _properties_to_args(properties):

--- a/foreign_cc/ninja.bzl
+++ b/foreign_cc/ninja.bzl
@@ -20,6 +20,7 @@ load(
     "expand_locations_and_make_variables",
 )
 load("//foreign_cc/private:ninja_script.bzl", "create_ninja_script")
+load("//foreign_cc/private:resource_sets.bzl", "size_exec_groups")
 load("//toolchains/native_tools:tool_access.bzl", "get_ninja_data")
 
 def _ninja_impl(ctx):
@@ -121,6 +122,12 @@ def _attrs():
     })
     return attrs
 
+_NINJA_TOOLCHAINS = [
+    "@rules_foreign_cc//toolchains:ninja_toolchain",
+    "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
+    "@bazel_tools//tools/cpp:toolchain_type",
+]
+
 ninja = rule(
     doc = (
         "Rule for building external libraries with [Ninja](https://ninja-build.org/)."
@@ -130,9 +137,6 @@ ninja = rule(
     output_to_genfiles = True,
     provides = [CcInfo],
     implementation = _ninja_impl,
-    toolchains = [
-        "@rules_foreign_cc//toolchains:ninja_toolchain",
-        "@rules_foreign_cc//foreign_cc/private/framework:shell_toolchain",
-        "@bazel_tools//tools/cpp:toolchain_type",
-    ],
+    exec_groups = size_exec_groups(_NINJA_TOOLCHAINS),
+    toolchains = _NINJA_TOOLCHAINS,
 )

--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -10,7 +10,13 @@ load("@rules_cc//cc:defs.bzl", "CcInfo", "cc_common")
 load("@rules_cc//cc/common:cc_shared_library_info.bzl", "CcSharedLibraryInfo")
 load("//foreign_cc:providers.bzl", "ForeignCcArtifactInfo", "ForeignCcDepsInfo")
 load("//foreign_cc/private:detect_root.bzl", "filter_containing_dirs_from_inputs")
-load("//foreign_cc/private:resource_sets.bzl", "SIZE_ATTRIBUTES", "get_resource_env_vars")
+load(
+    "//foreign_cc/private:resource_sets.bzl",
+    "SIZE_ATTRIBUTES",
+    "get_resource_env_vars",
+    "get_resource_exec_group",
+    "get_resource_set",
+)
 load(
     "//foreign_cc/private/framework:helpers.bzl",
     "convert_shell_script",
@@ -605,8 +611,10 @@ def cc_external_rule_impl(ctx, attrs):
         tool_runfiles += tool[DefaultInfo].default_runfiles.files.to_list()
 
     resource_set, env = get_resource_env_vars(ctx.attr)
+    exec_group = get_resource_exec_group(ctx.label, ctx.attr, get_resource_set(ctx.attr))
 
     ctx.actions.run_shell(
+        exec_group = exec_group,
         mnemonic = "Cc" + attrs.configure_name.capitalize() + "MakeRule",
         inputs = depset(inputs.declared_inputs),
         outputs = rule_outputs + [wrapped_outputs.log_file],

--- a/foreign_cc/private/resource_sets.bzl
+++ b/foreign_cc/private/resource_sets.bzl
@@ -1,10 +1,13 @@
 """Resource set definitions for build actions"""
 
 load("@bazel_lib//lib:resource_sets.bzl", "resource_set_for")
-load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo", "int_flag", "string_flag")
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo", "bool_flag", "int_flag", "string_flag")
 
 _PARALLELISM_OVERCOMMIT_DEFAULT = 2
 _PARALLELISM_OVERCOMMIT_SETTING = "parallelism_overcommit"
+
+_SIZE_EXEC_GROUPS_DEFAULT = True
+_SIZE_EXEC_GROUPS_SETTING = "size_exec_groups"
 
 _DEFAULT_SIZE = "default"
 _SIZES = {
@@ -38,6 +41,46 @@ _SIZES = {
 def _is_fixed(cfg, resource):
     return cfg.get("fixed_{}".format(resource), False)
 
+# The size table, for consumers that need to describe the sizes to something
+# outside the build -- currently just //foreign_cc:exec_properties.bzl.
+SIZES = {size: struct(cpu = cfg["cpu"], mem = cfg["mem"]) for size, cfg in _SIZES.items()}
+
+def size_exec_group_name(size):
+    """Returns the exec group name a target of `size` runs its build action in.
+
+    Bazel's resource_set is read by the local scheduler only; a remote executor
+    sizes an action from its RE platform properties instead. Nothing in the
+    Starlark action API can set those (`ctx.actions.run_shell` has no
+    `exec_properties`), but exec_properties can be scoped to an exec group by
+    name -- `{"<group>.<key>": "<value>"}` -- on either a platform or a target.
+    So each size gets an exec group, and remote users write the cpu/memory
+    properties their executor understands once, on their platform, instead of
+    repeating them on every target.
+
+    Args:
+        size: one of SIZES.
+    Returns:
+        The exec group name.
+    """
+    return "size_" + size
+
+def size_exec_groups(toolchains):
+    """Returns the `exec_groups` dict for a rule using SIZE_ATTRIBUTES.
+
+    Args:
+        toolchains: the rule's own `toolchains` list. Declared exec groups do
+          not inherit the rule's toolchain types, and an exec group resolves
+          its own execution platform, so passing anything else here risks the
+          build action running on a different platform than the one whose
+          shell toolchain generated its script.
+    Returns:
+        dict[str, exec_group]
+    """
+    return {
+        size_exec_group_name(size): exec_group(toolchains = toolchains)
+        for size in _SIZES
+    }
+
 def _setting(size, resource, mode):
     if size == _DEFAULT_SIZE:
         short_name = _DEFAULT_SIZE
@@ -60,10 +103,16 @@ def create_resource_set_settings():
     settings = [
         ((0, 0, 0, ""), _PARALLELISM_OVERCOMMIT_SETTING, _PARALLELISM_OVERCOMMIT_DEFAULT),
         ((0, 0, 1, ""), "size_default", _DEFAULT_SIZE),
+        ((0, 0, 2, ""), _SIZE_EXEC_GROUPS_SETTING, _SIZE_EXEC_GROUPS_DEFAULT),
     ]
     int_flag(
         name = _PARALLELISM_OVERCOMMIT_SETTING,
         build_setting_default = _PARALLELISM_OVERCOMMIT_DEFAULT,
+        visibility = ["//visibility:public"],
+    )
+    bool_flag(
+        name = _SIZE_EXEC_GROUPS_SETTING,
+        build_setting_default = _SIZE_EXEC_GROUPS_DEFAULT,
         visibility = ["//visibility:public"],
     )
     string_flag(
@@ -109,11 +158,14 @@ SIZE_ATTRIBUTES = {
         default = _DEFAULT_SIZE,
         mandatory = False,
         doc = """\
-Set the approximate size of this build, which controls two things:
+Set the approximate size of this build, which controls three things:
 
 1. The Bazel scheduler reservation, so large builds don't all run at once.
 2. The parallelism passed to the underlying build system via environment
    variables (CMAKE_BUILD_PARALLEL_LEVEL, GNUMAKEFLAGS, NINJA_JOBS, etc.).
+3. The exec group the build action runs in, so remote executors -- which
+   ignore the resource_set and size an action from its platform properties
+   -- can be told the same thing. See the "Remote execution" docs page.
 
 Build tool parallelism is set to the scheduler reservation plus a small
 overcommit (default +2, matching ninja's ncpus+2 convention). This hides
@@ -133,6 +185,10 @@ packages that are known-broken under parallel builds.
     ),
     "_parallelism_overcommit": attr.label(
         default = "//foreign_cc/settings:" + _PARALLELISM_OVERCOMMIT_SETTING,
+        providers = [BuildSettingInfo],
+    ),
+    "_size_exec_groups": attr.label(
+        default = "//foreign_cc/settings:" + _SIZE_EXEC_GROUPS_SETTING,
         providers = [BuildSettingInfo],
     ),
 } | {
@@ -172,6 +228,7 @@ def get_resource_set(attr):
             - allow_cpu_overcommit: True if the build tool may use more
               parallelism than the scheduler reservation (False for sizes
               like "serial" that must enforce an exact -j value)
+            - size: the effective size name, or None if bazel default
     """
     size = _DEFAULT_SIZE
     if attr.resource_size != _DEFAULT_SIZE:
@@ -185,6 +242,7 @@ def get_resource_set(attr):
             cpu = 0,
             mem = 0,
             allow_cpu_overcommit = False,
+            size = None,
         )
 
     cfg = _SIZES[size]
@@ -215,7 +273,47 @@ def get_resource_set(attr):
         cpu = actual_cpu,
         mem = actual_mem,
         allow_cpu_overcommit = not _is_fixed(cfg, "cpu"),
+        size = size,
     )
+
+def get_resource_exec_group(label, attr, resources):
+    """ get the exec group the build action should run in
+
+    Args:
+        label: the ctx.label of the target, for error messages
+        attr: the ctx.attr associated with the target
+        resources: the struct returned by get_resource_set
+    Returns:
+        str | None: the exec group name, or None to use the default exec group
+    """
+    if not resources.size:
+        return None
+
+    if not attr._size_exec_groups[BuildSettingInfo].value:
+        return None
+
+    # A declared exec group does not inherit the target's exec_compatible_with
+    # (only Bazel's internal copy-from-default groups do), so routing the action
+    # into one would silently drop the constraint and could land it on a
+    # different execution platform than the one whose shell toolchain generated
+    # its script. Bazel's per-group escape hatch is exec_group_compatible_with;
+    # refuse rather than diverge.
+    if getattr(attr, "exec_compatible_with", None):
+        group = size_exec_group_name(resources.size)
+        fail(
+            ("{label}: resource_size routes the build action into the {group} exec " +
+             "group, but exec_compatible_with does not apply to declared exec " +
+             "groups, so the constraint would be silently dropped. Use " +
+             "exec_group_compatible_with = {{\"{group}\": [...]}} instead, or turn " +
+             "the routing off with " +
+             "--@rules_foreign_cc//foreign_cc/settings:{setting}=False.").format(
+                label = label,
+                group = group,
+                setting = _SIZE_EXEC_GROUPS_SETTING,
+            ),
+        )
+
+    return size_exec_group_name(resources.size)
 
 def get_resource_env_vars(attr):
     """ get the values of env vars controlling parallelism

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -4,6 +4,7 @@ load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//tools/lint:linters.bzl", "shellcheck_test")
 load(":cmake_text_tests.bzl", "cmake_script_test_suite")
 load(":convert_shell_script_test.bzl", "shell_script_conversion_suite")
+load(":exec_properties_test.bzl", "exec_properties_test_suite")
 load(":make_env_vars_test.bzl", "make_env_vars_test_suite")
 load(":meson_text_tests.bzl", "meson_script_test_suite")
 load(":msbuild_text_tests.bzl", "msbuild_script_test_suite")
@@ -63,6 +64,8 @@ shellcheck_test(
 )
 
 cmake_script_test_suite()
+
+exec_properties_test_suite()
 
 meson_script_test_suite()
 

--- a/test/env_test/BUILD.bazel
+++ b/test/env_test/BUILD.bazel
@@ -46,6 +46,24 @@ env_test_make(
     },
 )
 
+# A sized target runs its build action in the exec group named after its
+# resource_size, which is how remote executors get told how big the action is.
+# Bazel rejects exec_properties naming an exec group the rule didn't declare
+# ("Tried to set properties for non-existent exec groups"), so this both pins
+# the group name -- it is public API for anyone writing an RBE platform -- and
+# proves the action still builds when routed out of the default exec group.
+env_test_make(
+    name = "make_tiny_exec_group",
+    check_makevars = STANDARD_VARS | {
+        "GNUMAKEFLAGS": "",
+        "MAKEFLAGS": " -j3 --jobserver-auth={{JOBSERVER}} -- PREFIX={{INSTALLDIR}}",
+    },
+    make_attrs = {
+        "exec_properties": {"size_tiny.EstimatedCPU": "1"},
+        "resource_size": "tiny",
+    },
+)
+
 env_test_make(
     name = "make_tiny",
     check_makevars = STANDARD_VARS | {

--- a/test/exec_properties_test.bzl
+++ b/test/exec_properties_test.bzl
@@ -1,0 +1,77 @@
+"""Unit tests for the remote-execution exec_properties helper."""
+
+load("@bazel_skylib//lib:partial.bzl", "partial")
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//foreign_cc:exec_properties.bzl", "foreign_cc_size_exec_properties")
+
+# buildifier: disable=bzl-visibility
+load("//foreign_cc/private:resource_sets.bzl", "SIZES", "size_exec_group_name")
+
+_TWO_SIZES = {
+    "large": struct(cpu = 8, mem = 1024),
+    "tiny": struct(cpu = 1, mem = 250),
+}
+
+def _every_size_gets_a_property_test(ctx):
+    env = unittest.begin(ctx)
+
+    properties = foreign_cc_size_exec_properties(cpu_property = "EstimatedCPU")
+
+    asserts.equals(env, len(SIZES), len(properties))
+    for size in SIZES:
+        asserts.true(
+            env,
+            size_exec_group_name(size) + ".EstimatedCPU" in properties,
+            "missing a property for size " + size,
+        )
+
+    return unittest.end(env)
+
+def _keys_are_scoped_to_the_exec_group_test(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(
+        env,
+        {
+            "size_large.EstimatedCPU": "8",
+            "size_large.EstimatedMemory": "1024M",
+            "size_tiny.EstimatedCPU": "1",
+            "size_tiny.EstimatedMemory": "250M",
+        },
+        foreign_cc_size_exec_properties(
+            cpu_property = "EstimatedCPU",
+            memory_property = "EstimatedMemory",
+            memory_format = "{}M",
+            sizes = _TWO_SIZES,
+        ),
+    )
+
+    return unittest.end(env)
+
+# Executors that only schedule on one dimension shouldn't be forced to declare
+# the other.
+def _properties_can_be_omitted_test(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(
+        env,
+        {"size_tiny.min-mem": "250"},
+        foreign_cc_size_exec_properties(
+            memory_property = "min-mem",
+            sizes = {"tiny": struct(cpu = 1, mem = 250)},
+        ),
+    )
+
+    return unittest.end(env)
+
+every_size_gets_a_property_test = unittest.make(_every_size_gets_a_property_test)
+keys_are_scoped_to_the_exec_group_test = unittest.make(_keys_are_scoped_to_the_exec_group_test)
+properties_can_be_omitted_test = unittest.make(_properties_can_be_omitted_test)
+
+def exec_properties_test_suite():
+    unittest.suite(
+        "exec_properties_test_suite",
+        partial.make(every_size_gets_a_property_test, size = "small"),
+        partial.make(keys_are_scoped_to_the_exec_group_test, size = "small"),
+        partial.make(properties_can_be_omitted_test, size = "small"),
+    )


### PR DESCRIPTION
`resource_size` tells Bazel's local scheduler how big a foreign_cc action is, via resource_set. It tells a remote executor nothing: a remote executor sizes an action from the RE platform properties attached to it, and resource_set is not one of those. So an RBE user annotating targets with resource_size got the right -j inside the action -- the env vars travel with it -- while the remote scheduler still packed those actions as if each needed one core.

Starlark cannot attach platform properties to an action: ctx.actions.run_shell has no exec_properties parameter, and an action's execution_requirements are not forwarded to the platform. The one mechanism available to a ruleset is exec groups, since exec_properties on a platform or target can be scoped to a group by name. So each build action now runs in the exec group named after its resource_size, and a remote user declares the mapping once:

    platform(
        name = "rbe_linux",
        exec_properties = foreign_cc_size_exec_properties(
            cpu_property = "EstimatedCPU",
            memory_property = "EstimatedMemory",
            memory_format = "{}M",
        ) | {"container-image": "docker://..."},
    )

Property names are executor-specific (BuildBuddy's EstimatedCPU, Buildfarm's min-cores, ...), so the helper takes them as arguments rather than guessing.

Targets without a resource_size keep using the default exec group, so a build that doesn't opt into sizing is unchanged.

One sharp edge, made explicit: a declared exec group does not inherit the target's exec_compatible_with, so routing would drop that constraint and could land the action on a different execution platform than the one whose shell toolchain generated its script. Setting both now fails at analysis time and points at exec_group_compatible_with. Routing can also be turned off wholesale with --@rules_foreign_cc//foreign_cc/settings:size_exec_groups=False.